### PR TITLE
Partially revert "Use tor_addr_from_getsockname() in several places"

### DIFF
--- a/changes/bug26568
+++ b/changes/bug26568
@@ -1,0 +1,3 @@
+  o Minor bugfixes (controller):
+    - Report the port correctly when a port is configured to bind to "auto".
+      Fixes bug 26568; bugfix on 0.3.4.1-alpha.

--- a/src/or/connection.c
+++ b/src/or/connection.c
@@ -1260,12 +1260,15 @@ connection_listener_new(const struct sockaddr *listensockaddr,
       gotPort = usePort;
     } else {
       tor_addr_t addr2;
-      if (tor_addr_from_getsockname(&addr2, s)<0) {
+      struct sockaddr_storage ss;
+      socklen_t ss_len=sizeof(ss);
+      if (getsockname(s, (struct sockaddr*)&ss, &ss_len)<0) {
         log_warn(LD_NET, "getsockname() couldn't learn address for %s: %s",
                  conn_type_to_string(type),
                  tor_socket_strerror(tor_socket_errno(s)));
         gotPort = 0;
       }
+      tor_addr_from_sockaddr(&addr2, (struct sockaddr*)&ss, &gotPort);
     }
 #ifdef HAVE_SYS_UN_H
   /*


### PR DESCRIPTION
This reverts part of commit 6ed384b827dce21ea3a44b587, in order to
fix bug 26568.  Bugfix on 0.3.4.1-alpha.