### PR TITLE
ntor_ref.py: pass only strings to subprocess.Popen

### DIFF
--- a/changes/bug26535.029
+++ b/changes/bug26535.029
@@ -1,0 +1,5 @@
+  o Minor bugfixes (testing, compatibility):
+    - When running the ntor_ref.py test, make sure only to pass strings
+      (rather than "bytes" objects) to the Python subprocess module.
+      Python 3 on Windows seems to require this.  Fixes bug 26535; bugfix on
+      0.2.5.5-alpha.

--- a/src/test/ntor_ref.py
+++ b/src/test/ntor_ref.py
@@ -336,13 +336,16 @@ def test_tor():
        Call the test-ntor-cl command-line program to make sure we can
        interoperate with Tor's ntor program
     """
-    enhex=lambda s: binascii.b2a_hex(s)
+    if sys.version_info[0] >= 3:
+        enhex=lambda s: binascii.b2a_hex(s).decode("ascii")
+    else:
+        enhex=lambda s: binascii.b2a_hex(s)
     dehex=lambda s: binascii.a2b_hex(s.strip())
 
-    PROG = b"./src/test/test-ntor-cl"
+    PROG = "./src/test/test-ntor-cl"
     def tor_client1(node_id, pubkey_B):
         " returns (msg, state) "
-        p = subprocess.Popen([PROG, b"client1", enhex(node_id),
+        p = subprocess.Popen([PROG, "client1", enhex(node_id),
                               enhex(pubkey_B.serialize())],
                              stdout=subprocess.PIPE)
         return map(dehex, p.stdout.readlines())


### PR DESCRIPTION
Recent Python3 versions seem to require this on Windows.

Fixes bug 26535; bug introduced in f4be34f70d6f277a0f3f73e, which
was apparently intended itself as a Python3 workaround.