### PR TITLE
Use a deterministic PRNG in test_circuit_timeout()

### DIFF
--- a/changes/ticket25995
+++ b/changes/ticket25995
@@ -1,0 +1,5 @@
+  o Minor bugfixes (tests):
+    - While running the circuit_timeout test, fix the PRNG to a deterministic
+      AES stream, so that the test coverage from this test will itself be
+      deterministic.  Fixes bug 25995; bugfix on 0.2.2.2-alpha.
+

--- a/src/test/test.c
+++ b/src/test/test.c
@@ -349,6 +349,18 @@ test_onion_queues(void *arg)
   tor_free(onionskin);
 }
 
+static crypto_cipher_t *crypto_rand_aes_cipher = NULL;
+
+// Mock replacement for crypto_rand: Generates bytes from a provided AES_CTR
+// cipher in <b>crypto_rand_aes_cipher</b>.
+static void
+crypto_rand_deterministic_aes(char *out, size_t n)
+{
+  tor_assert(crypto_rand_aes_cipher);
+  memset(out, 0, n);
+  crypto_cipher_crypt_inplace(crypto_rand_aes_cipher, out, n);
+}
+
 static void
 test_circuit_timeout(void *arg)
 {
@@ -377,6 +389,11 @@ test_circuit_timeout(void *arg)
   circuit_build_times_init(&final);
 
   state = or_state_new();
+
+  // Use a deterministic RNG here, or else we'll get nondeterministic
+  // coverage in some of the circuitstats functions.
+  MOCK(crypto_rand, crypto_rand_deterministic_aes);
+  crypto_rand_aes_cipher = crypto_cipher_new("xyzzyplughplover");
 
   circuitbuild_running_unit_tests();
 #define timeout0 (build_time_t)(30*1000.0)
@@ -512,6 +529,8 @@ test_circuit_timeout(void *arg)
   circuit_build_times_free_timeouts(&final);
   or_state_free(state);
   teardown_periodic_events();
+  UNMOCK(crypto_rand);
+  crypto_cipher_free(crypto_rand_aes_cipher);
 }
 
 /** Test encoding and parsing of rendezvous service descriptors. */


### PR DESCRIPTION
I'd prefer not to do this for randomized tests, but as things stand
with this test, it produces nondeterministic test coverage.

Closes ticket 25995; bugfix on 0.2.2.2-alpha when this test was
introduced.