### PR TITLE
Ticket25573

### DIFF
--- a/changes/ticket25573
+++ b/changes/ticket25573
@@ -1,0 +1,5 @@
+  o Minor features (controller):
+    - For purposes of CIRC_BW-based dropped cell detection, track half-closed
+      stream ids, and allow their ENDs, SENDMEs, and DATA to arrive without
+      counting it as dropped until either the END arrvies, or the windows
+      are empty. Closes ticket 25573.

--- a/changes/ticket25573
+++ b/changes/ticket25573
@@ -1,5 +1,5 @@
   o Minor features (controller):
     - For purposes of CIRC_BW-based dropped cell detection, track half-closed
-      stream ids, and allow their ENDs, SENDMEs, and DATA to arrive without
-      counting it as dropped until either the END arrvies, or the windows
-      are empty. Closes ticket 25573.
+      stream ids, and allow their ENDs, SENDMEs, DATA and path bias check
+      cells to arrive without counting it as dropped until either the END arrvies,
+      or the windows are empty. Closes ticket 25573.

--- a/src/or/circpathbias.c
+++ b/src/or/circpathbias.c
@@ -893,6 +893,7 @@ pathbias_check_probe_response(circuit_t *circ, const cell_t *cell)
     /* Check nonce */
     if (ipv4_host == ocirc->pathbias_probe_nonce) {
       pathbias_mark_use_success(ocirc);
+      circuit_read_valid_data(ocirc, rh.length);
       circuit_mark_for_close(circ, END_CIRC_REASON_FINISHED);
       log_info(LD_CIRC,
                "Got valid path bias probe back for circ %d, stream %d.",

--- a/src/or/circuitlist.c
+++ b/src/or/circuitlist.c
@@ -1041,6 +1041,14 @@ circuit_free_(circuit_t *circ)
 
     circuit_remove_from_origin_circuit_list(ocirc);
 
+    if (ocirc->half_streams) {
+      SMARTLIST_FOREACH_BEGIN(ocirc->half_streams, half_edge_t*,
+                              half_conn) {
+          tor_free(half_conn);
+      } SMARTLIST_FOREACH_END(half_conn);
+      smartlist_free(ocirc->half_streams);
+    }
+
     if (ocirc->build_state) {
         extend_info_free(ocirc->build_state->chosen_exit);
         circuit_free_cpath_node(ocirc->build_state->pending_final_cpath);

--- a/src/or/connection_edge.c
+++ b/src/or/connection_edge.c
@@ -2717,6 +2717,15 @@ get_unique_stream_id_by_circ(origin_circuit_t *circ)
   for (tmpconn = circ->p_streams; tmpconn; tmpconn=tmpconn->next_stream)
     if (tmpconn->stream_id == test_stream_id)
       goto again;
+
+  if (circ->half_streams) {
+    SMARTLIST_FOREACH_BEGIN(circ->half_streams, half_edge_t *, half_conn) {
+      if (half_conn->stream_id == test_stream_id) {
+        goto again;
+      }
+    } SMARTLIST_FOREACH_END(half_conn);
+  }
+
   return test_stream_id;
 }
 

--- a/src/or/connection_edge.h
+++ b/src/or/connection_edge.h
@@ -122,6 +122,13 @@ void connection_ap_warn_and_unmark_if_pending_circ(
                                              entry_connection_t *entry_conn,
                                              const char *where);
 
+int connection_half_edge_is_valid_data(smartlist_t *half_conns,
+                                       streamid_t stream_id);
+int connection_half_edge_is_valid_end(smartlist_t *half_conns,
+                                      streamid_t stream_id);
+int connection_half_edge_is_valid_sendme(smartlist_t *half_conns,
+                                         streamid_t stream_id);
+
 /** @name Begin-cell flags
  *
  * These flags are used in RELAY_BEGIN cells to change the default behavior

--- a/src/or/or.h
+++ b/src/or/or.h
@@ -1745,6 +1745,24 @@ typedef struct edge_connection_t {
   uint64_t dirreq_id;
 } edge_connection_t;
 
+/**
+ * Struct to track a connection that we closed that the other end
+ * still thinks is open. Exists in origin_circuit_t::half_streams until
+ * we get an end for this stream id.
+ */
+typedef struct half_edge_t {
+  /** stream_id for the half-closed connection */
+  streamid_t stream_id;
+
+  /** How many sendme's can the other end still send, based on how
+   * much data we had sent at the time of close */
+  int sendmes_pending;
+
+  /** How much more data can the other end still send, based on
+   * our deliver window */
+  int data_pending;
+} half_edge_t;
+
 /** Subtype of edge_connection_t for an "entry connection" -- that is, a SOCKS
  * connection, a DNS request, a TransPort connection or a NATD connection */
 typedef struct entry_connection_t {
@@ -3260,6 +3278,10 @@ typedef struct origin_circuit_t {
   /** Linked list of AP streams (or EXIT streams if hidden service)
    * associated with this circuit. */
   edge_connection_t *p_streams;
+
+  /** Smartlist of half-closed streams (half_connection_t*) that still
+   * have pending activity */
+  smartlist_t *half_streams;
 
   /** Bytes read on this circuit since last call to
    * control_event_circ_bandwidth_used().  Only used if we're configured


### PR DESCRIPTION
Check END, SENDME, and DATA cells against half-closed stream ids in order to properly report dropped bytes to the control port.

This change does not affect behavior -- it only affects what is reported to the CIRC_BW event.