### PR TITLE
Always initialize the periodic events list.

### DIFF
--- a/changes/bug27861
+++ b/changes/bug27861
@@ -1,0 +1,4 @@
+  o Major bugfixes (initialization, crash):
+    - Fix an assertion crash that would stop Tor from starting up if
+      the code tried to activate a periodic event too early. Fixes bug
+      27861; bugfix on 0.3.5.1-alpha.

--- a/src/core/mainloop/mainloop.c
+++ b/src/core/mainloop/mainloop.c
@@ -1535,7 +1535,9 @@ initialize_periodic_events_cb(evutil_socket_t fd, short events, void *data)
 STATIC void
 initialize_periodic_events(void)
 {
-  tor_assert(periodic_events_initialized == 0);
+  if (periodic_events_initialized)
+    return;
+
   periodic_events_initialized = 1;
 
   /* Set up all periodic events. We'll launch them by roles. */
@@ -2682,6 +2684,8 @@ dns_servers_relaunch_checks(void)
 void
 initialize_mainloop_events(void)
 {
+  initialize_periodic_events();
+
   if (!schedule_active_linked_connections_event) {
     schedule_active_linked_connections_event =
       mainloop_event_postloop_new(schedule_active_linked_connections_cb, NULL);
@@ -2699,10 +2703,7 @@ do_main_loop(void)
   /* initialize the periodic events first, so that code that depends on the
    * events being present does not assert.
    */
-  if (! periodic_events_initialized) {
-    initialize_periodic_events();
-  }
-
+  initialize_periodic_events();
   initialize_mainloop_events();
 
   /* set up once-a-second callback. */

--- a/src/test/test_periodic_event.c
+++ b/src/test/test_periodic_event.c
@@ -87,15 +87,19 @@ test_pe_launch(void *arg)
     item->fn = dumb_event_fn;
   }
 
-  /* Lets make sure that before intialization, we can't scan the periodic
-   * events list and launch them. Lets try by being a Client. */
   options = get_options_mutable();
   options->SocksPort_set = 1;
   periodic_events_on_new_options(options);
+#if 0
+  /* Lets make sure that before intialization, we can't scan the periodic
+   * events list and launch them. Lets try by being a Client. */
+  /* XXXX We make sure these events are initialized now way earlier than we
+   * did before. */
   for (int i = 0; periodic_events[i].name; ++i) {
     periodic_event_item_t *item = &periodic_events[i];
     tt_int_op(periodic_event_is_enabled(item), OP_EQ, 0);
   }
+#endif
 
   initialize_periodic_events();
 


### PR DESCRIPTION
Various places in our code try to activate these events or check
their status, so we should make sure they're initialized as early as
possible.  Fixes bug 27861; bugfix on 0.3.5.1-alpha.