### PR TITLE
SKIP test_keygen.sh on Windows until the underlying issue is resolved

### DIFF
--- a/changes/bug26830
+++ b/changes/bug26830
@@ -1,0 +1,3 @@
+  o Minor bugfixes (continuous integration):
+    - Skip an unreliable key generation test on Windows, until the underlying
+      issue in bug 26076 is resolved. Fixes bug 26830; bugfix on 0.2.7.3-rc.

--- a/src/test/test_keygen.sh
+++ b/src/test/test_keygen.sh
@@ -13,6 +13,12 @@ if [ $# -eq 0 ] || [ ! -f ${1} ] || [ ! -x ${1} ]; then
   fi
 fi
 
+if test "`uname -s | cut -d_ -f1`" = 'CYGWIN' || \
+   test "`uname -s | cut -d_ -f1`" = 'MINGW'; then
+    echo "This test is unreliable on Windows. See trac #26076. Skipping." >&2
+    exit 77
+fi
+
 if [ $# -ge 1 ]; then
   TOR_BINARY="${1}"
   shift


### PR DESCRIPTION
Skip an unreliable key generation test on Windows, until the underlying
issue in bug 26076 is resolved.

Fixes bug 26830; bugfix on 0.2.7.3-rc.

Opening a pull request to trigger Appveyor CI.