### PR TITLE
#26892: Early bailout from log_addr_has_changed() if running as client

### DIFF
--- a/changes/bug26892
+++ b/changes/bug26892
@@ -1,0 +1,6 @@
+  o Minor bugfixes (logging):
+    - As a precaution, do an early return from
+      log_addr_has_changed() if Tor is running as client. Also,
+      log a stack trace for debugging as this function should only
+      be called when Tor runs as server. Fixes bug 26892;
+      bugfix on 0.1.1.9-alpha.

--- a/src/feature/relay/router.c
+++ b/src/feature/relay/router.c
@@ -2686,6 +2686,9 @@ log_addr_has_changed(int severity,
   char addrbuf_prev[TOR_ADDR_BUF_LEN];
   char addrbuf_cur[TOR_ADDR_BUF_LEN];
 
+  if (BUG(!server_mode(get_options())))
+    return;
+
   if (tor_addr_to_str(addrbuf_prev, prev, sizeof(addrbuf_prev), 1) == NULL)
     strlcpy(addrbuf_prev, "???", TOR_ADDR_BUF_LEN);
   if (tor_addr_to_str(addrbuf_cur, cur, sizeof(addrbuf_cur), 1) == NULL)


### PR DESCRIPTION
https://trac.torproject.org/projects/tor/ticket/26892