### PR TITLE
Make crypto_strongest_rand() non-mockable

### DIFF
--- a/changes/bug27728
+++ b/changes/bug27728
@@ -1,0 +1,7 @@
+  o Minor bugfixes (compilation):
+    - Compile the ed25519-donna code with a correct declaration of
+      crypto_strongest_rand(). Previously, we build it with one type,
+      but link it against another in the unit tests, which caused
+      compilation failures with LTO enabled, and which could have
+      caused other undefined behavior in the tests. Fixes bug 27728;
+      bugfix on 0.3.5.1-alpha.

--- a/src/lib/crypt_ops/crypto_rand.c
+++ b/src/lib/crypt_ops/crypto_rand.c
@@ -335,8 +335,18 @@ crypto_strongest_rand_raw(uint8_t *out, size_t out_len)
  * Try to get <b>out_len</b> bytes of the strongest entropy we can generate,
  * storing it into <b>out</b>.
  **/
+void
+crypto_strongest_rand(uint8_t *out, size_t out_len)
+{
+  crypto_strongest_rand_(out, out_len);
+}
+
+/**
+ * Try to get <b>out_len</b> bytes of the strongest entropy we can generate,
+ * storing it into <b>out</b>. (Mockable version.)
+ **/
 MOCK_IMPL(void,
-crypto_strongest_rand,(uint8_t *out, size_t out_len))
+crypto_strongest_rand_,(uint8_t *out, size_t out_len))
 {
 #define DLEN DIGEST512_LEN
 

--- a/src/lib/crypt_ops/crypto_rand.h
+++ b/src/lib/crypt_ops/crypto_rand.h
@@ -21,7 +21,8 @@
 int crypto_seed_rng(void) ATTR_WUR;
 MOCK_DECL(void,crypto_rand,(char *to, size_t n));
 void crypto_rand_unmocked(char *to, size_t n);
-MOCK_DECL(void,crypto_strongest_rand,(uint8_t *out, size_t out_len));
+void crypto_strongest_rand(uint8_t *out, size_t out_len);
+MOCK_DECL(void,crypto_strongest_rand_,(uint8_t *out, size_t out_len));
 int crypto_rand_int(unsigned int max);
 int crypto_rand_int_range(unsigned int min, unsigned int max);
 uint64_t crypto_rand_uint64_range(uint64_t min, uint64_t max);

--- a/src/test/test_hs_descriptor.c
+++ b/src/test/test_hs_descriptor.c
@@ -909,7 +909,7 @@ test_build_authorized_client(void *arg)
                 client_pubkey_b16,
                 strlen(client_pubkey_b16));
 
-  MOCK(crypto_strongest_rand, mock_crypto_strongest_rand);
+  MOCK(crypto_strongest_rand_, mock_crypto_strongest_rand);
 
   hs_desc_build_authorized_client(subcredential,
                                   &client_auth_pk, &auth_ephemeral_sk,
@@ -925,7 +925,7 @@ test_build_authorized_client(void *arg)
  done:
   tor_free(desc_client);
   tor_free(mem_op_hex_tmp);
-  UNMOCK(crypto_strongest_rand);
+  UNMOCK(crypto_strongest_rand_);
 }
 
 struct testcase_t hs_descriptor[] = {


### PR DESCRIPTION
Instead, have it call a mockable function.  We don't want
crypto_strongest_rand() to be mockable, since doing so creates a
type error when we call it from ed25519-donna, which we do not build
in a test mode.

Fixes bug 27728; bugfix on 0.3.5.1-alpha