### PR TITLE
mainloop: Set client role if ControlPort is set

### DIFF
--- a/changes/ticket27849
+++ b/changes/ticket27849
@@ -1,0 +1,5 @@
+  o Major bugfixes (mainloop, bootstrap):
+    - Make sure Tor bootstraps and works properly if only the ControlPort is
+      set. Prior to this fix, Tor would only bootstrap with at least a client
+      port being set (Socks, Trans, NATD, DNS or HTTPTunnel port). Fixes bug
+      27849; bugfix on 0.3.4.1-alpha.

--- a/src/or/main.c
+++ b/src/or/main.c
@@ -1493,13 +1493,18 @@ get_my_roles(const or_options_t *options)
 
   int roles = 0;
   int is_bridge = options->BridgeRelay;
-  int is_client = options_any_client_port_set(options);
   int is_relay = server_mode(options);
   int is_dirauth = authdir_mode_v3(options);
   int is_bridgeauth = authdir_mode_bridge(options);
   int is_hidden_service = !!hs_service_get_num_services() ||
                           !!rend_num_services();
   int is_dirserver = dir_server_mode(options);
+  /* We also consider tor to have the role of a client if the ControlPort is
+   * set because a lot of things can be done over the control port which
+   * requires tor to have basic functionnalities. */
+  int is_client = options_any_client_port_set(options) ||
+                  options->ControlPort_set ||
+                  options->OwningControllerFD >= 0;
 
   if (is_bridge) roles |= PERIODIC_EVENT_ROLE_BRIDGE;
   if (is_client) roles |= PERIODIC_EVENT_ROLE_CLIENT;


### PR DESCRIPTION
It turns out that if _only_ the ControlPort is set and nothing else, tor would
simply not bootstrap and thus not start properly. Commit 67a41b63063370c2
removed that requirement for tor to be considered a "client".

Unfortunately, this made the mainloop enable basically nothing if only the
ControlPort is set in the torrc.

This commit now makes it that we also consider the ControlPort when deciding
if we are a Client or not. It does not revert 67a41b63063370c2 meaning
options_any_client_port_set() stays the same, not looking at the control port.

Fixes #27849.

Signed-off-by: David Goulet <dgoulet@torproject.org>