### PR TITLE
[Tor Trac #26769]: We should make HSv3 desc upload less frequent 

### DIFF
--- a/changes/bug26769
+++ b/changes/bug26769
@@ -1,0 +1,6 @@
+  o Minor bugfixes (onion services):
+    - Make onion services upload descriptors at a random time between 2-3
+      hours. This helps reduce the load on our network when compare to the
+      previous range of 1-2 hours. Fixes bug 26769; bugfix on 0.3.5.1-alpha.
+      Patch by Neel Chauhan.
+

--- a/src/feature/hs/hs_service.h
+++ b/src/feature/hs/hs_service.h
@@ -28,8 +28,8 @@
 
 /* As described in the specification, service publishes their next descriptor
  * at a random time between those two values (in seconds). */
-#define HS_SERVICE_NEXT_UPLOAD_TIME_MIN (60 * 60)
-#define HS_SERVICE_NEXT_UPLOAD_TIME_MAX (120 * 60)
+#define HS_SERVICE_NEXT_UPLOAD_TIME_MIN (120 * 60)
+#define HS_SERVICE_NEXT_UPLOAD_TIME_MAX (180 * 60)
 
 /* Service side introduction point. */
 typedef struct hs_service_intro_point_t {


### PR DESCRIPTION
For the bug report [here](https://trac.torproject.org/projects/tor/ticket/26769).