### PR TITLE
Improve openssl_version tests with better messages

### DIFF
--- a/changes/bug26152
+++ b/changes/bug26152
@@ -1,0 +1,4 @@
+  o Minor bugfixes (testing):
+    - When logging a version mismatch in our openssl_version tests,
+      report the actual offending version strings. Fixes bug 26152; bugfix on
+      0.2.9.1-alpha.

--- a/src/test/test_crypto.c
+++ b/src/test/test_crypto.c
@@ -152,8 +152,13 @@ test_crypto_openssl_version(void *arg)
   const char *h_version = crypto_openssl_get_header_version_str();
   tt_assert(version);
   tt_assert(h_version);
-  tt_assert(!strcmpstart(version, h_version)); /* "-fips" suffix, etc */
-  tt_assert(!strstr(version, "OpenSSL"));
+  if (strcmpstart(version, h_version)) { /* "-fips" suffix, etc */
+    TT_DIE(("OpenSSL library version %s did not begin with header version %s.",
+            version, h_version));
+  }
+  if (strstr(version, "OpenSSL")) {
+    TT_DIE(("assertion failed: !strstr(\"%s\", \"OpenSSL\")", version));
+  }
   int a=-1,b=-1,c=-1;
   if (!strcmpstart(version, "LibreSSL") || !strcmpstart(version, "BoringSSL"))
     return;


### PR DESCRIPTION
These tests would report errors, but wouldn't report the offending
strings.