### PR TITLE
Fix the selection of events to cancel in test_workqueue.c

### DIFF
--- a/changes/ticket26008
+++ b/changes/ticket26008
@@ -1,0 +1,7 @@
+  o Minor bugfixes (test):
+    - When testing workqueue event-cancellation, make sure that we actually
+      cancel an event, and that cancel each event with equal probability.
+      (It was previously possible, though extremely unlikely, for our
+      event-canceling test not to cancel any events.) Fixes bug 26008;
+      bugfix on 0.2.6.3-alpha.  
+


### PR DESCRIPTION
Our previous algorithm had a nonzero probability of picking no
events to cancel, which is of course incorrect.  The new code uses
Vitter's good old reservoir sampling "algorithm R" from 1985.

Fixes bug 26008; bugfix on 0.2.6.3-alpha.