### PR TITLE
Remove extraneous argument from Rust protover_compute_vote()

### DIFF
--- a/changes/bug27741
+++ b/changes/bug27741
@@ -1,0 +1,5 @@
+  o Minor bugfixes (rust, directory authority):
+    - Fix an API mismatch in the rust implementation of
+      protover_compute_vote(). This bug could have caused crashes on any
+      directory authorities running Tor with Rust (which we do not yet
+      recommend). Fixes bug 27741; bugfix on 0.3.3.6.

--- a/src/rust/protover/ffi.rs
+++ b/src/rust/protover/ffi.rs
@@ -207,8 +207,7 @@ pub extern "C" fn protover_get_supported_protocols() -> *const c_char {
 #[no_mangle]
 pub extern "C" fn protover_compute_vote(
     list: *const Stringlist,
-    threshold: c_int,
-    allow_long_proto_names: bool,
+    threshold: c_int
 ) -> *mut c_char {
 
     if list.is_null() {
@@ -223,13 +222,9 @@ pub extern "C" fn protover_compute_vote(
     let mut proto_entries: Vec<UnvalidatedProtoEntry> = Vec::new();
 
     for datum in data {
-        let entry: UnvalidatedProtoEntry = match allow_long_proto_names {
-            true => match UnvalidatedProtoEntry::from_str_any_len(datum.as_str()) {
-                Ok(n)  => n,
-                Err(_) => continue},
-            false => match datum.parse() {
-                Ok(n)  => n,
-                Err(_) => continue},
+        let entry: UnvalidatedProtoEntry = match datum.parse() {
+            Ok(n)  => n,
+            Err(_) => continue
         };
         proto_entries.push(entry);
     }


### PR DESCRIPTION
This argument was added to match an older idea for the C api, but we
decided not to do it that way in C.

Fixes bug 27741; bugfix on 0.3.3.6 / TROVE-2018-005 fix.