### PR TITLE
hs_ntor_ref.py: pass only strings to subprocess.Popen

### DIFF
--- a/changes/bug26535.032
+++ b/changes/bug26535.032
@@ -1,0 +1,5 @@
+  o Minor bugfixes (testing, compatibility):
+    - When running the hs_ntor_ref.py test, make sure only to pass strings
+      (rather than "bytes" objects) to the Python subprocess module.
+      Python 3 on Windows seems to require this.  Fixes bug 26535; bugfix on
+      0.3.1.1-alpha.

--- a/src/test/hs_ntor_ref.py
+++ b/src/test/hs_ntor_ref.py
@@ -234,8 +234,11 @@ Utilities for communicating with the little-t-tor ntor wrapper to conduct the
 integration tests
 """
 
-PROG = b"./src/test/test-hs-ntor-cl"
-enhex=lambda s: binascii.b2a_hex(s)
+PROG = "./src/test/test-hs-ntor-cl"
+if sys.version_info[0] >= 3:
+    enhex=lambda s: binascii.b2a_hex(s).decode("ascii")
+else:
+    enhex=lambda s: binascii.b2a_hex(s)
 dehex=lambda s: binascii.a2b_hex(s.strip())
 
 def tor_client1(intro_auth_pubkey_str, intro_enc_pubkey,


### PR DESCRIPTION
Recent Python3 versions seem to require this on Windows.

Fixes bug 26535; bug copied from ntor_ref.py on 0.3.1.1-alpha.