### PR TITLE
Switch to use should_record_bridge_info()

### DIFF
--- a/changes/ticket25290
+++ b/changes/ticket25290
@@ -1,0 +1,5 @@
+  o Code simplification and refactoring:
+    - We switch to should_record_bridge_info() in geoip_note_client_seen() and
+      options_need_geoip_info() instead of accessing the configuration values
+      directly. Fixes bug 25290; bugfix on 0.2.1.6-alpha. Patch by Neel
+      Chauhan.

--- a/src/or/config.c
+++ b/src/or/config.c
@@ -1682,8 +1682,7 @@ options_act_reversible(const or_options_t *old_options, char **msg)
 int
 options_need_geoip_info(const or_options_t *options, const char **reason_out)
 {
-  int bridge_usage =
-    options->BridgeRelay && options->BridgeRecordUsageByCountry;
+  int bridge_usage = should_record_bridge_info(options);
   int routerset_usage =
     routerset_needs_geoip(options->EntryNodes) ||
     routerset_needs_geoip(options->ExitNodes) ||

--- a/src/or/geoip.c
+++ b/src/or/geoip.c
@@ -628,8 +628,7 @@ geoip_note_client_seen(geoip_client_action_t action,
     /* Only remember statistics if the DoS mitigation subsystem is enabled. If
      * not, only if as entry guard or as bridge. */
     if (!dos_enabled()) {
-      if (!options->EntryStatistics &&
-          (!(options->BridgeRelay && options->BridgeRecordUsageByCountry))) {
+      if (!options->EntryStatistics && !should_record_bridge_info(options)) {
         return;
       }
     }


### PR DESCRIPTION
Both in geoip_note_client_seen() and options_need_geoip_info(), switch from
accessing the options directly to using the should_record_bridge_info() helper
function.

Fixes #25290

Signed-off-by: David Goulet <dgoulet@torproject.org>