### PR TITLE
Patches for #24782

### DIFF
--- a/changes/bug24782
+++ b/changes/bug24782
@@ -1,0 +1,4 @@
+  o Minor features (config options):
+    - Change the way the default value for MaxMemInQueues is calculated. We now
+      use 0.4 * RAM if the system have 8 GB RAM or more, otherwise we use the
+      former value of 0.75 * RAM. Closes ticket 24782.

--- a/src/common/compat.c
+++ b/src/common/compat.c
@@ -3379,8 +3379,8 @@ get_total_system_memory_impl(void)
  * Try to find out how much physical memory the system has. On success,
  * return 0 and set *<b>mem_out</b> to that value. On failure, return -1.
  */
-int
-get_total_system_memory(size_t *mem_out)
+MOCK_IMPL(int,
+get_total_system_memory, (size_t *mem_out))
 {
   static size_t mem_cached=0;
   uint64_t m = get_total_system_memory_impl();

--- a/src/common/compat.h
+++ b/src/common/compat.h
@@ -701,7 +701,7 @@ char *make_path_absolute(char *fname);
 
 char **get_environment(void);
 
-int get_total_system_memory(size_t *mem_out);
+MOCK_DECL(int, get_total_system_memory, (size_t *mem_out));
 
 int compute_num_cpus(void);
 

--- a/src/or/config.c
+++ b/src/or/config.c
@@ -770,8 +770,6 @@ static void config_maybe_load_geoip_files_(const or_options_t *options,
 static int options_validate_cb(void *old_options, void *options,
                                void *default_options,
                                int from_setconf, char **msg);
-static uint64_t compute_real_max_mem_in_queues(const uint64_t val,
-                                               int log_guess);
 static void cleanup_protocol_warning_severity_level(void);
 static void set_protocol_warning_severity_level(int warning_severity);
 
@@ -4542,7 +4540,7 @@ options_validate(or_options_t *old_options, or_options_t *options,
 /* Given the value that the user has set for MaxMemInQueues, compute the
  * actual maximum value.  We clip this value if it's too low, and autodetect
  * it if it's set to 0. */
-static uint64_t
+STATIC uint64_t
 compute_real_max_mem_in_queues(const uint64_t val, int log_guess)
 {
   uint64_t result;

--- a/src/or/config.c
+++ b/src/or/config.c
@@ -4566,9 +4566,11 @@ compute_real_max_mem_in_queues(const uint64_t val, int log_guess)
       uint64_t avail = 0;
 
       if (ram >= (8 * ONE_GIGABYTE)) {
-        /* If we have more than, or equal to, 8 GB of RAM available, we set the
-         * MaxMemInQueues to 0.4 * RAM, since the relay operator should
-         * probably be running multiple relays on this host.
+        /* If we have 8 GB, or more, RAM available, we set the MaxMemInQueues
+         * to 0.4 * RAM. The idea behind this value is that the amount of RAM
+         * is more than enough for a single relay and should allow the relay
+         * operator to run two relays if they have additional bandwidth
+         * available.
          */
         avail = (ram / 5) * 2;
       } else {

--- a/src/or/config.c
+++ b/src/or/config.c
@@ -4548,11 +4548,6 @@ compute_real_max_mem_in_queues(const uint64_t val, int log_guess)
   if (val == 0) {
 #define ONE_GIGABYTE (U64_LITERAL(1) << 30)
 #define ONE_MEGABYTE (U64_LITERAL(1) << 20)
-#if SIZEOF_VOID_P >= 8
-#define MAX_DEFAULT_MAXMEM (8*ONE_GIGABYTE)
-#else
-#define MAX_DEFAULT_MAXMEM (2*ONE_GIGABYTE)
-#endif
     /* The user didn't pick a memory limit.  Choose a very large one
      * that is still smaller than the system memory */
     static int notice_sent = 0;
@@ -4567,14 +4562,28 @@ compute_real_max_mem_in_queues(const uint64_t val, int log_guess)
       result = ONE_GIGABYTE;
 #endif /* SIZEOF_VOID_P >= 8 */
     } else {
-      /* We detected it, so let's pick 3/4 of the total RAM as our limit. */
-      const uint64_t avail = (ram / 4) * 3;
+      /* We detected the amount of memory available. */
+      uint64_t avail = 0;
 
-      /* Make sure it's in range from 0.25 GB to 8 GB. */
-      if (avail > MAX_DEFAULT_MAXMEM) {
+      if (ram >= (8 * ONE_GIGABYTE)) {
+        /* If we have more than, or equal to, 8 GB of RAM available, we set the
+         * MaxMemInQueues to 0.4 * RAM, since the relay operator should
+         * probably be running multiple relays on this host.
+         */
+        avail = (ram / 5) * 2;
+      } else {
+        /* If we have less than 8 GB of RAM available, we use the "old" default
+         * for MaxMemInQueues of 0.75 * RAM.
+         */
+        avail = (ram / 4) * 3;
+      }
+
+      /* Make sure it's in range from 0.25 GB to 8 GB for 64-bit and 0.25 to 2
+       * GB for 32-bit. */
+      if (avail > MAX_DEFAULT_MEMORY_QUEUE_SIZE) {
         /* If you want to use more than this much RAM, you need to configure
            it yourself */
-        result = MAX_DEFAULT_MAXMEM;
+        result = MAX_DEFAULT_MEMORY_QUEUE_SIZE;
       } else if (avail < ONE_GIGABYTE / 4) {
         result = ONE_GIGABYTE / 4;
       } else {

--- a/src/or/config.h
+++ b/src/or/config.h
@@ -258,6 +258,10 @@ STATIC int parse_port_config(smartlist_t *out,
                   const unsigned flags);
 
 STATIC int check_bridge_distribution_setting(const char *bd);
+
+STATIC uint64_t compute_real_max_mem_in_queues(const uint64_t val,
+                                               int log_guess);
+
 #endif /* defined(CONFIG_PRIVATE) */
 
 #endif /* !defined(TOR_CONFIG_H) */

--- a/src/or/config.h
+++ b/src/or/config.h
@@ -22,6 +22,13 @@
  * expose more information than we're comfortable with. */
 #define MIN_HEARTBEAT_PERIOD (30*60)
 
+/** Maximum default value for MaxMemInQueues, in gigabytes. */
+#if SIZEOF_VOID_P >= 8
+#define MAX_DEFAULT_MEMORY_QUEUE_SIZE (U64_LITERAL(8) << 30)
+#else
+#define MAX_DEFAULT_MEMORY_QUEUE_SIZE (U64_LITERAL(2) << 30)
+#endif
+
 MOCK_DECL(const char*, get_dirportfrontpage, (void));
 MOCK_DECL(const or_options_t *, get_options, (void));
 MOCK_DECL(or_options_t *, get_options_mutable, (void));


### PR DESCRIPTION
Proposing the following fix for https://bugs.torproject.org/24782:

For system where we have 8 GB of RAM or more calculate `MaxMemInQueues` as `0.4 * RAM`, for systems where we have less we continue to use the old value of `0.75 * RAM`.