### PR TITLE
Move unreachable port warnings to a periodic event.

### DIFF
--- a/changes/ticket25952
+++ b/changes/ticket25952
@@ -1,0 +1,9 @@
+  o Minor features (mainloop):
+    - Move responsibility for
+      warning relay operators about unreachable ports
+      from a once-per-second callback to a callback that is only scheduled as
+      needed.  Once enough items are removed from our once-per-second
+      callback, we can eliminate it entirely to conserve CPU when idle.
+      Closes ticket
+      25952.
+


### PR DESCRIPTION
Arguably, the conditions under which these events happen should be a
bit different, but the rules are complex enough here that I've tried
to have this commit be pure refactoring.

Closes ticket 25952.

Finally, before this code goes away, take a moment to look at the
amazing way that we used to try to have an event happen
every N seconds:

      get_uptime() / N != (get_uptime()+seconds_elapsed) / N

Truly, it is a thing of wonder.  I'm glad we didn't start using this
pattern everywhere else.