### PR TITLE
Don't disable an unsupported compiler warning [ticket 26785]

### DIFF
--- a/changes/bug26785
+++ b/changes/bug26785
@@ -1,0 +1,4 @@
+  o Minor bugfixes (compilation, portability):
+    - Don't try to use a pragma to temporarily disable
+      -Wunused-const-variable if the compiler doesn't support it.
+      Fixes bug 26785; bugfix on 0.3.2.11.

--- a/configure.ac
+++ b/configure.ac
@@ -2143,6 +2143,9 @@ dnl     -Wthread-safety-precise
   if test "$tor_cv_cflags__Woverlength_strings" = "yes"; then
     AC_DEFINE([HAVE_CFLAG_WOVERLENGTH_STRINGS], 1, [True if we have -Woverlength-strings])
   fi
+  if test "$tor_cv_cflags__warn_unused_const_variable_2" = "yes"; then
+    AC_DEFINE([HAVE_CFLAG_WUNUSED_CONST_VARIABLE], 1, [True if we have -Wunused-const-variable])
+  fi
 
   if test "x$enable_fatal_warnings" = "xyes"; then
     # I'd like to use TOR_CHECK_CFLAGS here, but I can't, since the

--- a/src/common/compress_zstd.c
+++ b/src/common/compress_zstd.c
@@ -19,9 +19,13 @@
 #include "compress_zstd.h"
 
 #ifdef HAVE_ZSTD
+#ifdef HAVE_CFLAG_WUNUSED_CONST_VARIABLE
 DISABLE_GCC_WARNING(unused-const-variable)
+#endif
 #include <zstd.h>
+#ifdef HAVE_CFLAG_WUNUSED_CONST_VARIABLE
 ENABLE_GCC_WARNING(unused-const-variable)
+#endif
 #endif
 
 /** Total number of bytes allocated for Zstandard state. */


### PR DESCRIPTION
Conditionalize the pragma that temporarily disables
-Wunused-const-variable.  Some versions of gcc don't support it.  We
need to do this because of an apparent bug in some libzstd headers.
Fixes bug 26785; bugfix on 0.3.2.11.