### PR TITLE
Check waitpid return value and exit status in tinytest.c

### DIFF
--- a/changes/bug27658
+++ b/changes/bug27658
@@ -1,0 +1,6 @@
+  o Minor bugfixes (testing):
+    - If a unit test running in a subprocess exits abnormally or with a
+      nonzero status code, treat the test as having failed, even if
+      the test reported success. Without this fix, memory leaks don't cause
+      cause the tests to fail, even with LeakSanitizer. Fixes bug 27658;
+      bugfix on 0.2.2.4-alpha.

--- a/src/ext/tinytest.c
+++ b/src/ext/tinytest.c
@@ -207,12 +207,20 @@ testcase_run_forked_(const struct testgroup_t *group,
 		r = (int)read(outcome_pipe[0], b, 1);
 		if (r == 0) {
 			printf("[Lost connection!] ");
-			return 0;
+			return FAIL;
 		} else if (r != 1) {
 			perror("read outcome from pipe");
 		}
-		waitpid(pid, &status, 0);
+		r = waitpid(pid, &status, 0);
 		close(outcome_pipe[0]);
+		if (r == -1) {
+			perror("waitpid");
+			return FAIL;
+		}
+                if (! WIFEXITED(status) || WEXITSTATUS(status) != 0) {
+			printf("[did not exit cleanly.]");
+			return FAIL;
+                }
 		return b[0]=='Y' ? OK : (b[0]=='S' ? SKIP : FAIL);
 	}
 #endif


### PR DESCRIPTION
It's possible for a unit test to report success via its pipe, but to
fail as it tries to clean up and exit.  Notably, this happens on a
leak sanitizer failure.

Fixes bug 27658; bugfix on 0.2.2.4-alpha when tinytest was
introduced.