### PR TITLE
hs-v3: Don't assert if we don't have the intro point descriptor

### DIFF
--- a/changes/ticket27774
+++ b/changes/ticket27774
@@ -1,0 +1,4 @@
+  o Minor bugfixes (hidden service v3):
+    - Client side would dump a stack trace if tor doesn't have the descriptor
+      for the intro point it is trying to connect to. Fixes bug 27774; bugfix
+      on 0.3.2.1-alpha.

--- a/src/feature/hs/hs_client.c
+++ b/src/feature/hs/hs_client.c
@@ -576,10 +576,17 @@ send_introduce1(origin_circuit_t *intro_circ,
   /* Send the INTRODUCE1 cell. */
   if (hs_circ_send_introduce1(intro_circ, rend_circ, ip,
                               desc->subcredential) < 0) {
-    /* Unable to send the cell, the intro circuit has been marked for close so
-     * this is a permanent error. */
+    /* We were unable to send the cell for some reasons. In every case, the
+     * intro circuit has to be closed by the above function. We'll return a
+     * transient error so tor can recover and pick a new intro point. To avoid
+     * picking that same intro point, we'll note down the intro point failure
+     * so it doesn't get reused. */
+    hs_cache_client_intro_state_note(service_identity_pk,
+                                     &intro_circ->hs_ident->intro_auth_pk,
+                                     INTRO_POINT_FAILURE_UNREACHABLE);
+    /* Intro circuit must be closed else we have a code flow issue. */
     tor_assert_nonfatal(TO_CIRCUIT(intro_circ)->marked_for_close);
-    goto perm_err;
+    goto tran_err;
   }
 
   /* Cell has been sent successfully. Copy the introduction point


### PR DESCRIPTION
When sending the INTRODUCE1 cell, we lookup the intro point onion key but
there is a possibility that between opening the circuit and sending the cell
the relay descriptor of the node could have been removed leading to not
finding the onion key and a non fatal assert client side which also closes the
SOCKS connection without trying anything else.

We now look for that missing onion key and recover gracefully by closing the
intro point circuit, noting down the error in the failure cache and tor then
tries a new intro point.

Note that the send introduce1 function now makes sure to close the intro
circuit in case of an error because the caller is expecting it by validating
it with a non fatal assert. It is especially important so we can recover and
select a new intro point.

Fixes #27774

Signed-off-by: David Goulet <dgoulet@torproject.org>