### PR TITLE
node: Make node_supports_v3_rendezvous_point() also check for the key

### DIFF
--- a/changes/ticket27797
+++ b/changes/ticket27797
@@ -1,0 +1,5 @@
+  o Minor bugfixes (node, hidden service v3):
+    - When selecting a v3 rendezvous point, not only look at the protover but
+      also if the curve25519 onion key is present. That way we avoid picking a
+      node that supports the v3 rendezvous but for which we don't have the
+      descriptor yet for the key. Fixes bug 27797; bugfix on 0.3.2.1-alpha.

--- a/src/feature/nodelist/nodelist.c
+++ b/src/feature/nodelist/nodelist.c
@@ -1141,6 +1141,11 @@ node_supports_v3_rendezvous_point(const node_t *node)
 {
   tor_assert(node);
 
+  /* We can't use a v3 rendezvous point without the curve25519 onion pk. */
+  if (!node_get_curve25519_onion_key(node)) {
+    return 0;
+  }
+
   return node_get_protover_summary_flags(node)->supports_v3_rendezvous_point;
 }
 


### PR DESCRIPTION
It is not enough to look at protover for v3 rendezvous support but also we
need to make sure that the curve25519 onion key is present or in other words
that the descriptor has been fetched and does contain it.

Fixes #27797.

Signed-off-by: David Goulet <dgoulet@torproject.org>