### PR TITLE
Hold monotonic time constant during channel/outbound_cell test

### DIFF
--- a/changes/ticket25994
+++ b/changes/ticket25994
@@ -1,0 +1,5 @@
+  o Minor bugfixes (tests):
+    - Change the behavior of the "channel/outbound" test so that it never
+      causes a 10-second rollover for the EWMA circuitmux code. Previously,
+      this behavior would happen randomly, and result in fluctuating test
+      coverage. Fixes bug 25994; bugfix on 0.3.3.1-alpha.

--- a/src/test/test_channel.c
+++ b/src/test/test_channel.c
@@ -544,6 +544,11 @@ test_channel_outbound_cell(void *arg)
 
   (void) arg;
 
+  /* Set the test time to be mocked, since this test assumes that no
+   * time will pass, ewma values will not need to be re-scaled, and so on */
+  monotime_enable_test_mocking();
+  monotime_set_mock_time_nsec(U64_LITERAL(1000000000) * 12345);
+
   cmux_ewma_set_options(NULL,NULL);
 
   /* The channel will be freed so we need to hijack this so the scheduler
@@ -660,6 +665,7 @@ test_channel_outbound_cell(void *arg)
   tor_free(p_cell);
   channel_free_all();
   UNMOCK(scheduler_release_channel);
+  monotime_disable_test_mocking();
 }
 
 /* Test inbound cell. The callstack is:


### PR DESCRIPTION
This change should make it impossible for the monotonic time to roll
over from one EWMA tick to the next during this test, and make it so
that this test never invokes scale_active_circuits() (which it
doesn't test).

(Earlier changes during the 0.3.4 series should make this call even
rarer than it was before, since we fixed #25927 and removed
cached_gettimeofday.  Because this test didn't update
cached_gettimeofday, the chance of rolling over a 10-second interval
was much higher.)

Closes ticket 25994; bugfix on 0.3.3.1-alpha when this test was
introduced.