### PR TITLE
Use correct CARGO_HOME in test_rust.sh

### DIFF
--- a/src/test/test_rust.sh
+++ b/src/test/test_rust.sh
@@ -8,7 +8,7 @@ for cargo_toml_dir in "${abs_top_srcdir:-../../..}"/src/rust/*; do
     if [ -e "${cargo_toml_dir}/Cargo.toml" ]; then
 	cd "${cargo_toml_dir}" && \
 	    CARGO_TARGET_DIR="${abs_top_builddir:-../../..}/src/rust/target" \
-	    CARGO_HOME="${abs_top_builddir:-../../..}/src/rust" \
+	    CARGO_HOME="${abs_top_builddir:-../../..}/src/rust/.cargo" \
 	    "${CARGO:-cargo}" test --all-features ${CARGO_ONLINE-"--frozen"} \
 	    ${EXTRA_CARGO_OPTIONS} \
 	    --manifest-path "${cargo_toml_dir}/Cargo.toml" || exitcode=1


### PR DESCRIPTION
Out-of-tree builds could fail to run the rust tests if built in
offline mode.  cargo expects CARGO_HOME to point to the .cargo
directory, not the directory containing .cargo.

Fixes bug 26455; bug not in any released tor.