### PR TITLE
Update the protocol versions recommendations to remove LinkAuth=1

### DIFF
--- a/changes/27286
+++ b/changes/27286
@@ -1,0 +1,4 @@
+  o Minor features (directory authorities):
+    - Authorities no longer vote to make the subprotocol version "LinkAuth=1"
+      a requirement: it is unsupportable with NSS, and hasn't been needed
+      since Tor 0.3.0.1-alpha. Closes ticket 27286.

--- a/src/or/dirserv.c
+++ b/src/or/dirserv.c
@@ -3082,16 +3082,16 @@ dirserv_generate_networkstatus_vote_obj(crypto_pk_t *private_key,
   /* These are hardwired, to avoid disaster. */
   v3_out->recommended_relay_protocols =
     tor_strdup("Cons=1-2 Desc=1-2 DirCache=1 HSDir=1 HSIntro=3 HSRend=1 "
-               "Link=4 LinkAuth=1 Microdesc=1-2 Relay=2");
+               "Link=4 LinkAuth=3 Microdesc=1-2 Relay=2");
   v3_out->recommended_client_protocols =
     tor_strdup("Cons=1-2 Desc=1-2 DirCache=1 HSDir=1 HSIntro=3 HSRend=1 "
-               "Link=4 LinkAuth=1 Microdesc=1-2 Relay=2");
+               "Link=4 LinkAuth=3 Microdesc=1-2 Relay=2");
   v3_out->required_client_protocols =
     tor_strdup("Cons=1-2 Desc=1-2 DirCache=1 HSDir=1 HSIntro=3 HSRend=1 "
-               "Link=4 LinkAuth=1 Microdesc=1-2 Relay=2");
+               "Link=4 Microdesc=1-2 Relay=2");
   v3_out->required_relay_protocols =
     tor_strdup("Cons=1 Desc=1 DirCache=1 HSDir=1 HSIntro=3 HSRend=1 "
-               "Link=3-4 LinkAuth=1 Microdesc=1 Relay=1-2");
+               "Link=3-4 Microdesc=1 Relay=1-2");
 
   /* We are not allowed to vote to require anything we don't have. */
   tor_assert(protover_all_supported(v3_out->required_relay_protocols, NULL));


### PR DESCRIPTION
LinkAuth method 1 is the one where we pull the TLS master secrets
out of the OpenSSL data structures and authenticate them with
RSA. Right now we list method 1 as required for clients and relays.
That's a problem, since we can't reasonably support it with NSS. So
let's remove it as a requirement, and have only method 3 as a
recommendation.

Closes ticket 27286