### PR TITLE
rust: Remove redundant "testing" feature from tor_log crate.

### DIFF
--- a/src/rust/crypto/Cargo.toml
+++ b/src/rust/crypto/Cargo.toml
@@ -25,5 +25,4 @@ rand = { version = "=0.5.0-pre.2", default-features = false }
 rand_core = { version = "=0.2.0-pre.0", default-features = false }
 
 [features]
-testing = ["tor_log/testing"]
 

--- a/src/rust/protover/Cargo.toml
+++ b/src/rust/protover/Cargo.toml
@@ -4,7 +4,6 @@ version = "0.0.1"
 name = "protover"
 
 [features]
-testing = ["tor_log/testing"]
 
 [dependencies]
 libc = "=0.2.39"

--- a/src/rust/tor_log/Cargo.toml
+++ b/src/rust/tor_log/Cargo.toml
@@ -9,7 +9,6 @@ path = "lib.rs"
 crate_type = ["rlib", "staticlib"]
 
 [features]
-testing = []
 
 [dependencies]
 libc = "0.2.39"

--- a/src/rust/tor_log/tor_log.rs
+++ b/src/rust/tor_log/tor_log.rs
@@ -88,7 +88,7 @@ pub fn tor_log_msg_impl(
 
 /// This implementation is used when compiling for actual use, as opposed to
 /// testing.
-#[cfg(all(not(test), not(feature = "testing")))]
+#[cfg(not(test))]
 pub mod log {
     use libc::{c_char, c_int};
     use super::LogDomain;
@@ -142,7 +142,7 @@ pub mod log {
 
 /// This module exposes no-op functionality for testing other Rust modules
 /// without linking to C.
-#[cfg(any(test, feature = "testing"))]
+#[cfg(test)]
 pub mod log {
     use libc::{c_char, c_int};
     use super::LogDomain;


### PR DESCRIPTION
It was synonymous with the builtin "test" feature.

 * FIXES #26399: https://bugs.torproject.org/26399