### PR TITLE
Don't redefine str(n)casecmp on windows unless they're missing

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -610,6 +610,8 @@ AC_CHECK_FUNCS(
         sigaction \
         socketpair \
 	statvfs \
+        strncasecmp \
+        strcasecmp \
         strlcat \
         strlcpy \
 	strnlen \

--- a/src/lib/string/compat_string.h
+++ b/src/lib/string/compat_string.h
@@ -13,9 +13,20 @@
 
 /* ===== String compatibility */
 #ifdef _WIN32
-/* Windows names string functions differently from most other platforms. */
-#define strncasecmp _strnicmp
-#define strcasecmp _stricmp
+/* Windows doesn't have str(n)casecmp, but mingw defines it: only define it
+ * ourselves if it's missing. */
+#ifndef HAVE_STRNCASECMP
+static inline int strncasecmp(const char *a, const char *b, size_t n);
+static inline int strncasecmp(const char *a, const char *b, size_t n) {
+  return strncmpi(a,b);
+}
+#endif
+#ifndef HAVE_STRCASECMP
+static inline int strcasecmp(const char *a, const char *b, size_t n);
+static inline int strcasecmp(const char *a, const char *b, size_t n) {
+  return strcmpi(a,b);
+}
+#endif
 #endif
 
 #if defined __APPLE__


### PR DESCRIPTION
When we do redefine them, use inline functions instead of #define.

This fixes a latent code problem in our redefinition of these
functions, which was exposed by our refactoring: Previously, we
would #define strcasecmp after string.h was included, so nothing bad
would happen.  But when we refactored, we would sometimes #define it
first, which was a problem on mingw, whose headers contain
(approximately):

inline int strcasecmp (const char *a, const char *b)
   { return _stricmp(a,b); }

Our define turned this into:
  inline int _stricmp(const char *a, const char *b)
    { return _stricmp(a,b); }

And GCC would correctly infer that this function would loop forever,
rather than actually comparing anything.  This caused bug 26594.

Fixes bug 26594; bug not in any released version of Tor.