### PR TITLE
[Tor Trac #20874]: ReachableAddresses adds an extra reject *:* on every SAVECONF

### DIFF
--- a/changes/bug20874
+++ b/changes/bug20874
@@ -1,0 +1,7 @@
+  o Minor bugfixes (client, reachableaddresses):
+    - Instead of adding an "reject *:*" line to ReachableAddresses when
+      loading the configuration, add one to the policy after parsing it
+      in parse_reachable_addresses(). This prevents extra "reject *.*"
+      lines from accumulating on reloads. Fixes bug 20874; bugfix on
+      0.3.5.1-alpha. Patch by Neel Chauhan.
+

--- a/src/app/config/config.c
+++ b/src/app/config/config.c
@@ -3359,7 +3359,6 @@ STATIC int
 options_validate(or_options_t *old_options, or_options_t *options,
                  or_options_t *default_options, int from_setconf, char **msg)
 {
-  int i;
   config_line_t *cl;
   const char *uname = get_uname();
   int n_ports=0;
@@ -3676,30 +3675,6 @@ options_validate(or_options_t *old_options, or_options_t *options,
         options->ReachableORAddresses = new_line;
         log_notice(LD_CONFIG, "Converting FascistFirewall config option "
             "to new format: \"ReachableORAddresses *:443\"");
-      }
-    }
-  }
-
-  /* Terminate Reachable*Addresses with reject *
-   */
-  for (i=0; i<3; i++) {
-    config_line_t **linep =
-      (i==0) ? &options->ReachableAddresses :
-        (i==1) ? &options->ReachableORAddresses :
-                 &options->ReachableDirAddresses;
-    if (!*linep)
-      continue;
-    /* We need to end with a reject *:*, not an implicit accept *:* */
-    for (;;) {
-      linep = &((*linep)->next);
-      if (!*linep) {
-        *linep = tor_malloc_zero(sizeof(config_line_t));
-        (*linep)->key = tor_strdup(
-          (i==0) ?  "ReachableAddresses" :
-            (i==1) ? "ReachableORAddresses" :
-                     "ReachableDirAddresses");
-        (*linep)->value = tor_strdup("reject *:*");
-        break;
       }
     }
   }

--- a/src/core/or/policies.c
+++ b/src/core/or/policies.c
@@ -317,6 +317,14 @@ parse_reachable_addresses(void)
     }
   }
 
+  /* Prepend a reject *.* to reachable_(or|dir)_addr_policy */
+  if (!ret && (options->ReachableDirAddresses ||
+               options->ReachableORAddresses ||
+               options->ReachableAddresses)) {
+    append_exit_policy_string(&reachable_or_addr_policy, "reject *:*");
+    append_exit_policy_string(&reachable_dir_addr_policy, "reject *:*");
+  }
+
   return ret;
 }
 

--- a/src/test/test_options.c
+++ b/src/test/test_options.c
@@ -1634,6 +1634,18 @@ test_options_validate__reachable_addresses(void *ignored)
   tt_str_op(tdata->opt->ReachableAddresses->value, OP_EQ, "*:82");
   tor_free(msg);
 
+  free_options_test_data(tdata);
+  mock_clean_saved_logs();
+  tdata = get_options_test_data("FascistFirewall 1\n"
+                                "ReachableAddresses *:82\n"
+                                "MaxClientCircuitsPending 1\n"
+                                "ConnLimit 1\n");
+
+  ret = options_validate(tdata->old_opt, tdata->opt, tdata->def_opt, 0, &msg);
+  tt_int_op(ret, OP_EQ, -1);
+  tt_ptr_op(tdata->opt->ReachableAddresses->next, OP_EQ, NULL);
+  tor_free(msg);
+
 #define SERVERS_REACHABLE_MSG "Servers must be able to freely connect to" \
   " the rest of the Internet, so they must not set Reachable*Addresses or" \
   " FascistFirewall or FirewallPorts or ClientUseIPv4 0."


### PR DESCRIPTION
For the bug [here](https://trac.torproject.org/projects/tor/ticket/20874).