### PR TITLE
router: Keep RSA onion public key in ASN.1 format

### DIFF
--- a/src/core/or/circuitbuild.c
+++ b/src/core/or/circuitbuild.c
@@ -2864,6 +2864,8 @@ extend_info_new(const char *nickname,
 extend_info_t *
 extend_info_from_node(const node_t *node, int for_direct_connect)
 {
+  crypto_pk_t *rsa_pubkey = NULL;
+  extend_info_t *info = NULL;
   tor_addr_port_t ap;
   int valid_addr = 0;
 
@@ -2911,25 +2913,28 @@ extend_info_from_node(const node_t *node, int for_direct_connect)
   /* Retrieve the curve25519 pubkey. */
   const curve25519_public_key_t *curve_pubkey =
     node_get_curve25519_onion_key(node);
+  rsa_pubkey = node_get_rsa_onion_key(node);
 
-  if (valid_addr && node->ri)
-    return extend_info_new(node->ri->nickname,
+  if (valid_addr && node->ri) {
+    info = extend_info_new(node->ri->nickname,
                            node->identity,
                            ed_pubkey,
-                           node->ri->onion_pkey,
+                           rsa_pubkey,
                            curve_pubkey,
                            &ap.addr,
                            ap.port);
-  else if (valid_addr && node->rs && node->md)
-    return extend_info_new(node->rs->nickname,
+  } else if (valid_addr && node->rs && node->md) {
+    info = extend_info_new(node->rs->nickname,
                            node->identity,
                            ed_pubkey,
-                           node->md->onion_pkey,
+                           rsa_pubkey,
                            curve_pubkey,
                            &ap.addr,
                            ap.port);
-  else
-    return NULL;
+  }
+
+  crypto_pk_free(rsa_pubkey);
+  return info;
 }
 
 /** Release storage held by an extend_info_t struct. */

--- a/src/feature/dirauth/dirvote.c
+++ b/src/feature/dirauth/dirvote.c
@@ -3754,8 +3754,9 @@ dirvote_create_microdescriptor(const routerinfo_t *ri, int consensus_method)
   size_t keylen;
   smartlist_t *chunks = smartlist_new();
   char *output = NULL;
+  crypto_pk_t *rsa_pubkey = routerinfo_get_rsa_onion_pkey(ri);
 
-  if (crypto_pk_write_public_key_to_string(ri->onion_pkey, &key, &keylen)<0)
+  if (crypto_pk_write_public_key_to_string(rsa_pubkey, &key, &keylen)<0)
     goto done;
   summary = policy_summarize(ri->exit_policy, AF_INET);
   if (ri->declared_family)
@@ -3826,6 +3827,7 @@ dirvote_create_microdescriptor(const routerinfo_t *ri, int consensus_method)
   }
 
  done:
+  crypto_pk_free(rsa_pubkey);
   tor_free(output);
   tor_free(key);
   tor_free(summary);

--- a/src/feature/nodelist/microdesc.h
+++ b/src/feature/nodelist/microdesc.h
@@ -56,5 +56,8 @@ void microdesc_note_outdated_dirserver(const char *relay_digest);
 int microdesc_relay_is_outdated_dirserver(const char *relay_digest);
 void microdesc_reset_outdated_dirservers_list(void);
 
+crypto_pk_t *microdesc_get_rsa_onion_pkey(const microdesc_t *md);
+void microdesc_set_rsa_onion_pkey(microdesc_t *md, const crypto_pk_t *pk);
+
 #endif /* !defined(TOR_MICRODESC_H) */
 

--- a/src/feature/nodelist/microdesc_st.h
+++ b/src/feature/nodelist/microdesc_st.h
@@ -53,8 +53,10 @@ struct microdesc_t {
 
   /* Fields in the microdescriptor. */
 
-  /** As routerinfo_t.onion_pkey */
-  crypto_pk_t *onion_pkey;
+  /* Public RSA key for onions in ASN.1 encoded. */
+  char *onion_pkey;
+  size_t onion_pkey_len;
+
   /** As routerinfo_t.onion_curve25519_pkey */
   struct curve25519_public_key_t *onion_curve25519_pkey;
   /** Ed25519 identity key, if included. */

--- a/src/feature/nodelist/nodelist.c
+++ b/src/feature/nodelist/nodelist.c
@@ -1761,6 +1761,32 @@ node_get_curve25519_onion_key(const node_t *node)
     return NULL;
 }
 
+/* Return a newly allocacted RSA onion public key taken from the given node.
+ *
+ * Return NULL if node is NULL or no RSA onion public key can be found. It is
+ * the caller responsability to free the returned object. */
+crypto_pk_t *
+node_get_rsa_onion_key(const node_t *node)
+{
+  crypto_pk_t *pk = NULL;
+
+  if (!node) {
+    goto end;
+  }
+
+  if (node->ri) {
+    pk = routerinfo_get_rsa_onion_pkey(node->ri);
+  } else if (node->rs && node->md) {
+    pk = microdesc_get_rsa_onion_pkey(node->md);
+  } else {
+    /* No descriptor or microdescriptor. */
+    goto end;
+  }
+
+ end:
+  return pk;
+}
+
 /** Refresh the country code of <b>ri</b>.  This function MUST be called on
  * each router when the GeoIP database is reloaded, and on all new routers. */
 void

--- a/src/feature/nodelist/nodelist.h
+++ b/src/feature/nodelist/nodelist.h
@@ -95,6 +95,7 @@ void node_get_pref_ipv6_dirport(const node_t *node, tor_addr_port_t *ap_out);
 int node_has_curve25519_onion_key(const node_t *node);
 const struct curve25519_public_key_t *node_get_curve25519_onion_key(
                                   const node_t *node);
+crypto_pk_t *node_get_rsa_onion_key(const node_t *node);
 
 MOCK_DECL(smartlist_t *, nodelist_get_list, (void));
 

--- a/src/feature/nodelist/routerinfo_st.h
+++ b/src/feature/nodelist/routerinfo_st.h
@@ -27,7 +27,10 @@ struct routerinfo_t {
   tor_addr_t ipv6_addr;
   uint16_t ipv6_orport;
 
-  crypto_pk_t *onion_pkey; /**< Public RSA key for onions. */
+  /* Public RSA key for onions in ASN.1 encoded. */
+  char *onion_pkey;
+  size_t onion_pkey_len;
+
   crypto_pk_t *identity_pkey;  /**< Public RSA key for signing. */
   /** Public curve25519 key for onions */
   struct curve25519_public_key_t *onion_curve25519_pkey;

--- a/src/feature/nodelist/routerlist.h
+++ b/src/feature/nodelist/routerlist.h
@@ -297,6 +297,8 @@ int routerinfo_incompatible_with_extrainfo(const crypto_pk_t *ri,
                                            signed_descriptor_t *sd,
                                            const char **msg);
 int routerinfo_has_curve25519_onion_key(const routerinfo_t *ri);
+crypto_pk_t *routerinfo_get_rsa_onion_pkey(const routerinfo_t *ri);
+void routerinfo_set_onion_pkey(routerinfo_t *ri, const crypto_pk_t *pk);
 int routerstatus_version_supports_extend2_cells(const routerstatus_t *rs,
                                                 int allow_unknown_versions);
 

--- a/src/feature/relay/router.c
+++ b/src/feature/relay/router.c
@@ -1464,6 +1464,8 @@ router_should_advertise_begindir(const or_options_t *options,
 static extend_info_t *
 extend_info_from_router(const routerinfo_t *r)
 {
+  crypto_pk_t *rsa_pubkey;
+  extend_info_t *info;
   tor_addr_port_t ap;
   tor_assert(r);
 
@@ -1477,10 +1479,13 @@ extend_info_from_router(const routerinfo_t *r)
     ed_id_key = NULL;
 
   router_get_prim_orport(r, &ap);
-  return extend_info_new(r->nickname, r->cache_info.identity_digest,
+  rsa_pubkey = routerinfo_get_rsa_onion_pkey(r);
+  info = extend_info_new(r->nickname, r->cache_info.identity_digest,
                          ed_id_key,
-                         r->onion_pkey, r->onion_curve25519_pkey,
+                         rsa_pubkey, r->onion_curve25519_pkey,
                          &ap.addr, ap.port);
+  crypto_pk_free(rsa_pubkey);
+  return info;
 }
 
 /**See if we currently believe our ORPort or DirPort to be
@@ -2313,8 +2318,8 @@ router_build_fresh_descriptor(routerinfo_t **r, extrainfo_t **e)
   ri->supports_tunnelled_dir_requests =
     directory_permits_begindir_requests(options);
   ri->cache_info.published_on = time(NULL);
-  ri->onion_pkey = crypto_pk_dup_key(get_onion_key()); /* must invoke from
-                                                        * main thread */
+  routerinfo_set_onion_pkey(ri, get_onion_key()); /* must invoke from
+                                                   * main thread */
   ri->onion_curve25519_pkey =
     tor_memdup(&get_current_curve25519_keypair()->pubkey,
                sizeof(curve25519_public_key_t));
@@ -2849,6 +2854,7 @@ router_dump_router_to_string(routerinfo_t *router,
 {
   char *address = NULL;
   char *onion_pkey = NULL; /* Onion key, PEM-encoded. */
+  crypto_pk_t *rsa_pubkey = NULL;
   char *identity_pkey = NULL; /* Identity key, PEM-encoded. */
   char digest[DIGEST256_LEN];
   char published[ISO_TIME_LEN+1];
@@ -2915,7 +2921,8 @@ router_dump_router_to_string(routerinfo_t *router,
   }
 
   /* PEM-encode the onion key */
-  if (crypto_pk_write_public_key_to_string(router->onion_pkey,
+  rsa_pubkey = routerinfo_get_rsa_onion_pkey(router);
+  if (crypto_pk_write_public_key_to_string(rsa_pubkey,
                                            &onion_pkey,&onion_pkeylen)<0) {
     log_warn(LD_BUG,"write onion_pkey to string failed!");
     goto err;
@@ -3200,6 +3207,7 @@ router_dump_router_to_string(routerinfo_t *router,
     SMARTLIST_FOREACH(chunks, char *, cp, tor_free(cp));
     smartlist_free(chunks);
   }
+  crypto_pk_free(rsa_pubkey);
   tor_free(address);
   tor_free(family_line);
   tor_free(onion_pkey);

--- a/src/test/test_dir.c
+++ b/src/test/test_dir.c
@@ -166,7 +166,7 @@ test_dir_formats(void *arg)
   r1->supports_tunnelled_dir_requests = 1;
   tor_addr_parse(&r1->ipv6_addr, "1:2:3:4::");
   r1->ipv6_orport = 9999;
-  r1->onion_pkey = crypto_pk_dup_key(pk1);
+  routerinfo_set_onion_pkey(r1, pk1);
   /* Fake just enough of an ntor key to get by */
   curve25519_keypair_t r1_onion_keypair;
   curve25519_keypair_generate(&r1_onion_keypair, 0);
@@ -209,7 +209,7 @@ test_dir_formats(void *arg)
   r2->or_port = 9005;
   r2->dir_port = 0;
   r2->supports_tunnelled_dir_requests = 1;
-  r2->onion_pkey = crypto_pk_dup_key(pk2);
+  routerinfo_set_onion_pkey(r2, pk2);
   curve25519_keypair_t r2_onion_keypair;
   curve25519_keypair_generate(&r2_onion_keypair, 0);
   r2->onion_curve25519_pkey = tor_memdup(&r2_onion_keypair.pubkey,
@@ -302,7 +302,9 @@ test_dir_formats(void *arg)
   tt_int_op(rp1->bandwidthrate,OP_EQ, r1->bandwidthrate);
   tt_int_op(rp1->bandwidthburst,OP_EQ, r1->bandwidthburst);
   tt_int_op(rp1->bandwidthcapacity,OP_EQ, r1->bandwidthcapacity);
-  tt_int_op(crypto_pk_cmp_keys(rp1->onion_pkey, pk1), OP_EQ, 0);
+  crypto_pk_t *onion_pkey = routerinfo_get_rsa_onion_pkey(rp1);
+  tt_int_op(crypto_pk_cmp_keys(onion_pkey, pk1), OP_EQ, 0);
+  crypto_pk_free(onion_pkey);
   tt_int_op(crypto_pk_cmp_keys(rp1->identity_pkey, pk2), OP_EQ, 0);
   tt_assert(rp1->supports_tunnelled_dir_requests);
   //tt_assert(rp1->exit_policy == NULL);
@@ -419,7 +421,9 @@ test_dir_formats(void *arg)
   tt_mem_op(rp2->onion_curve25519_pkey->public_key,OP_EQ,
              r2->onion_curve25519_pkey->public_key,
              CURVE25519_PUBKEY_LEN);
-  tt_int_op(crypto_pk_cmp_keys(rp2->onion_pkey, pk2), OP_EQ, 0);
+  onion_pkey = routerinfo_get_rsa_onion_pkey(rp2);
+  tt_int_op(crypto_pk_cmp_keys(onion_pkey, pk2), OP_EQ, 0);
+  crypto_pk_free(onion_pkey);
   tt_int_op(crypto_pk_cmp_keys(rp2->identity_pkey, pk1), OP_EQ, 0);
   tt_assert(rp2->supports_tunnelled_dir_requests);
 

--- a/src/test/test_hs_service.c
+++ b/src/test/test_hs_service.c
@@ -1238,7 +1238,7 @@ test_build_update_descriptors(void *arg)
     tt_int_op(ret, OP_EQ, 0);
     ri.onion_curve25519_pkey =
       tor_malloc_zero(sizeof(curve25519_public_key_t));
-    ri.onion_pkey = crypto_pk_new();
+    ri.onion_pkey = tor_malloc_zero(140);
     curve25519_public_key_generate(ri.onion_curve25519_pkey,
                                    &curve25519_secret_key);
     memset(ri.cache_info.identity_digest, 'A', DIGEST_LEN);
@@ -1264,7 +1264,7 @@ test_build_update_descriptors(void *arg)
   update_all_descriptors(now);
   tor_free(node->ri->onion_curve25519_pkey); /* Avoid memleak. */
   tor_free(node->ri->cache_info.signing_key_cert);
-  crypto_pk_free(node->ri->onion_pkey);
+  tor_free(node->ri->onion_pkey);
   expect_log_msg_containing("just picked 1 intro points and wanted 3 for next "
                             "descriptor. It currently has 0 intro points. "
                             "Launching ESTABLISH_INTRO circuit shortly.");

--- a/src/test/test_router.c
+++ b/src/test/test_router.c
@@ -49,7 +49,7 @@ NS(router_get_my_routerinfo)(void)
     mock_routerinfo->platform = tor_strdup("unittest");
     mock_routerinfo->cache_info.published_on = now;
     mock_routerinfo->identity_pkey = crypto_pk_dup_key(ident_key);
-    mock_routerinfo->onion_pkey = crypto_pk_dup_key(tap_key);
+    routerinfo_set_onion_pkey(mock_routerinfo, tap_key);
     mock_routerinfo->bandwidthrate = 9001;
     mock_routerinfo->bandwidthburst = 9002;
   }
@@ -89,11 +89,13 @@ test_router_dump_router_to_string_no_bridge_distribution_method(void *arg)
 
   /* Generate our server descriptor and ensure that the substring
    * "bridge-distribution-request any" occurs somewhere within it. */
+  crypto_pk_t *onion_pkey = routerinfo_get_rsa_onion_pkey(router);
   desc = router_dump_router_to_string(router,
                                       router->identity_pkey,
-                                      router->onion_pkey,
+                                      onion_pkey,
                                       &ntor_keypair,
                                       &signing_keypair);
+  crypto_pk_free(onion_pkey);
   tt_ptr_op(desc, !=, NULL);
   found = strstr(desc, needle);
   tt_ptr_op(found, !=, NULL);


### PR DESCRIPTION
The OpenSSL "RSA" object is currently 408 bytes compares to the ASN.1 encoding
which is 140 for a 1024 RSA key.

We save 268 bytes per descriptor (routerinfo_t) *and* microdescriptor
(microdesc_t). Scaling this to 6000 relays, and considering client usually
only have microdescriptors, we save 1.608 MB of RAM which is considerable for
mobile client.

This commit makes it that we keep the RSA onion public key (used for TAP
handshake) in ASN.1 format instead of an OpenSSL RSA object.

Changes is done in both routerinfo_t and microdesc_t.

Closes #27246

Signed-off-by: David Goulet <dgoulet@torproject.org>