### PR TITLE
report origin of mystery core file

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -210,6 +210,7 @@ after_failure:
   - if [[ "$DISTCHECK" == "" ]]; then cat test-suite.log || echo "cat failed"; fi
   ## `make distcheck` puts it somewhere different.
   - if [[ "$DISTCHECK" != "" ]]; then make show-distdir-testlog || echo "make failed"; fi
+  - if [[ "$DISTCHECK" != "" ]]; then make show-distdir-core || echo "make failed"; fi
 
 after_success:
   ## If this build was one that produced coverage, upload it.

--- a/Makefile.am
+++ b/Makefile.am
@@ -452,6 +452,15 @@ show-distdir-testlog:
 	else \
 	  cat $(distdir)/_build/$(TEST_SUITE_LOG); fi
 
+# Similarly, this relies on automake internals to run file on an
+# intermittent core file whose provenance is not known to us.  See
+# ticket 26787.
+show-distdir-core:
+	@if test -d "$(distdir)/_build/sub"; then \
+	  file $(distdir)/_build/sub/core ; \
+	else \
+	  file $(distdir)/_build/core; fi
+
 show-libs:
 	@echo $(TOR_INTERNAL_LIBS)
 

--- a/changes/ticket28024
+++ b/changes/ticket28024
@@ -1,0 +1,4 @@
+  o Minor features (testing):
+    - Report what program produced the mysterious core file that we
+      occasionally see on Travis CI during make distcheck.  Closes
+      ticket 28024.


### PR DESCRIPTION
Report what program produced the mysterious core file that we
occasionally see on Travis CI during make distcheck.  Closes ticket
28024.