### PR TITLE
Warn the directory authority operator if their versions list is bogus

### DIFF
--- a/changes/bug26485
+++ b/changes/bug26485
@@ -1,0 +1,4 @@
+  o Minor bugfixes (directory authority):
+    - When voting for recommended versions, make sure that all of the
+      versions are well-formed and parsable. Fixes bug 26485; bugfix on
+      0.1.1.6-alpha.

--- a/src/or/config.c
+++ b/src/or/config.c
@@ -3098,6 +3098,14 @@ options_validate(or_options_t *old_options, or_options_t *options,
          !options->RecommendedServerVersions))
       REJECT("Versioning authoritative dir servers must set "
              "Recommended*Versions.");
+
+    char *t;
+    /* Call these functions to produce warnings only. */
+    t = format_recommended_version_list(options->RecommendedClientVersions, 1);
+    tor_free(t);
+    t = format_recommended_version_list(options->RecommendedServerVersions, 1);
+    tor_free(t);
+
     if (options->UseEntryGuards) {
       log_info(LD_CONFIG, "Authoritative directory servers can't set "
                "UseEntryGuards. Disabling.");
@@ -8003,4 +8011,3 @@ init_cookie_authentication(const char *fname, const char *header,
   tor_free(cookie_file_str);
   return retval;
 }
-

--- a/src/or/dirserv.c
+++ b/src/or/dirserv.c
@@ -1043,7 +1043,7 @@ format_recommended_version_list(const config_line_t *ln, int warn)
   }
 
   /* Handle the case where a dirauth operator has accidentally made some
-   * versions comma-separated instead of space-separated. */
+   * versions space-separated instead of comma-separated. */
   smartlist_t *more_versions = smartlist_new();
   SMARTLIST_FOREACH_BEGIN(versions, char *, v) {
     if (strchr(v, ' ')) {

--- a/src/or/dirserv.h
+++ b/src/or/dirserv.h
@@ -104,7 +104,7 @@ char *routerstatus_format_entry(
 void dirserv_free_all(void);
 void cached_dir_decref(cached_dir_t *d);
 cached_dir_t *new_cached_dir(char *s, time_t published);
-
+char *format_recommended_version_list(const config_line_t *line, int warn);
 int validate_recommended_package_line(const char *line);
 
 #ifdef DIRSERV_PRIVATE
@@ -141,4 +141,3 @@ int dirserv_read_guardfraction_file(const char *fname,
                                  smartlist_t *vote_routerstatuses);
 
 #endif
-

--- a/src/or/dirvote.c
+++ b/src/or/dirvote.c
@@ -673,6 +673,14 @@ compute_consensus_versions_list(smartlist_t *lst, int n_versioning)
   int min = n_versioning / 2;
   smartlist_t *good = smartlist_new();
   char *result;
+  SMARTLIST_FOREACH_BEGIN(lst, const char *, v) {
+    if (strchr(v, ' ')) {
+      log_warn(LD_DIR, "At least one authority has voted for a version %s "
+               "that contains a space. This probably wasn't intentional, and "
+               "is likely to cause trouble. Please tell them to stop it.",
+               escaped(v));
+    }
+  } SMARTLIST_FOREACH_END(v);
   sort_version_list(lst, 0);
   get_frequent_members(good, lst, min);
   result = smartlist_join_strings(good, ",", 0, NULL);
@@ -4002,4 +4010,3 @@ vote_routerstatus_find_microdesc_hash(char *digest256_out,
   }
   return -1;
 }
-


### PR DESCRIPTION
Prevents bug 26485; bugfix on 0.1.1.6-alpha.