### PR TITLE
Bug26259

### DIFF
--- a/changes/bug26259
+++ b/changes/bug26259
@@ -1,0 +1,4 @@
+  o Minor bugfixes (control port):
+    - Do not count 0-length RELAY_COMMAND_DATA cells as valid data in CIRC_BW
+      events. Previously, such cells were counted entirely in the OVERHEAD
+      field. Now they are not. Fixes bug 26259; bugfix on 0.3.4.1-alpha.

--- a/src/or/relay.c
+++ b/src/or/relay.c
@@ -1556,7 +1556,7 @@ connection_edge_process_relay_cell(cell_t *cell, circuit_t *circ,
         return -END_CIRC_REASON_TORPROTOCOL;
       }
       /* Total all valid application bytes delivered */
-      if (CIRCUIT_IS_ORIGIN(circ)) {
+      if (CIRCUIT_IS_ORIGIN(circ) && rh.length > 0) {
         circuit_read_valid_data(TO_ORIGIN_CIRCUIT(circ), rh.length);
       }
 

--- a/src/test/test_relaycell.c
+++ b/src/test/test_relaycell.c
@@ -233,6 +233,13 @@ test_circbw_relay(void *arg)
                                      circ->cpath);
   ASSERT_COUNTED_BW();
 
+  /* Empty Data cell on open connection: not counted */
+  ENTRY_TO_CONN(entryconn)->marked_for_close = 0;
+  PACK_CELL(1, RELAY_COMMAND_DATA, "");
+  connection_edge_process_relay_cell(&cell, TO_CIRCUIT(circ), edgeconn,
+                                     circ->cpath);
+  ASSERT_UNCOUNTED_BW();
+
   /* Sendme on stream: not counted */
   ENTRY_TO_CONN(entryconn)->outbuf_flushlen = 0;
   PACK_CELL(1, RELAY_COMMAND_SENDME, "Data1234");


### PR DESCRIPTION
Exempt 0-length data cells from OVERHEAD (valid) CIRC_BW counts.