### PR TITLE
Allow single DA if explicitly configured

### DIFF
--- a/src/or/routerlist.c
+++ b/src/or/routerlist.c
@@ -1806,6 +1806,9 @@ router_pick_dirserver_generic(smartlist_t *sourcelist,
   const routerstatus_t *choice;
   int busy = 0;
 
+  if (smartlist_len(sourcelist) == 1)
+    flags |= PDS_ALLOW_SELF;
+
   choice = router_pick_trusteddirserver_impl(sourcelist, type, flags, &busy);
   if (choice || !(flags & PDS_RETRY_IF_NO_SERVERS))
     return choice;


### PR DESCRIPTION
When on a private network a single directory authority is explicitly
configured, allow that DA's instace of tor to pick itself as its own
DA, by having router_pick_dirserver_generic() set the PDS_ALLOW_SELF
flag when the list of potential sources contains only one element.
This would subsequently allow router_pick_trusteddirserver_impl() to
calculate is 'requreother' condition as 'false', enabling it to pick
itself as a valid DA candidate.

Fixes #25928

Signed-off-by: Gabriel Somlo <gsomlo@gmail.com>