### PR TITLE
rust: Remove --all-features flag from `cargo test` call in test_rust.sh.

### DIFF
--- a/src/test/test_rust.sh
+++ b/src/test/test_rust.sh
@@ -9,7 +9,7 @@ for cargo_toml_dir in "${abs_top_srcdir:-../../..}"/src/rust/*; do
 	cd "${cargo_toml_dir}" && \
 	    CARGO_TARGET_DIR="${abs_top_builddir:-../../..}/src/rust/target" \
 	    CARGO_HOME="${abs_top_builddir:-../../..}/src/rust" \
-	    "${CARGO:-cargo}" test --all-features ${CARGO_ONLINE-"--frozen"} \
+	    "${CARGO:-cargo}" test ${CARGO_ONLINE-"--frozen"} \
 	    ${EXTRA_CARGO_OPTIONS} \
 	    --manifest-path "${cargo_toml_dir}/Cargo.toml" || exitcode=1
     fi


### PR DESCRIPTION
We'd like to feature gate code that calls C from Rust, as a workaround
to several linker issues when running `cargo test` (#25386), and we
can't feature gate anything out of test code if `cargo test` is called
with `--all-features`.

 * FIXES #26400: https://bugs.torproject.org/26400