### PR TITLE
[Tor Trac #27250]: Duplicate line '#include "lib/net/address.h' in src/test/test_address.c

### DIFF
--- a/src/test/test_address.c
+++ b/src/test/test_address.c
@@ -26,7 +26,6 @@
 #include "core/or/or.h"
 #include "feature/nodelist/nodelist.h"
 #include "lib/net/address.h"
-#include "lib/net/address.h"
 #include "test/test.h"
 #include "test/log_test_helpers.h"
 


### PR DESCRIPTION
For the bug report [here](https://trac.torproject.org/projects/tor/ticket/27250).