### PR TITLE
[Tor Trac #15518]: Tor considers routers in the same IPv6 /16 to be "in the same subnet"

### DIFF
--- a/changes/bug15518
+++ b/changes/bug15518
@@ -1,0 +1,6 @@
+  o Minor bugfixes (ipv6):
+    - In addrs_in_same_network_family(), we choose the subnet size based
+      on the IP version (IPv4 or IPv6). Previously, we chose a fixed subnet
+      size of /16 for both IPv4 and IPv6 addresses. Fixes bug 15518; bugfix
+      on 0.3.5.1-alpha. Patch by Neel Chauhan.
+

--- a/changes/bug27081
+++ b/changes/bug27081
@@ -1,0 +1,4 @@
+  o Minor bugfixes (compilation, windows):
+    - Don't link or search for pthreads when building for Windows, even if we
+      are using build environment (like mingw) that provides a pthreads
+      library. Fixes bug 27081; bugfix on 0.1.0.1-rc.

--- a/configure.ac
+++ b/configure.ac
@@ -563,8 +563,10 @@ if test "$LIBS" != "$saved_LIBS"; then
    have_rt=yes
 fi
 
-AC_SEARCH_LIBS(pthread_create, [pthread])
-AC_SEARCH_LIBS(pthread_detach, [pthread])
+if test "$bwin32" = "false"; then
+  AC_SEARCH_LIBS(pthread_create, [pthread])
+  AC_SEARCH_LIBS(pthread_detach, [pthread])
+fi
 
 AM_CONDITIONAL(THREADS_WIN32, test "$bwin32" = "true")
 AM_CONDITIONAL(THREADS_PTHREADS, test "$bwin32" = "false")

--- a/src/feature/nodelist/nodelist.c
+++ b/src/feature/nodelist/nodelist.c
@@ -1792,7 +1792,15 @@ int
 addrs_in_same_network_family(const tor_addr_t *a1,
                              const tor_addr_t *a2)
 {
-  return 0 == tor_addr_compare_masked(a1, a2, 16, CMP_SEMANTIC);
+  switch (tor_addr_family(a1)) {
+    case AF_INET:
+      return 0 == tor_addr_compare_masked(a1, a2, 16, CMP_SEMANTIC);
+    case AF_INET6:
+      return 0 == tor_addr_compare_masked(a1, a2, 32, CMP_SEMANTIC);
+    default:
+      /* If not IPv4 or IPv6, return 0. */
+      return 0;
+  }
 }
 
 /** Return true if <b>node</b>'s nickname matches <b>nickname</b>

--- a/src/test/test_address.c
+++ b/src/test/test_address.c
@@ -24,6 +24,8 @@
 #endif /* defined(HAVE_IFCONF_TO_SMARTLIST) */
 
 #include "core/or/or.h"
+#include "feature/nodelist/nodelist.h"
+#include "lib/net/address.h"
 #include "lib/net/address.h"
 #include "test/test.h"
 #include "test/log_test_helpers.h"
@@ -1139,6 +1141,36 @@ test_address_tor_addr_eq_ipv4h(void *ignored)
   tor_free(a);
 }
 
+static void
+test_address_tor_addr_in_same_network_family(void *ignored)
+{
+  (void)ignored;
+  tor_addr_t a, b;
+
+  tor_addr_parse(&a, "8.8.8.8");
+  tor_addr_parse(&b, "8.8.4.4");
+  tt_int_op(addrs_in_same_network_family(&a, &b), OP_EQ, 1);
+
+  tor_addr_parse(&a, "8.8.8.8");
+  tor_addr_parse(&b, "1.1.1.1");
+  tt_int_op(addrs_in_same_network_family(&a, &b), OP_EQ, 0);
+
+  tor_addr_parse(&a, "8.8.8.8");
+  tor_addr_parse(&b, "2001:4860:4860::8844");
+  tt_int_op(addrs_in_same_network_family(&a, &b), OP_EQ, 0);
+
+  tor_addr_parse(&a, "2001:4860:4860::8888");
+  tor_addr_parse(&b, "2001:4860:4860::8844");
+  tt_int_op(addrs_in_same_network_family(&a, &b), OP_EQ, 1);
+
+  tor_addr_parse(&a, "2001:4860:4860::8888");
+  tor_addr_parse(&b, "2001:470:20::2");
+  tt_int_op(addrs_in_same_network_family(&a, &b), OP_EQ, 0);
+
+ done:
+  return;
+}
+
 #define ADDRESS_TEST(name, flags) \
   { #name, test_address_ ## name, flags, NULL, NULL }
 
@@ -1170,6 +1202,7 @@ struct testcase_t address_tests[] = {
   ADDRESS_TEST(tor_addr_to_ipv4n, 0),
   ADDRESS_TEST(tor_addr_to_mapped_ipv4h, 0),
   ADDRESS_TEST(tor_addr_eq_ipv4h, 0),
+  ADDRESS_TEST(tor_addr_in_same_network_family, 0),
   END_OF_TESTCASES
 };
 


### PR DESCRIPTION
For the bug [here](https://trac.torproject.org/projects/tor/ticket/15518).