### PR TITLE
Add a missing include to get the declaration of OPENSSL_1_1_API

### DIFF
--- a/changes/bug26156
+++ b/changes/bug26156
@@ -1,0 +1,3 @@
+  o Minor bugfixes (compilation):
+    - Fix compilation when building with OpenSSL 1.1.0 with the
+      "no-deprecated" flag enabled. Fixes bug 26156; bugfix on 0.3.4.1-alpha.

--- a/src/common/aes.c
+++ b/src/common/aes.c
@@ -16,6 +16,7 @@
   #include <ws2tcpip.h>
 #endif
 
+#include "compat_openssl.h"
 #include <openssl/opensslv.h>
 #include "crypto_openssl_mgt.h"
 


### PR DESCRIPTION
Apparently, even though I had tested on OpenSSL 1.1.1 with
no-deprecated, OpenSSL 1.1.0 is different enough that I should have
tested with that as well.

Fixes bug 26156; bugfix on 0.3.4.1-alpha where we first declared
support for this configuration.