### PR TITLE
Revise our assertion and bug macros to work with -Wparentheses

### DIFF
--- a/changes/bug27709
+++ b/changes/bug27709
@@ -1,0 +1,4 @@
+  o Minor bugfixes (code safety):
+    - Rewrite our assertion macros so that they no longer suppress
+      the compiler's -Wparentheses warnings on their inputs. Fixes bug 27709;
+      bugfix on 0.0.6.

--- a/src/common/util_bug.h
+++ b/src/common/util_bug.h
@@ -38,6 +38,10 @@
  * and then passed right to a conditional.  If you do anything else to the
  * expression here, or introduce any more parentheses, the compiler won't
  * help you.
+ *
+ * We only do this for the unit-test build case because it interferes with
+ * the likely-branch labeling.  Note below that in the other case, we define
+ * these macros to just be synonyms for PREDICT_(UN)LIKELY.
  */
 #define ASSERT_PREDICT_UNLIKELY_(e)             \
   ({                                            \


### PR DESCRIPTION
On GCC and Clang, there's a feature to warn you about bad
conditionals like "if (a = b)", which should be "if (a == b)".
However, they don't warn you if there are extra parentheses around
"a = b".

Unfortunately, the tor_assert() macro and all of its kin have been
passing their inputs through stuff like PREDICT_UNLIKELY(expr) or
PREDICT_UNLIKELY(!(expr)), both of which expand to stuff with more
parentheses around "expr", thus suppressing these warnings.

To fix this, this patch introduces new macros that do not wrap
expr.  They're only used when GCC or Clang is enabled (both define
__GNUC__), since they require GCC's "({statement expression})"
syntax extension.  They're only used when we're building the
unit-test variant of the object files, since they suppress the
branch-prediction hints.

I've confirmed that tor_assert(), tor_assert_nonfatal(),
tor_assert_nonfatal_once(), BUG(), and IF_BUG_ONCE() all now give
compiler warnings when their argument is an assignment expression.

Fixes bug 27709.

Bugfix on 0.0.6, where we first introduced the "tor_assert()" macro.