### PR TITLE
hs-v3: Silence some logging for client authorization

### DIFF
--- a/src/feature/dircache/directory.c
+++ b/src/feature/dircache/directory.c
@@ -3124,7 +3124,7 @@ handle_response_fetch_hsdesc_v3(dir_connection_t *conn,
   case 200:
     /* We got something: Try storing it in the cache. */
     if (hs_cache_store_as_client(body, &conn->hs_ident->identity_pk) < 0) {
-      log_warn(LD_REND, "Failed to store hidden service descriptor");
+      log_info(LD_REND, "Failed to store hidden service descriptor");
       /* Fire control port FAILED event. */
       hs_control_desc_event_failed(conn->hs_ident, conn->identity_digest,
                                    "BAD_DESC");

--- a/src/feature/hs/hs_client.c
+++ b/src/feature/hs/hs_client.c
@@ -1258,10 +1258,6 @@ hs_client_decode_descriptor(const char *desc_str,
                                   client_auht_sk, desc);
   memwipe(subcredential, 0, sizeof(subcredential));
   if (ret < 0) {
-    log_warn(LD_GENERAL, "Could not parse received descriptor as client.");
-    if (get_options()->SafeLogging_ == SAFELOG_SCRUB_NONE) {
-      log_warn(LD_GENERAL, "%s", escaped(desc_str));
-    }
     goto err;
   }
 


### PR DESCRIPTION
If a tor client gets a descriptor that it can't decrypt, chances are that the
onion requires client authorization.

If a tor client is configured with client authorization for an onion but
decryption fails, it means that the configured keys aren't working anymore.

In both cases, we'll log notice the former and log warn the latter and the
rest of the decryption errors are now at info level.

Two logs statement have been removed because it was redundant and printing the
fetched descriptor in the logs when 80% of it is encrypted wat not helping.

Fixes #27550

Signed-off-by: David Goulet <dgoulet@torproject.org>