### PR TITLE
Fix a bug warning when sending an error on an HTTPTunnelPort conn

### DIFF
--- a/changes/bug26470
+++ b/changes/bug26470
@@ -1,0 +1,4 @@
+  o Minor bugfixes (HTTP tunnel):
+    - Fix a bug warning when closing an HTTP tunnel connection due to
+      an HTTP request we couldn't handle. Fixes bug 26470; bugfix on
+      0.3.2.1-alpha.

--- a/src/or/connection_edge.c
+++ b/src/or/connection_edge.c
@@ -2537,8 +2537,11 @@ connection_ap_process_http_connect(entry_connection_t *conn)
  err:
   if (BUG(errmsg == NULL))
     errmsg = "HTTP/1.0 400 Bad Request\r\n\r\n";
-  log_warn(LD_EDGE, "Saying %s", escaped(errmsg));
+  log_info(LD_EDGE, "HTTP tunnel error: saying %s", escaped(errmsg));
   connection_buf_add(errmsg, strlen(errmsg), ENTRY_TO_CONN(conn));
+  /* Mark it as "has_finished" so that we don't try to send an extra socks
+   * reply. */
+  conn->socks_request->has_finished = 1;
   connection_mark_unattached_ap(conn,
                                 END_STREAM_REASON_HTTPPROTOCOL|
                                 END_STREAM_REASON_FLAG_ALREADY_SOCKS_REPLIED);
@@ -4162,4 +4165,3 @@ connection_edge_free_all(void)
   smartlist_free(pending_entry_connections);
   pending_entry_connections = NULL;
 }
-


### PR DESCRIPTION
Fixes bug 26470; bugfix on 0.3.2.1-alpha.