### PR TITLE
Bootstrap: check the exit policy and flag on descriptors

### DIFF
--- a/changes/bug27236
+++ b/changes/bug27236
@@ -1,0 +1,5 @@
+  o Minor bugfixes (testing, bootstrap):
+    - When calculating bootstrap progress, check exit policies and the exit
+      flag. Previously, Tor would only check the exit flag, which caused
+      race conditions in small and fast networks like chutney.
+      Fixes bug 27236; bugfix on 0.2.6.3-alpha.


### PR DESCRIPTION
Previously, Tor would only check the exit flag. In small networks, Tor
could bootstrap once it received a consensus with exits, without fetching
the new descriptors for those exits.

After bootstrap, Tor delays descriptor fetches, leading to failures in
fast networks like chutney.

Fixes 27236; bugfix on 0.2.6.3-alpha.