### PR TITLE
[Tor Trac #27490]: When ClientPreferIPv6ORPort is set to auto, and a relay is being chosen for a directory or orport connection, prefer IPv4 or IPv6 at random

### DIFF
--- a/changes/ticket27490
+++ b/changes/ticket27490
@@ -1,0 +1,6 @@
+  o Minor features (ipv6):
+    - If ClientPreferIPv6ORPort is set to auto and a relay is being chosen
+      for a Directory or ORPort connection, we choose IPv4 or IPv6 at random.
+      Previously, we preferred to IPv4 if ClientPreferIPv6ORPort is auto
+      except when an IPv6 bridge was specified. Closes ticket 27490. Patch
+      by Neel Chauhan.


### PR DESCRIPTION
For the ticket [here](https://trac.torproject.org/projects/tor/ticket/27490).