### PR TITLE
Fix CID 1433643

### DIFF
--- a/changes/bug25675
+++ b/changes/bug25675
@@ -1,0 +1,4 @@
+  o Minor bugfixes (C correctness):
+    - Add a missing lock acquisition in the shutdown code of the
+      control subsystem. Fixes bug 25675; bugfix on 0.2.7.3-rc. Found
+      by Coverity; this is CID 1433643.


### PR DESCRIPTION
Add a missing lock acquisition around access to queued_control_events
in control_free_all().  Use the reassign-and-unlock strategy as in
queued_events_flush_all().  Fixes bug 25675.  Coverity found this bug,
but only after we recently added an access to
flush_queued_event_pending.