### PR TITLE
Add a test for dirserv_read_measured_bandwidths,

### DIFF
--- a/src/test/V3BandwidthsFilev100
+++ b/src/test/V3BandwidthsFilev100
@@ -1,0 +1,2 @@
+1524832619
+node_id=$68A483E05A2ABDCA6DA5A3EF8DB5177638A27F80 bw=392760 nick=Test measured_at=1523911725 updated_at=1523911725 pid_error=4.11374090719 pid_error_sum=4.11374090719 pid_bw=57136645 pid_delta=2.12168374577 circ_fail=0.2 scanner=/filepath

--- a/src/test/V3BandwidthsFilev110
+++ b/src/test/V3BandwidthsFilev110
@@ -1,0 +1,2 @@
+1524832619 version=1.1.0 software=sbws software_version=0.1.0
+node_id=$68A483E05A2ABDCA6DA5A3EF8DB5177638A27F80 bw=392760 nick=Test rtt=380 time=1523911725

--- a/src/test/V3BandwidthsFilev110n
+++ b/src/test/V3BandwidthsFilev110n
@@ -1,0 +1,5 @@
+1524832619
+version=1.1.0
+software=sbws
+software_version=0.1.0
+node_id=$68A483E05A2ABDCA6DA5A3EF8DB5177638A27F80 bw=392760 nick=Test rtt=380 time=1523911725

--- a/src/test/include.am
+++ b/src/test/include.am
@@ -363,7 +363,10 @@ EXTRA_DIST += \
 	src/test/test_workqueue_efd2.sh \
 	src/test/test_workqueue_pipe.sh \
 	src/test/test_workqueue_pipe2.sh \
-	src/test/test_workqueue_socketpair.sh
+	src/test/test_workqueue_socketpair.sh \
+	src/test/V3BandwidthsFilev100 \
+	src/test/V3BandwidthsFilev110 \
+	src/test/V3BandwidthsFilev110n
 
 test-rust:
 	$(TESTS_ENVIRONMENT) "$(abs_top_srcdir)/src/test/test_rust.sh"

--- a/src/test/test_dir.c
+++ b/src/test/test_dir.c
@@ -1552,6 +1552,22 @@ test_dir_measured_bw_kb(void *arg)
  done:
   return;
 }
+static void
+test_dir_dirserv_read_measured_bandwidths(void *arg)
+{
+  (void)arg;
+  /* TODO: timestamp should be written to the file from current time
+  or the whole time should be generated with current time,
+  otherwise tests will fail considering time stale. */
+  const char v100[] = SRCDIR "/src/test/V3BandwidthsFilev100";
+  tt_int_op(0, OP_EQ, dirserv_read_measured_bandwidths(v100, NULL));
+  const char v110[] = SRCDIR "/src/test/V3BandwidthsFilev110";
+  tt_int_op(-1, OP_EQ, dirserv_read_measured_bandwidths(v110, NULL));
+  const char v110n[] = SRCDIR "/src/test/V3BandwidthsFilev110n";
+  tt_int_op(0, OP_EQ, dirserv_read_measured_bandwidths(v110n, NULL));
+ done:
+  return;
+}
 
 #define MBWC_INIT_TIME 1000
 
@@ -5849,6 +5865,7 @@ struct testcase_t dir_tests[] = {
   DIR_LEGACY(clip_unmeasured_bw_kb_alt),
   DIR(fmt_control_ns, 0),
   DIR(dirserv_set_routerstatus_testing, 0),
+  DIR(dirserv_read_measured_bandwidths, 0),
   DIR(http_handling, 0),
   DIR(purpose_needs_anonymity_returns_true_for_bridges, 0),
   DIR(purpose_needs_anonymity_returns_false_for_own_bridge_desc, 0),
@@ -5885,4 +5902,3 @@ struct testcase_t dir_tests[] = {
   DIR(networkstatus_consensus_has_ipv6, TT_FORK),
   END_OF_TESTCASES
 };
-


### PR DESCRIPTION
@teor2345 this is the branch with the test where i was using document files, but they fail as soon as the hardcoded timestamp is not valid. That's why i didn't create a PR before, was going to wait for the additional headers test, but i should probably work on this without the additional headers.