### PR TITLE
Fix CID 1430932 [0.3.3]

### DIFF
--- a/changes/bug25629
+++ b/changes/bug25629
@@ -1,0 +1,3 @@
+  o Minor bugfixes (C correctness):
+    - Fix a very unlikely null pointer dereference.  Fixes bug 25629;
+      bugfix on 0.2.9.15.  Found by Coverity; this is CID 1430932.

--- a/src/or/nodelist.c
+++ b/src/or/nodelist.c
@@ -507,22 +507,22 @@ nodelist_add_microdesc(microdesc_t *md)
   if (rs == NULL)
     return NULL;
   node = node_get_mutable_by_id(rs->identity_digest);
-  if (node) {
-    node_remove_from_ed25519_map(node);
-    if (node->md)
-      node->md->held_by_nodes--;
+  if (node == NULL)
+    return NULL;
 
-    node->md = md;
-    md->held_by_nodes++;
-    /* Setting the HSDir index requires the ed25519 identity key which can
-     * only be found either in the ri or md. This is why this is called here.
-     * Only nodes supporting HSDir=2 protocol version needs this index. */
-    if (rs->pv.supports_v3_hsdir) {
-      node_set_hsdir_index(node, ns);
-    }
-    node_add_to_ed25519_map(node);
+  node_remove_from_ed25519_map(node);
+  if (node->md)
+    node->md->held_by_nodes--;
+
+  node->md = md;
+  md->held_by_nodes++;
+  /* Setting the HSDir index requires the ed25519 identity key which can
+   * only be found either in the ri or md. This is why this is called here.
+   * Only nodes supporting HSDir=2 protocol version needs this index. */
+  if (rs->pv.supports_v3_hsdir) {
+    node_set_hsdir_index(node, ns);
   }
-
+  node_add_to_ed25519_map(node);
   node_add_to_address_set(node);
 
   return node;


### PR DESCRIPTION
Coverity found a null pointer reference in nodelist_add_microdesc().
This is almost certainly impossible assuming that the routerstatus_t
returned by router_get_consensus_status_by_descriptor_digest() always
corresponds to an entry in the nodelist.  Fixes bug 25629.