### PR TITLE
Prevent duplicate initialization of NSS DH module

### DIFF
--- a/src/lib/crypt_ops/crypto_dh_nss.c
+++ b/src/lib/crypt_ops/crypto_dh_nss.c
@@ -53,6 +53,8 @@ crypto_dh_init_nss(void)
   circuit_dh_param.prime.len = DH1024_KEY_LEN;
   circuit_dh_param.base.data = dh_generator_data;
   circuit_dh_param.base.len = 1;
+
+  dh_initialized = 1;
 }
 
 void


### PR DESCRIPTION
Allowing this didn't do any actual harm, since there aren't any
shared structures or leakable objects here.  Still, it's bad style
and might cause trouble in the future.

Closes ticket 27856.