### PR TITLE
Don't crash when closing a connection before initializing libevent

### DIFF
--- a/src/or/main.c
+++ b/src/or/main.c
@@ -1676,6 +1676,11 @@ static mainloop_event_t *postloop_cleanup_ev=NULL;
 void
 mainloop_schedule_postloop_cleanup(void)
 {
+  if (PREDICT_UNLIKELY(postloop_cleanup_ev == NULL)) {
+    // (It's possible that we can get here if we decide to close a connection
+    // in the earliest stages of our configuration, before we create events.)
+    return;
+  }
   mainloop_event_activate(postloop_cleanup_ev);
 }
 


### PR DESCRIPTION
Fixes bug 25981; bugfix on 96c5ac338a7df.  Bug not in any released
version of Tor.