### PR TITLE
[Tor Trac #25885]: count_acceptable_nodes() would be more accurate using node_has_preferred_descriptor() 

### DIFF
--- a/changes/bug25885
+++ b/changes/bug25885
@@ -1,0 +1,7 @@
+  o Minor bugfixes (guards):
+    - In count_acceptable_nodes(), check if we have at least one bridge
+      or guard node, and two non-guard nodes for a circuit. Previously,
+      we have added up the sum of all nodes with a descriptor, but that
+      could cause us to build circuits that fail if we had either too
+      many bridges, or not enough guard nodes. Fixes bug 25885; bugfix
+      on 0.3.6.1-alpha. Patch by Neel Chauhan.

--- a/src/core/or/circuitbuild.h
+++ b/src/core/or/circuitbuild.h
@@ -84,7 +84,8 @@ void circuit_upgrade_circuits_from_guard_wait(void);
 STATIC circid_t get_unique_circ_id_by_chan(channel_t *chan);
 STATIC int new_route_len(uint8_t purpose, extend_info_t *exit_ei,
                          smartlist_t *nodes);
-MOCK_DECL(STATIC int, count_acceptable_nodes, (smartlist_t *nodes));
+MOCK_DECL(STATIC int, count_acceptable_nodes, (smartlist_t *nodes,
+                                               int direct));
 
 STATIC int onion_extend_cpath(origin_circuit_t *circ);
 

--- a/src/test/test_circuitbuild.c
+++ b/src/test/test_circuitbuild.c
@@ -21,11 +21,11 @@ static smartlist_t dummy_nodes;
 static extend_info_t dummy_ei;
 
 static int
-mock_count_acceptable_nodes(smartlist_t *nodes)
+mock_count_acceptable_nodes(smartlist_t *nodes, int direct)
 {
   (void)nodes;
 
-  return DEFAULT_ROUTE_LEN + 1;
+  return direct ? 1 : DEFAULT_ROUTE_LEN + 1;
 }
 
 /* Test route lengths when the caller of new_route_len() doesn't


### PR DESCRIPTION
For the bug [here](https://trac.torproject.org/projects/tor/ticket/25885).