### PR TITLE
If options_act() fails, restore the previous value of global_options

### DIFF
--- a/changes/bug27708
+++ b/changes/bug27708
@@ -1,0 +1,4 @@
+  o Major bugfixes (restart-in-process):
+    - Fix a use-after-free error that could be caused by passing Tor an
+      impossible set of options that would fail during options_act().
+      Fixes bug 27708; bugfix on 0.3.3.1-alpha.

--- a/src/or/config.c
+++ b/src/or/config.c
@@ -868,6 +868,7 @@ set_options(or_options_t *new_val, char **msg)
               "Acting on config options left us in a broken state. Dying.");
       tor_shutdown_event_loop_and_exit(1);
     }
+    global_options = old_options;
     return -1;
   }
   /* Issues a CONF_CHANGED event to notify controller of the change. If Tor is


### PR DESCRIPTION
Before 0.3.3.1-alpha, we would exit() in this case immediately.  But
now that we leave tor_main() more conventionally, we need to make
sure we restore things so as not to cause a double free.

Fixes bug 27708; bugfix on 0.3.3.1-alpha.