### PR TITLE
Trac #21346: Only choose IPv6 exits when NoIPv4Traffic is set as a SocksPort flag

### DIFF
--- a/changes/bug21346
+++ b/changes/bug21346
@@ -1,0 +1,4 @@
+  o Minor bugfix (ipv6):
+    - When "NoIPv4Traffic" is set as a SocksPort option flag, reject
+      circuits which don't allow exiting on IPv6. Fixes bug 21346;
+      bugfix on 0.3.4.2-alpha. Patch by Neel Chauhan.


### PR DESCRIPTION
Pull request for [Tor Trac #21346](https://trac.torproject.org/projects/tor/ticket/21346).