### PR TITLE
Run crypto_prefork() before start_daemon().

### DIFF
--- a/src/app/config/config.c
+++ b/src/app/config/config.c
@@ -1417,6 +1417,8 @@ options_act_reversible(const or_options_t *old_options, char **msg)
    * the subprocess.  Libevent bases can't be reliably inherited across
    * processes. */
   if (running_tor && options->RunAsDaemon) {
+    if (! start_daemon_has_been_called())
+      crypto_prefork();
     /* No need to roll back, since you can't change the value. */
     if (start_daemon())
       crypto_postfork();

--- a/src/lib/process/daemon.c
+++ b/src/lib/process/daemon.c
@@ -38,6 +38,16 @@ static int finish_daemon_called = 0;
 /** Socketpair used to communicate between parent and child process while
  * daemonizing. */
 static int daemon_filedes[2];
+
+/**
+ * Return true iff we've called start_daemon() at least once.
+ */
+bool
+start_daemon_has_been_called(void)
+{
+  return start_daemon_called != 0;
+}
+
 /** Start putting the process into daemon mode: fork and drop all resources
  * except standard fds.  The parent process never returns, but stays around
  * until finish_daemon is called.  (Note: it's safe to call this more

--- a/src/lib/process/daemon.h
+++ b/src/lib/process/daemon.h
@@ -11,7 +11,11 @@
 #ifndef TOR_DAEMON_H
 #define TOR_DAEMON_H
 
+#include <stdbool.h>
+
 int start_daemon(void);
 int finish_daemon(const char *desired_cwd);
+
+bool start_daemon_has_been_called(void);
 
 #endif


### PR DESCRIPTION
Without this, RunAsDaemon breaks NSS.

Fixes bug 27664; bug not in any released Tor.