### PR TITLE
Allow DA address to be specified as FQDN

### DIFF
--- a/doc/tor-gencert.1.txt
+++ b/doc/tor-gencert.1.txt
@@ -73,8 +73,7 @@ OPTIONS
 
 **-a** __address__:__port__::
     If provided, advertise the address:port combination as this authority's
-    preferred directory port in its certificate. If the address is a hostname,
-    the hostname is resolved to an IP before it's published.
+    preferred directory port in its certificate.
 
 BUGS
 ----

--- a/src/or/config.c
+++ b/src/or/config.c
@@ -6304,10 +6304,8 @@ parse_dir_authority_line(const char *line, dirinfo_type_t required_type,
     smartlist_del_keeporder(items, 0);
   }
 
-  while (smartlist_len(items)) {
+  while (smartlist_len(items) > 2) {
     char *flag = smartlist_get(items, 0);
-    if (TOR_ISDIGIT(flag[0]))
-      break;
     if (!strcasecmp(flag, "hs") ||
                !strcasecmp(flag, "no-hs")) {
       log_warn(LD_CONFIG, "The DirAuthority options 'hs' and 'no-hs' are "

--- a/src/or/routerparse.c
+++ b/src/or/routerparse.c
@@ -2363,18 +2363,16 @@ authority_cert_parse_from_string(const char *s, const char **end_of_string)
 
   tok = find_opt_by_keyword(tokens, K_DIR_ADDRESS);
   if (tok) {
-    struct in_addr in;
     char *address = NULL;
     tor_assert(tok->n_args);
     /* XXX++ use some tor_addr parse function below instead. -RD */
     if (tor_addr_port_split(LOG_WARN, tok->args[0], &address,
                             &cert->dir_port) < 0 ||
-        tor_inet_aton(address, &in) == 0) {
+        tor_lookup_hostname(address, &cert->addr) != 0) {
       log_warn(LD_DIR, "Couldn't parse dir-address in certificate");
       tor_free(address);
       goto err;
     }
-    cert->addr = ntohl(in.s_addr);
     tor_free(address);
   }
 

--- a/src/tools/tor-gencert.c
+++ b/src/tools/tor-gencert.c
@@ -191,19 +191,11 @@ parse_commandline(int argc, char **argv)
     } else if (!strcmp(argv[i], "-v")) {
       verbose = 1;
     } else if (!strcmp(argv[i], "-a")) {
-      uint32_t addr;
-      uint16_t port;
-      char b[INET_NTOA_BUF_LEN];
-      struct in_addr in;
       if (i+1>=argc) {
         fprintf(stderr, "No argument to -a\n");
         return 1;
       }
-      if (addr_port_lookup(LOG_ERR, argv[++i], NULL, &addr, &port)<0)
-        return 1;
-      in.s_addr = htonl(addr);
-      tor_inet_ntoa(&in, b, sizeof(b));
-      tor_asprintf(&address, "%s:%d", b, (int)port);
+      address = argv[++i];
     } else if (!strcmp(argv[i], "--create-identity-key")) {
       make_new_id = 1;
     } else if (!strcmp(argv[i], "--passphrase-fd")) {
@@ -588,11 +580,9 @@ main(int argc, char **argv)
     EVP_PKEY_free(identity_key);
   if (signing_key)
     EVP_PKEY_free(signing_key);
-  tor_free(address);
   tor_free(identity_key_file);
   tor_free(signing_key_file);
   tor_free(certificate_file);
-  tor_free(address);
 
   crypto_global_cleanup();
   return r;


### PR DESCRIPTION
It would be very helpful, particularly in sandbox situations, to specify
the Directory Authority by FQDN hostname instead of by IP address. This
would allow us to defer picking an actual IP address until the simulation
is started, and even to use some "in-game" DNS facility to figure out
the actual address after the simulation is launched.

Right now, specifying a FQDN for the "DirAuthority" config file entry
even *partially* works already: if the FQDN happens to start with a
digit, it is correctly resolved internally using available DNS resolver
infrastructure :)

The first attached patch makes that work in all cases (even when the
FQDN hostname does *not* begin with a digit).

The second attached patch allows FQDNs to be inserted into DA certs
created using tor-gencert, and correspondingly resolved when a client
parses the downloaded DA certificate.

I realize there is ongoing work to refactor parsing the DA config entry
(TRAC ticket #17224), so please consider this patch set either independently
on its own merits or as part of that larger effort. In the first case,
I'd be happy to redo and resubmit the patches based on review/feedback.

Thanks,
--Gabriel