### PR TITLE
Revise geoip tests to not require paths of actual geoip config

### DIFF
--- a/changes/bug25787
+++ b/changes/bug25787
@@ -1,0 +1,7 @@
+  o Minor bugfixes (testing):
+    - Instead of trying to  read the geoip configuration files from within the
+      unit tests, instead create our own ersatz files with just enough
+      geoip data in the format we expect. Trying to read from the source
+      directory created problems on Windows with mingw, where the
+      build system's paths are not the same as the platform's paths.
+      Fixes bug 25787; bugfix on 0.3.4.1-alpha.

--- a/src/test/include.am
+++ b/src/test/include.am
@@ -345,7 +345,6 @@ src_test_test_bt_cl_CPPFLAGS= $(src_test_AM_CPPFLAGS) $(TEST_CPPFLAGS)
 
 EXTRA_DIST += \
 	src/test/bt_test.py \
-	src/test/geoip_dummy \
 	src/test/ntor_ref.py \
 	src/test/hs_ntor_ref.py \
 	src/test/hs_build_address.py \


### PR DESCRIPTION
When I wrote the first one of these, it needed the path of the geoip
file.  But that doesn't translate well in at least two cases:

   - Mingw, where the compile-time path is /c/foo/bar and the
     run-time path is c:\foo\bar.

   - Various CI weirdnesses, where we cross-compile a test binary,
     then copy it into limbo and expect it to work.

Together, these problems precluded these tests running on windows.

So, instead let's just generate some minimal files ourselves, and
test against them.

Fixes bug 25787