### PR TITLE
Fix compilation of Rust crypto doctests

### DIFF
--- a/changes/bug26415
+++ b/changes/bug26415
@@ -1,0 +1,3 @@
+  o Minor bugfixes (testing):
+    - Fix compilation of the doctests in the Rust crypto crate.  Fixes
+      bug 26415; bugfix on 0.3.4.1-alpha.

--- a/src/rust/crypto/digests/sha2.rs
+++ b/src/rust/crypto/digests/sha2.rs
@@ -44,9 +44,9 @@ pub struct Sha256 {
 /// # Examples
 ///
 /// ```
-/// use crypto::digest::Sha256;
+/// use crypto::digests::sha2::{Sha256, Digest};
 ///
-/// let hasher: Sha256 = Sha256::default();
+/// let mut hasher: Sha256 = Sha256::default();
 /// ```
 ///
 /// # Returns
@@ -67,12 +67,12 @@ impl BlockInput for Sha256 {
 /// # Examples
 ///
 /// ```
-/// use crypto::digest::Sha256;
+/// use crypto::digests::sha2::{Sha256, Digest};
 ///
-/// let hasher: Sha256 = Sha256::default();
+/// let mut hasher: Sha256 = Sha256::default();
 ///
-/// hasher.process(b"foo");
-/// hasher.process(b"bar");
+/// hasher.input(b"foo");
+/// hasher.input(b"bar");
 /// ```
 impl Input for Sha256 {
     fn process(&mut self, msg: &[u8]) {
@@ -111,9 +111,9 @@ pub struct Sha512 {
 /// # Examples
 ///
 /// ```
-/// use crypto::digest::Sha512;
+/// use crypto::digests::sha2::{Sha512, Digest};
 ///
-/// let hasher: Sha256 = Sha512::default();
+/// let mut hasher: Sha512 = Sha512::default();
 /// ```
 ///
 /// # Returns
@@ -134,12 +134,12 @@ impl BlockInput for Sha512 {
 /// # Examples
 ///
 /// ```
-/// use crypto::digest::Sha512;
+/// use crypto::digests::sha2::{Sha512, Digest};
 ///
-/// let hasher: Sha512 = Sha512::default();
+/// let mut hasher: Sha512 = Sha512::default();
 ///
-/// hasher.process(b"foo");
-/// hasher.process(b"bar");
+/// hasher.input(b"foo");
+/// hasher.input(b"bar");
 /// ```
 impl Input for Sha512 {
     fn process(&mut self, msg: &[u8]) {

--- a/src/rust/crypto/lib.rs
+++ b/src/rust/crypto/lib.rs
@@ -10,18 +10,18 @@
 //! and extendable output functions.
 //!
 //! ```
-//! use crypto::digests::sha256::Sha256;
+//! use crypto::digests::sha2::*;
 //!
-//! let hasher: Sha256 = Sha256::default();
+//! let mut hasher: Sha256 = Sha256::default();
 //! let mut result: [u8; 32] = [0u8; 32];
 //!
-//! hasher.input("foo");
-//! hasher.input("bar");
-//! hasher.input("baz");
+//! hasher.input(b"foo");
+//! hasher.input(b"bar");
+//! hasher.input(b"baz");
 //!
-//! result.copy_from_slice(hasher.result().as_bytes());
+//! result.copy_from_slice(hasher.result().as_slice());
 //!
-//! assert!(result == "XXX");
+//! assert!(result == [b'X'; DIGEST256_LEN]);
 //! ```
 
 #[deny(missing_docs)]


### PR DESCRIPTION
The doctests for src/rust/crypto don't compile for multiple reasons,
including some missing exports and incorrect identifier paths.  Fixes
bug 26415; bugfix on 0.3.4.1-alpha.