### PR TITLE
test_entrynodes: fix a GCC warning

### DIFF
--- a/src/test/test_entrynodes.c
+++ b/src/test/test_entrynodes.c
@@ -1113,6 +1113,7 @@ test_entry_guard_update_from_consensus_status(void *arg)
   for (i = 0; i < 5; ++i) {
     entry_guard_t *g = smartlist_get(gs->sampled_entry_guards, i);
     node_t *n = (node_t*) bfn_mock_node_get_by_id(g->identity);
+    tt_assert(n);
     n->is_possible_guard = 0;
   }
 
@@ -1151,6 +1152,7 @@ test_entry_guard_update_from_consensus_status(void *arg)
   {
     entry_guard_t *g = smartlist_get(gs->sampled_entry_guards, 0);
     node_t *n = (node_t*) bfn_mock_node_get_by_id(g->identity);
+    tt_assert(n);
     n->is_possible_guard = 1;
   }
   {
@@ -1158,6 +1160,7 @@ test_entry_guard_update_from_consensus_status(void *arg)
      */
     entry_guard_t *g = smartlist_get(gs->sampled_entry_guards, 5);
     node_t *n = (node_t*) bfn_mock_node_get_by_id(g->identity);
+    tt_assert(n);
     smartlist_remove(big_fake_net_nodes, n);
     tor_free(n->rs);
     tor_free(n->md);
@@ -1216,6 +1219,7 @@ test_entry_guard_update_from_consensus_repair(void *arg)
     /* these will get a date. */
     entry_guard_t *g = smartlist_get(gs->sampled_entry_guards, i);
     node_t *n = (node_t*) bfn_mock_node_get_by_id(g->identity);
+    tt_assert(n);
     n->is_possible_guard = 0;
     g->currently_listed = 0;
   }
@@ -1281,6 +1285,7 @@ test_entry_guard_update_from_consensus_remove(void *arg)
   {
     entry_guard_t *g = smartlist_get(gs->sampled_entry_guards, 0);
     node_t *n = (node_t*) bfn_mock_node_get_by_id(g->identity);
+    tt_assert(n);
     n->is_possible_guard = 0;
     g->currently_listed = 0;
     g->unlisted_since_date = one_day_ago;
@@ -1290,6 +1295,7 @@ test_entry_guard_update_from_consensus_remove(void *arg)
   {
     entry_guard_t *g = smartlist_get(gs->sampled_entry_guards, 1);
     node_t *n = (node_t*) bfn_mock_node_get_by_id(g->identity);
+    tt_assert(n);
     n->is_possible_guard = 0;
     g->currently_listed = 0;
     g->unlisted_since_date = one_year_ago;


### PR DESCRIPTION
Some versions of GCC complain that the bfn_mock_node_get_by_id
function might return NULL, but we're assuming that it won't.
(We're assuming it won't return NULL because we know in the tests
that we're passing it valid IDs.)

To make GCC happy, tt_assert() that each node_t is set before using
it.

Fixes a second case of bug26269; bugfix on 0.3.0.1-alpha.