### PR TITLE
Always call tor_free_all() when exiting tor_run_main()

### DIFF
--- a/changes/bug26948
+++ b/changes/bug26948
@@ -1,0 +1,4 @@
+  o Minor bugfixes (in-process restart):
+    - Always call tor_free_all() when leaving tor_run_main(). When we
+      did not, restarting tor in-process would cause an assertion failure.
+      Fixes bug 26948; bugfix on 0.3.3.1-alpha.

--- a/src/or/main.c
+++ b/src/or/main.c
@@ -4035,10 +4035,10 @@ tor_run_main(const tor_main_configuration_t *tor_cfg)
 #endif /* defined(NT_SERVICE) */
   {
     int init_rv = tor_init(argc, argv);
-    if (init_rv < 0)
-      return -1;
-    else if (init_rv > 0)
-      return 0;
+    if (init_rv) {
+      tor_free_all(0);
+      return (init_rv < 0) ? -1 : 0;
+    }
   }
 
   if (get_options()->Sandbox && get_options()->command == CMD_RUN_TOR) {
@@ -4046,6 +4046,7 @@ tor_run_main(const tor_main_configuration_t *tor_cfg)
 
     if (sandbox_init(cfg)) {
       log_err(LD_BUG,"Failed to create syscall sandbox filter");
+      tor_free_all(0);
       return -1;
     }
 


### PR DESCRIPTION
We would usually call it through tor_cleanup(), but in some code
paths, we wouldn't. These paths would break restart-in-process,
since leaving fields uncleared would cause assertion failures on
restart.

Fixes bug 26948; bugfix on 0.3.3.1-alpha