### PR TITLE
#27618: Bugfix: sizeof(socklen) doesn't make sense when calling connect()

### DIFF
--- a/src/tools/tor-resolve.c
+++ b/src/tools/tor-resolve.c
@@ -224,7 +224,7 @@ do_resolve(const char *hostname,
   socklen = tor_addr_to_sockaddr(sockshost, socksport,
                                  (struct sockaddr *)&ss, sizeof(ss));
 
-  if (connect(s, (struct sockaddr*)&ss, sizeof(socklen))) {
+  if (connect(s, (struct sockaddr*)&ss, socklen)) {
     log_sock_error("connecting to SOCKS host", s);
     goto err;
   }


### PR DESCRIPTION
Bugfix on 2f657a1416f2f81dd1be900269c4ae9bdb29f52d; bug not in
any Tor release.

https://trac.torproject.org/projects/tor/ticket/27618#ticket