### PR TITLE
[bug26108] rust: Export crypto_rand::* functions from our external crate.

### DIFF
--- a/src/rust/external/lib.rs
+++ b/src/rust/external/lib.rs
@@ -15,4 +15,5 @@ pub mod crypto_digest;
 mod crypto_rand;
 mod external;
 
+pub use crypto_rand::*;
 pub use external::*;


### PR DESCRIPTION
https://trac.torproject.org/projects/tor/ticket/26108