### PR TITLE
Make CacheDirectoryGroupReadable an autobool.

### DIFF
--- a/changes/ticket26913
+++ b/changes/ticket26913
@@ -1,0 +1,7 @@
+  o Minor bugfixes (directory permissions):
+    - When a user requests a group-readable DataDirectory, give it to
+      them. Previously, when the DataDirectory and the CacheDirectory
+      were the same, the default setting (0) for
+      CacheDirectoryGroupReadable would always override the setting for
+      DataDirectoryGroupReadable. Fixes bug 26913; bugfix on
+      0.3.3.1-alpha.

--- a/doc/tor.1.txt
+++ b/doc/tor.1.txt
@@ -423,10 +423,12 @@ GENERAL OPTIONS
     running.
     (Default: uses the value of DataDirectory.)
 
-[[CacheDirectoryGroupReadable]] **CacheDirectoryGroupReadable** **0**|**1**::
+[[CacheDirectoryGroupReadable]] **CacheDirectoryGroupReadable** **0**|**1**|**auto**::
     If this option is set to 0, don't allow the filesystem group to read the
     CacheDirectory. If the option is set to 1, make the CacheDirectory readable
-    by the default GID. (Default: 0)
+    by the default GID. If the option is "auto", then we use the
+    setting for DataDirectoryGroupReadable when the CacheDirectory is the
+    same as the DataDirectory, and 0 otherwise. (Default: auto)
 
 [[FallbackDir]] **FallbackDir** __ipv4address__:__port__ orport=__port__ id=__fingerprint__ [weight=__num__] [ipv6=**[**__ipv6address__**]**:__orport__]::
     When we're unable to connect to any directory cache for directory info

--- a/src/or/config.c
+++ b/src/or/config.c
@@ -259,7 +259,7 @@ static config_var_t option_vars_[] = {
   V(BridgeRelay,                 BOOL,     "0"),
   V(BridgeDistribution,          STRING,   NULL),
   VAR("CacheDirectory",          FILENAME, CacheDirectory_option, NULL),
-  V(CacheDirectoryGroupReadable, BOOL,     "0"),
+  V(CacheDirectoryGroupReadable, AUTOBOOL,     "auto"),
   V(CellStatistics,              BOOL,     "0"),
   V(PaddingStatistics,           BOOL,     "1"),
   V(LearnCircuitBuildTimeout,    BOOL,     "1"),
@@ -1516,9 +1516,26 @@ options_act_reversible(const or_options_t *old_options, char **msg)
                                       msg) < 0) {
     goto done;
   }
+
+  /* We need to handle the group-readable flag for the cache directory
+   * specially, since the directory defaults to being the same as the
+   * DataDirectory. */
+  int cache_dir_group_readable;
+  if (options->CacheDirectoryGroupReadable != -1) {
+    /* If the user specified a value, use their setting */
+    cache_dir_group_readable = options->CacheDirectoryGroupReadable;
+  } else if (!strcmp(options->CacheDirectory, options->DataDirectory)) {
+    /* If the user left the value as "auto", and the cache is the same as the
+     * datadirectory, use the datadirectory setting.
+     */
+    cache_dir_group_readable = options->DataDirectoryGroupReadable;
+  } else {
+    /* Otherwise, "auto" means "not group readable". */
+    cache_dir_group_readable = 0;
+  }
   if (check_and_create_data_directory(running_tor /* create */,
                                       options->CacheDirectory,
-                                      options->CacheDirectoryGroupReadable,
+                                      cache_dir_group_readable,
                                       options->User,
                                       msg) < 0) {
     goto done;


### PR DESCRIPTION
Since the default cache directory is the same as the default data
directory, we don't want the default CacheDirectoryGroupReadable
value (0) to override an explicitly set "DataDirectoryGroupReadable
1".

To fix this, I'm making CacheDirectoryGroupReadable into an
autobool, and having the default (auto) value mean "Use the value of
DataDirectoryGroupReadable if the directories are the same, and 0
otherwise."

Fixes bug 26913; bugfix on 0.3.3.1-alpha when the CacheDirectory
option was introduced.