### PR TITLE
Refactor to remove n_libevent_errors

### DIFF
--- a/changes/ticket26016
+++ b/changes/ticket26016
@@ -1,0 +1,4 @@
+  o Code simplification and refactoring:
+    - Use our standard rate-limiting code to deal with excessive libevent
+      failures, rather than the hand-rolled logic we had before.
+      Closes ticket 26016.


### PR DESCRIPTION
We cleared this value in second_elapsed_callback.  But what were we
using it for?  For detecting if Libevent returned EINVAL too often!
We already have a way to detect too-frequent events, and that's with
a ratelim_t.  Refactor the code to use that instead.  Closes ticket
26016.