### PR TITLE
Don't search for -lpthread on Windows

### DIFF
--- a/changes/bug27081
+++ b/changes/bug27081
@@ -1,0 +1,4 @@
+  o Minor bugfixes (compilation, windows):
+    - Don't link or search for pthreads when building for Windows, even if we
+      are using build environment (like mingw) that provides a pthreads
+      library. Fixes bug 27081; bugfix on 0.1.0.1-rc.

--- a/configure.ac
+++ b/configure.ac
@@ -370,8 +370,10 @@ if test "$LIBS" != "$saved_LIBS"; then
    have_rt=yes
 fi
 
-AC_SEARCH_LIBS(pthread_create, [pthread])
-AC_SEARCH_LIBS(pthread_detach, [pthread])
+if test "$bwin32" = "false"; then
+  AC_SEARCH_LIBS(pthread_create, [pthread])
+  AC_SEARCH_LIBS(pthread_detach, [pthread])
+fi
 
 AM_CONDITIONAL(THREADS_WIN32, test "$bwin32" = "true")
 AM_CONDITIONAL(THREADS_PTHREADS, test "$bwin32" = "false")


### PR DESCRIPTION
If we're building for Windows, we want to use windows threads no
matter what, and we don't want to link a pthread library even if it
is present.  Fixes bug 27081; bugfix on 1790dc67607799a in 0.1.0.1-rc.