### PR TITLE
test: Update approx_time before the test starts

### DIFF
--- a/changes/ticket27810
+++ b/changes/ticket27810
@@ -1,0 +1,5 @@
+  o Minor bugfixes (test, hidden service v3):
+    - Make the the hs_service tests uses the same time source when creating
+      the introduction point and testing it. This helps make test work on very
+      slow system like ARM or Travis. Fixes bug 27810; bugfix on
+      0.3.2.1-alpha.

--- a/src/test/test_hs_service.c
+++ b/src/test/test_hs_service.c
@@ -748,6 +748,8 @@ test_helper_functions(void *arg)
   MOCK(node_get_by_id, mock_node_get_by_id);
 
   hs_service_init();
+  time_t now = time(NULL);
+  update_approx_time(now);
 
   service = helper_create_service();
 
@@ -807,7 +809,6 @@ test_helper_functions(void *arg)
 
   /* Testing can_service_launch_intro_circuit() */
   {
-    time_t now = time(NULL);
     /* Put the start of the retry period back in time, we should be allowed.
      * to launch intro circuit. */
     service->state.num_intro_circ_launched = 2;
@@ -831,7 +832,6 @@ test_helper_functions(void *arg)
 
   /* Testing intro_point_should_expire(). */
   {
-    time_t now = time(NULL);
     /* Just some basic test of the current state. */
     tt_u64_op(ip->introduce2_max, OP_GE,
               INTRO_POINT_MIN_LIFETIME_INTRODUCTIONS);


### PR DESCRIPTION
This way we have the same time source when the IP is created and tested later.

Fixes #27810

Signed-off-by: David Goulet <dgoulet@torproject.org>