### PR TITLE
Add checks in get_net_param_from_list() for valid output domain.

### DIFF
--- a/src/feature/nodelist/networkstatus.c
+++ b/src/feature/nodelist/networkstatus.c
@@ -2417,6 +2417,8 @@ get_net_param_from_list(smartlist_t *net_params, const char *param_name,
     res = max_val;
   }
 
+  tor_assert(res >= min_val);
+  tor_assert(res <= max_val);
   return res;
 }
 


### PR DESCRIPTION
This patch adds two assertions in get_net_param_from_list() to ensure
that the `res` value is correctly within the range of the output domain.

Hopefully fixes Coverity CID #1415721, #1415722, and #1415723.

See: https://bugs.torproject.org/26780