### PR TITLE
Add more optional packages to Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -42,11 +42,12 @@ addons:
     packages:
       ## Required dependencies
       - libevent-dev
-      - libseccomp2
       - zlib1g-dev
       ## Optional dependencies
+      - libcap-dev
       - liblzma-dev
       - libscrypt-dev
+      - libseccomp-dev
       ## zstd doesn't exist in Ubuntu Trusty
       #- libzstd
 

--- a/changes/ticket26560
+++ b/changes/ticket26560
@@ -1,0 +1,3 @@
+  o Minor features (continuous integration):
+    - Install libcap-dev and libseccomp2-dev so these optional
+      dependencies get tested on Travis CI.  Closes ticket 26560.


### PR DESCRIPTION
Apparently we weren't building with either libcap or libseccomp on
Travis.  Install libcap-dev and libseccomp-dev in .travis.yml.  Closes
ticket 26560.