### PR TITLE
Add unit test for ..get_start_of_next_voting_interval().

### DIFF
--- a/changes/ticket26014
+++ b/changes/ticket26014
@@ -1,0 +1,4 @@
+  o Minor features (Testing):
+    - Add a unit test for voting_schedule_get_start_of_next_interval().
+      Closes ticket 26014, and helps make unit test coverage more
+      deterministic.

--- a/src/or/voting_schedule.c
+++ b/src/or/voting_schedule.c
@@ -39,7 +39,9 @@ voting_schedule_get_start_of_next_interval(time_t now, int interval,
   tm.tm_sec = 0;
 
   if (tor_timegm(&tm, &midnight_today) < 0) {
+    // LCOV_EXCL_START
     log_warn(LD_BUG, "Ran into an invalid time when trying to find midnight.");
+    // LCOV_EXCL_STOP
   }
   midnight_tomorrow = midnight_today + (24*60*60);
 

--- a/src/test/include.am
+++ b/src/test/include.am
@@ -171,6 +171,7 @@ src_test_test_SOURCES = \
 	src/test/test_util.c \
 	src/test/test_util_format.c \
 	src/test/test_util_process.c \
+	src/test/test_voting_schedule.c \
 	src/test/test_helpers.c \
 	src/test/test_dns.c \
 	src/test/testing_common.c \

--- a/src/test/test.c
+++ b/src/test/test.c
@@ -859,6 +859,7 @@ struct testgroup_t testgroups[] = {
   { "dir/", dir_tests },
   { "dir_handle_get/", dir_handle_get_tests },
   { "dir/md/", microdesc_tests },
+  { "dir/voting-schedule/", voting_schedule_tests },
   { "dos/", dos_tests },
   { "entryconn/", entryconn_tests },
   { "entrynodes/", entrynodes_tests },

--- a/src/test/test.h
+++ b/src/test/test.h
@@ -265,6 +265,7 @@ extern struct testcase_t tortls_tests[];
 extern struct testcase_t util_tests[];
 extern struct testcase_t util_format_tests[];
 extern struct testcase_t util_process_tests[];
+extern struct testcase_t voting_schedule_tests[];
 extern struct testcase_t dns_tests[];
 extern struct testcase_t handle_tests[];
 extern struct testcase_t sr_tests[];

--- a/src/test/test_voting_schedule.c
+++ b/src/test/test_voting_schedule.c
@@ -1,0 +1,64 @@
+/* Copyright (c) 2018, The Tor Project, Inc. */
+/* See LICENSE for licensing information */
+
+#include "orconfig.h"
+
+#include "or.h"
+#include "voting_schedule.h"
+
+#include "test.h"
+
+static void
+test_voting_schedule_interval_start(void *arg)
+{
+#define next_interval voting_schedule_get_start_of_next_interval
+  (void)arg;
+  char buf[ISO_TIME_LEN+1];
+
+  // Midnight UTC tonight (as I am writing this test)
+  const time_t midnight = 1525651200;
+  format_iso_time(buf, midnight);
+  tt_str_op(buf, OP_EQ, "2018-05-07 00:00:00");
+
+  /* Some simple tests with a 50-minute voting interval */
+
+  tt_i64_op(next_interval(midnight, 3000, 0), OP_EQ,
+            midnight+3000);
+
+  tt_i64_op(next_interval(midnight+100, 3000, 0), OP_EQ,
+            midnight+3000);
+
+  tt_i64_op(next_interval(midnight+3000, 3000, 0), OP_EQ,
+            midnight+6000);
+
+  tt_i64_op(next_interval(midnight+3001, 3000, 0), OP_EQ,
+            midnight+6000);
+
+  /* Make sure that we roll around properly at midnight */
+  tt_i64_op(next_interval(midnight+83000, 3000, 0), OP_EQ,
+            midnight+84000);
+
+  /* We start fresh at midnight UTC, even if there are leftover seconds. */
+  tt_i64_op(next_interval(midnight+84005, 3000, 0), OP_EQ,
+            midnight+86400);
+
+  /* Now try with offsets.  (These are only used for test networks.) */
+  tt_i64_op(next_interval(midnight, 3000, 99), OP_EQ,
+            midnight+99);
+
+  tt_i64_op(next_interval(midnight+100, 3000, 99), OP_EQ,
+            midnight+3099);
+
+ done:
+  ;
+#undef next_interval
+}
+
+#define VS(name,flags)                                          \
+  { #name, test_voting_schedule_##name, (flags), NULL, NULL }
+
+struct testcase_t voting_schedule_tests[] = {
+  VS(interval_start, 0),
+  END_OF_TESTCASES
+};
+


### PR DESCRIPTION
This functionality was covered only accidentally by our voting-test
code, and as such wasn't actually tested at all.  The tests that
called it made its coverage nondeterministic, depending on what time
of day you ran the tests.

Closes ticket 26014.