### PR TITLE
Unify the logic for detecting partial dir downloads

### DIFF
--- a/changes/bug27241
+++ b/changes/bug27241
@@ -1,0 +1,5 @@
+  o Minor features (directory client):
+    - When we close a directory connection for not having given us data
+      for a long time, try to use the partial response if we were fetching
+      microdescriptors or extrainfo documents. Previously we only did
+      this for server descriptors. Closes ticket 27241.

--- a/src/core/mainloop/main.c
+++ b/src/core/mainloop/main.c
@@ -1219,11 +1219,10 @@ run_connection_housekeeping(int i, time_t now)
     log_info(LD_DIR,"Expiring wedged directory conn (fd %d, purpose %d)",
              (int)conn->s, conn->purpose);
     /* This check is temporary; it's to let us know whether we should consider
-     * parsing partial serverdesc responses. */
-    if (conn->purpose == DIR_PURPOSE_FETCH_SERVERDESC &&
+     * parsing partial responses. */
+    if (dir_conn_purpose_allows_partial_response(conn->purpose) &&
         connection_get_inbuf_len(conn) >= 1024) {
-      log_info(LD_DIR,"Trying to extract information from wedged server desc "
-               "download.");
+      log_info(LD_DIR,"Trying to extract information from wedged download.");
       connection_dir_reached_eof(TO_DIR_CONN(conn));
     } else {
       connection_mark_for_close(conn);

--- a/src/feature/dircache/directory.h
+++ b/src/feature/dircache/directory.h
@@ -217,6 +217,7 @@ int download_status_get_n_attempts(const download_status_t *dls);
 
 int purpose_needs_anonymity(uint8_t dir_purpose, uint8_t router_purpose,
                             const char *resource);
+int dir_conn_purpose_allows_partial_response(int purpose);
 
 #ifdef DIRECTORY_PRIVATE
 


### PR DESCRIPTION
Previously, our directory.c code allowed partial downloads for lists
of microdescriptors, server descriptors, and extrainfo documents --
but the "wedged connection" logic in main.c only handled server
descriptors.

Closes ticket 27241.