### PR TITLE
Make hs_get_responsible_hsdirs() deterministic.

### DIFF
--- a/changes/ticket25997
+++ b/changes/ticket25997
@@ -1,0 +1,5 @@
+  o Minor bugfixes (testing, coverage):
+    - Remove randomness from the hs_common/responsible_hsdirs test,
+      so that it always takes the same path through the function it tests.
+      Fixes bug 25997; bugfix on 0.3.2.1-alpha.
+

--- a/src/test/test_hs_common.c
+++ b/src/test/test_hs_common.c
@@ -360,11 +360,8 @@ mock_networkstatus_get_live_consensus(time_t now)
 static void
 test_responsible_hsdirs(void *arg)
 {
-  time_t now = approx_time();
   smartlist_t *responsible_dirs = smartlist_new();
   networkstatus_t *ns = NULL;
-  int retval;
-
   (void) arg;
 
   hs_init();
@@ -386,12 +383,12 @@ test_responsible_hsdirs(void *arg)
     helper_add_hsdir_to_networkstatus(ns, 3, "spyro", 0);
   }
 
-  ed25519_keypair_t kp;
-  retval = ed25519_keypair_generate(&kp, 0);
-  tt_int_op(retval, OP_EQ , 0);
+  /* Use a fixed time period and pub key so we always take the same path */
+  ed25519_public_key_t pubkey;
+  uint64_t time_period_num = 17653; // 2 May, 2018, 14:00.
+  memset(&pubkey, 42, sizeof(pubkey));
 
-  uint64_t time_period_num = hs_get_time_period_num(now);
-  hs_get_responsible_hsdirs(&kp.pubkey, time_period_num,
+  hs_get_responsible_hsdirs(&pubkey, time_period_num,
                             0, 0, responsible_dirs);
 
   /* Make sure that we only found 2 responsible HSDirs.


### PR DESCRIPTION
This test was using the current time to pick the time period number,
and a randomly generated hs key.  Therefore, it sometimes picked an
index that would wrap around the example dht, and sometimes would
not.

The fix here is just to fix the time period and the public key.

Fixes bug 25997; bugfix on 0.3.2.1-alpha.