### PR TITLE
Fix forking tests on Windows when there is a space in the path.

### DIFF
--- a/changes/bug26437
+++ b/changes/bug26437
@@ -1,0 +1,3 @@
+  o Testing:
+    - Fix forking tests on Windows when there is a space somewhere in the path.
+      Fixes bug 26437; bugfix on 0.2.2.4-alpha.

--- a/src/ext/tinytest.c
+++ b/src/ext/tinytest.c
@@ -145,7 +145,7 @@ testcase_run_forked_(const struct testgroup_t *group,
 	if (opt_verbosity>0)
 		printf("[forking] ");
 
-	snprintf(buffer, sizeof(buffer), "%s --RUNNING-FORKED %s %s%s",
+	snprintf(buffer, sizeof(buffer), "\"%s\" --RUNNING-FORKED %s %s%s",
 		 commandname, verbosity_flag, group->prefix, testcase->name);
 
 	memset(&si, 0, sizeof(si));


### PR DESCRIPTION
See: https://bugs.torproject.org/26437