### PR TITLE
rust: Add "test-c-from-rust" feature-gate.

### DIFF
--- a/src/rust/Cargo.toml
+++ b/src/rust/Cargo.toml
@@ -14,3 +14,12 @@ members = [
 debug = true
 panic = "abort"
 
+[features]
+default = []
+# If this feature is enabled, test code which calls Tor C code from Rust will
+# execute with `cargo test`.  Due to numerous linker issues (#25386), this is
+# currently disabled by default.  Crates listed here are those which, in their
+# unittests, doctests, and/or integration tests, call C code.
+test-c-from-rust = [
+    "crypto/test-c-from-rust",
+]

--- a/src/rust/crypto/Cargo.toml
+++ b/src/rust/crypto/Cargo.toml
@@ -26,4 +26,8 @@ rand_core = { version = "=0.2.0-pre.0", default-features = false }
 
 [features]
 testing = ["tor_log/testing"]
+# If this feature is enabled, test code which calls Tor C code from Rust will
+# execute with `cargo test`.  Due to numerous linker issues (#25386), this is
+# currently disabled by default.
+test-c-from-rust = []
 

--- a/src/rust/crypto/digests/sha2.rs
+++ b/src/rust/crypto/digests/sha2.rs
@@ -165,15 +165,19 @@ impl FixedOutput for Sha512 {
 
 #[cfg(test)]
 mod test {
+    #[cfg(feature = "test-c-from-rust")]
     use digest::Digest;
 
+    #[cfg(feature = "test-c-from-rust")]
     use super::*;
 
+    #[cfg(feature = "test-c-from-rust")]
     #[test]
     fn sha256_default() {
         let _: Sha256 = Sha256::default();
     }
 
+    #[cfg(feature = "test-c-from-rust")]
     #[test]
     fn sha256_digest() {
         let mut h: Sha256 = Sha256::new();
@@ -190,11 +194,13 @@ mod test {
         assert_eq!(&result[..], &b"xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"[..]);
     }
 
+    #[cfg(feature = "test-c-from-rust")]
     #[test]
     fn sha512_default() {
         let _: Sha512 = Sha512::default();
     }
 
+    #[cfg(feature = "test-c-from-rust")]
     #[test]
     fn sha512_digest() {
         let mut h: Sha512 = Sha512::new();


### PR DESCRIPTION
Due to linker issues (#25386) when testing Rust code which calls C,
all tests which touch FFI code should now be feature-gated behind the
"test-c-from-rust" flag.  To run this test code, cargo must be called
with `cargo test --features="test-c-from-rust"`.

 * FIXES #26398: https://bugs.torproject.org/26398