### PR TITLE
Add timeval.h include to compat_pthreads.c for timeradd()

### DIFF
--- a/changes/bug27963_timeradd
+++ b/changes/bug27963_timeradd
@@ -1,0 +1,4 @@
+  o Minor bugfixes (compilation, opensolaris):
+    - Add a missing include to compat_pthreads.c, to fix compilation
+      on OpenSolaris and its descendants. Fixes bug 27963; bugfix
+      on 0.3.5.1-alpha.

--- a/src/lib/thread/.may_include
+++ b/src/lib/thread/.may_include
@@ -4,3 +4,4 @@ lib/lock/*.h
 lib/log/*.h
 lib/testsupport/*.h
 lib/thread/*.h
+lib/wallclock/*.h

--- a/src/lib/thread/compat_pthreads.c
+++ b/src/lib/thread/compat_pthreads.c
@@ -12,6 +12,7 @@
 
 #include "orconfig.h"
 #include "lib/thread/threads.h"
+#include "lib/wallclock/timeval.h"
 #include "lib/log/log.h"
 #include "lib/log/util_bug.h"
 


### PR DESCRIPTION
OpenSolaris apparently doesn't have timeradd(), so we added a
replacement, but we weren't including it here after the big
refactoring in 0.3.5.1-alpha.

Fixes bug 27963; bugfix on 0.3.5.1-alpha.