### PR TITLE
Show test-suite.log for distcheck on Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -125,7 +125,9 @@ script:
 
 after_failure:
   ## `make check` will leave a log file with more details of test failures.
-  - cat test-suite.log
+  - if [[ "$DISTCHECK" == "" ]]; then cat test-suite.log; fi
+  ## `make distcheck` puts it somewhere different.
+  - if [[ "$DISTCHECK" != "" ]]; then make show-distdir-testlog; fi
 
 after_success:
   ## If this build was one that produced coverage, upload it.

--- a/Makefile.am
+++ b/Makefile.am
@@ -216,3 +216,12 @@ mostlyclean-local:
 	rm -rf $(HTML_COVER_DIR)
 	rm -rf $(top_builddir)/doc/doxygen
 	rm -rf $(TEST_NETWORK_ALL_LOG_DIR)
+
+# This relies on some internal details of how automake implements
+# distcheck.  We check two directories because automake-1.15 changed
+# from $(distdir)/_build to $(distdir)/_build/sub.
+show-distdir-testlog:
+	@if test -d "$(distdir)/_build/sub"; then \
+	  cat $(distdir)/_build/sub/$(TEST_SUITE_LOG); \
+	else \
+	  cat $(distdir)/_build/$(TEST_SUITE_LOG); fi


### PR DESCRIPTION
When Travis CI runs make distcheck, test-suite.log doesn't exist in
the expected place.  Add a new make target to show this file and use
it when DISTCHECK=yes in .travis.yml.  Fixes bug 25814; bug not in any
released Tor.