### PR TITLE
Trac #25886: Make frac_nodes_with_descriptors() take and use for_direct_connect (Revision 2)

### DIFF
--- a/changes/bug25886
+++ b/changes/bug25886
@@ -1,0 +1,7 @@
+  o Minor bugfixes (relay):
+    - In frac_nodes_with_descriptors(), add for_direct_connect, and replace
+      node_has_any_descriptor() with node_has_preferred_descriptor(). Also,
+      if f_guard in compute_frac_paths_available() is greater than 0 and we
+      are using bridges, automatically make it 1.0. Fixes bug 25886; bugfix
+      on 0.3.4.2-alpha. Patch by Neel Chauhan.
+

--- a/src/or/nodelist.c
+++ b/src/or/nodelist.c
@@ -2213,9 +2213,15 @@ compute_frac_paths_available(const networkstatus_t *consensus,
      * browsing (as distinct from hidden service web browsing). */
   }
 
-  f_guard = frac_nodes_with_descriptors(guards, WEIGHT_FOR_GUARD);
-  f_mid   = frac_nodes_with_descriptors(mid,    WEIGHT_FOR_MID);
-  f_exit  = frac_nodes_with_descriptors(exits,  WEIGHT_FOR_EXIT);
+  f_guard = frac_nodes_with_descriptors(guards, WEIGHT_FOR_GUARD, 1);
+  f_mid   = frac_nodes_with_descriptors(mid,    WEIGHT_FOR_MID,   0);
+  f_exit  = frac_nodes_with_descriptors(exits,  WEIGHT_FOR_EXIT,  0);
+
+  /* As bridges have a self measurev bandwidth value, and we don't require
+   * all bridges to be online at once, if f_guard is greater than 0 and we
+   * are using bridges, set f_guard to 1.0. */
+  if (f_guard > 0 && options->UseBridges)
+    f_guard = 1.0;
 
   log_debug(LD_NET,
             "f_guard: %.2f, f_mid: %.2f, f_exit: %.2f",
@@ -2269,9 +2275,10 @@ compute_frac_paths_available(const networkstatus_t *consensus,
               np,
               nu);
 
-    f_myexit= frac_nodes_with_descriptors(myexits,WEIGHT_FOR_EXIT);
+    f_myexit= frac_nodes_with_descriptors(myexits, WEIGHT_FOR_EXIT, 0);
     f_myexit_unflagged=
-              frac_nodes_with_descriptors(myexits_unflagged,WEIGHT_FOR_EXIT);
+              frac_nodes_with_descriptors(myexits_unflagged,
+                                          WEIGHT_FOR_EXIT, 0);
 
     log_debug(LD_NET,
               "f_exit: %.2f, f_myexit: %.2f, f_myexit_unflagged: %.2f",

--- a/src/or/routerlist.c
+++ b/src/or/routerlist.c
@@ -2746,10 +2746,15 @@ compute_weighted_bandwidths(const smartlist_t *sl,
 
 /** For all nodes in <b>sl</b>, return the fraction of those nodes, weighted
  * by their weighted bandwidths with rule <b>rule</b>, for which we have
- * descriptors. */
+ * descriptors.
+ *
+ * If <b>for_direct_connect</b> is true, we intend to connect to the node
+ * directly, as the first hop of a circuit; otherwise, we intend to connect
+ * to it indirectly, or use it as if we were connecting to it indirectly. */
 double
 frac_nodes_with_descriptors(const smartlist_t *sl,
-                            bandwidth_weight_rule_t rule)
+                            bandwidth_weight_rule_t rule,
+                            int for_direct_conn)
 {
   double *bandwidths = NULL;
   double total, present;
@@ -2761,7 +2766,7 @@ frac_nodes_with_descriptors(const smartlist_t *sl,
       total <= 0.0) {
     int n_with_descs = 0;
     SMARTLIST_FOREACH(sl, const node_t *, node, {
-      if (node_has_any_descriptor(node))
+      if (node_has_preferred_descriptor(node, for_direct_conn))
         n_with_descs++;
     });
     return ((double)n_with_descs) / smartlist_len(sl);
@@ -2769,7 +2774,7 @@ frac_nodes_with_descriptors(const smartlist_t *sl,
 
   present = 0.0;
   SMARTLIST_FOREACH_BEGIN(sl, const node_t *, node) {
-    if (node_has_any_descriptor(node))
+    if (node_has_preferred_descriptor(node, for_direct_conn))
       present += bandwidths[node_sl_idx];
   } SMARTLIST_FOREACH_END(node);
 

--- a/src/or/routerlist.h
+++ b/src/or/routerlist.h
@@ -74,7 +74,8 @@ uint32_t router_get_advertised_bandwidth_capped(const routerinfo_t *router);
 const node_t *node_sl_choose_by_bandwidth(const smartlist_t *sl,
                                           bandwidth_weight_rule_t rule);
 double frac_nodes_with_descriptors(const smartlist_t *sl,
-                                   bandwidth_weight_rule_t rule);
+                                   bandwidth_weight_rule_t rule,
+                                   int for_direct_conn);
 
 const node_t *router_choose_random_node(smartlist_t *excludedsmartlist,
                                         struct routerset_t *excludedset,


### PR DESCRIPTION
Was asked for [here](https://trac.torproject.org/projects/tor/ticket/25886). I included making `f_guard` `1.0` if bridges are used in `compute_frac_paths_available()`.