### PR TITLE
Fix a memory leak in --dump-config

### DIFF
--- a/changes/bug27893
+++ b/changes/bug27893
@@ -1,0 +1,3 @@
+  o Minor bugfixes (memory leaks):
+    - Fix a small memory leak when calling Tor with --dump-config.
+      Fixes bug 27893; bugfix on 0.3.2.1-alpha.

--- a/src/app/config/config.c
+++ b/src/app/config/config.c
@@ -824,6 +824,7 @@ static void config_maybe_load_geoip_files_(const or_options_t *options,
 static int options_validate_cb(void *old_options, void *options,
                                void *default_options,
                                int from_setconf, char **msg);
+static void options_free_cb(void *options);
 static void cleanup_protocol_warning_severity_level(void);
 static void set_protocol_warning_severity_level(int warning_severity);
 
@@ -839,6 +840,7 @@ STATIC config_format_t options_format = {
   option_deprecation_notes_,
   option_vars_,
   options_validate_cb,
+  options_free_cb,
   NULL
 };
 
@@ -3147,6 +3149,13 @@ options_validate_cb(void *old_options, void *options, void *default_options,
                           from_setconf, msg);
   in_option_validation = 0;
   return rv;
+}
+
+/** Callback to free an or_options_t */
+static void
+options_free_cb(void *options)
+{
+  or_options_free_(options);
 }
 
 #define REJECT(arg) \

--- a/src/app/config/confparse.c
+++ b/src/app/config/confparse.c
@@ -1009,8 +1009,9 @@ config_dump(const config_format_t *fmt, const void *default_options,
   result = smartlist_join_strings(elements, "", 0, NULL);
   SMARTLIST_FOREACH(elements, char *, cp, tor_free(cp));
   smartlist_free(elements);
-  if (defaults_tmp)
-    config_free(fmt, defaults_tmp);
+  if (defaults_tmp) {
+    fmt->free_fn(defaults_tmp);
+  }
   return result;
 }
 

--- a/src/app/config/confparse.h
+++ b/src/app/config/confparse.h
@@ -155,6 +155,9 @@ typedef struct config_var_t {
  * of arguments. */
 typedef int (*validate_fn_t)(void*,void*,void*,int,char**);
 
+/** Callback to free a configuration object. */
+typedef void (*free_cfg_fn_t)(void*);
+
 /** Information on the keys, value types, key-to-struct-member mappings,
  * variable descriptions, validation functions, and abbreviations for a
  * configuration or storage format. */
@@ -169,6 +172,7 @@ typedef struct config_format_t {
   config_var_t *vars; /**< List of variables we recognize, their default
                        * values, and where we stick them in the structure. */
   validate_fn_t validate_fn; /**< Function to validate config. */
+  free_cfg_fn_t free_fn; /**< Function to free the configuration. */
   /** If present, extra is a LINELIST variable for unrecognized
    * lines.  Otherwise, unrecognized lines are an error. */
   config_var_t *extra;

--- a/src/app/config/statefile.c
+++ b/src/app/config/statefile.c
@@ -143,6 +143,8 @@ static int or_state_validate_cb(void *old_options, void *options,
                                 void *default_options,
                                 int from_setconf, char **msg);
 
+static void or_state_free_cb(void *state);
+
 /** Magic value for or_state_t. */
 #define OR_STATE_MAGIC 0x57A73f57
 
@@ -162,6 +164,7 @@ static const config_format_t state_format = {
   NULL,
   state_vars_,
   or_state_validate_cb,
+  or_state_free_cb,
   &state_extra_var,
 };
 
@@ -257,6 +260,12 @@ or_state_validate_cb(void *old_state, void *state, void *default_state,
   (void) old_state;
 
   return or_state_validate(state, msg);
+}
+
+static void
+or_state_free_cb(void *state)
+{
+  or_state_free_(state);
 }
 
 /** Return 0 if every setting in <b>state</b> is reasonable, and a

--- a/src/feature/dirauth/shared_random_state.c
+++ b/src/feature/dirauth/shared_random_state.c
@@ -63,6 +63,7 @@ DUMMY_TYPECHECK_INSTANCE(sr_disk_state_t);
 static int
 disk_state_validate_cb(void *old_state, void *state, void *default_state,
                        int from_setconf, char **msg);
+static void disk_state_free_cb(void *);
 
 /* Array of variables that are saved to disk as a persistent state. */
 static config_var_t state_vars[] = {
@@ -96,6 +97,7 @@ static const config_format_t state_format = {
   NULL,
   state_vars,
   disk_state_validate_cb,
+  disk_state_free_cb,
   &state_extra_var,
 };
 
@@ -340,6 +342,12 @@ disk_state_validate_cb(void *old_state, void *state, void *default_state,
   (void) state;
   (void) msg;
   return 0;
+}
+
+static void
+disk_state_free_cb(void *state)
+{
+  disk_state_free_(state);
 }
 
 /* Parse the Commit line(s) in the disk state and translate them to the


### PR DESCRIPTION
When freeing a configuration object from confparse.c in
dump_config(), we need to call the appropriate higher-level free
function (like or_options_free()) and not just config_free().

This only happens with options (since they're the one where
options_validate allocates extra stuff) and only when running
--dump-config with something other than minimal (since
OPTIONS_DUMP_MINIMAL doesn't hit this code).

Fixes bug 27893; bugfix on 0.3.2.1-alpha.