### PR TITLE
Restore sys/random.h inclusion for getentropy()

### DIFF
--- a/src/common/crypto.c
+++ b/src/common/crypto.c
@@ -60,12 +60,6 @@ ENABLE_GCC_WARNING(redundant-decls)
 #ifdef HAVE_UNISTD_H
 #include <unistd.h>
 #endif
-#ifdef HAVE_SYS_SYSCALL_H
-#include <sys/syscall.h>
-#endif
-#ifdef HAVE_SYS_RANDOM_H
-#include <sys/random.h>
-#endif
 
 #include "torlog.h"
 #include "torint.h"

--- a/src/common/crypto_rand.c
+++ b/src/common/crypto_rand.c
@@ -55,6 +55,12 @@ ENABLE_GCC_WARNING(redundant-decls)
 #ifdef HAVE_UNISTD_H
 #include <unistd.h>
 #endif
+#ifdef HAVE_SYS_SYSCALL_H
+#include <sys/syscall.h>
+#endif
+#ifdef HAVE_SYS_RANDOM_H
+#include <sys/random.h>
+#endif
 
 /**
  * How many bytes of entropy we add at once.


### PR DESCRIPTION
Code movement for the refactoring for ticket 24658 didn't copy the
inclusion of sys/random.h, which is needed to get a prototype for
getentropy() on macOS 10.12 Sierra.  It also didn't copy the inclusion
of sys/syscall.h, which might prevent the getrandom() syscall from
being properly detected.  Move these inclusions.  Bug not in any
released Tor.