### PR TITLE
[Tor Trac #27075]: Fix typo in control_event_hs_descriptor_content()

### DIFF
--- a/src/feature/control/control.c
+++ b/src/feature/control/control.c
@@ -7702,11 +7702,11 @@ control_event_hsv3_descriptor_failed(const char *onion_address,
   tor_free(desc_id_field);
 }
 
-/** Send HS_DESC_CONTENT event after completion of a successful fetch from hs
- * directory. If <b>hsdir_id_digest</b> is NULL, it is replaced by "UNKNOWN".
- * If <b>content</b> is NULL, it is replaced by an empty string. The
- * <b>onion_address</b> or <b>desc_id</b> set to NULL will no trigger the
- * control event. */
+/** Send HS_DESC_CONTENT event after completion of a successful fetch
+ * from hs directory. If <b>hsdir_id_digest</b> is NULL, it is replaced
+ * by "UNKNOWN". If <b>content</b> is NULL, it is replaced by an empty
+ * string. The  <b>onion_address</b> or <b>desc_id</b> set to NULL will
+ * not trigger the control event. */
 void
 control_event_hs_descriptor_content(const char *onion_address,
                                     const char *desc_id,


### PR DESCRIPTION
For the bug report [here](https://trac.torproject.org/projects/tor/ticket/27075).