### PR TITLE
[Tor Trac #28066]: Fix typo in comment for hs_cell_parse_introduce2()

### DIFF
--- a/src/feature/hs/hs_cell.c
+++ b/src/feature/hs/hs_cell.c
@@ -620,7 +620,7 @@ hs_cell_parse_intro_established(const uint8_t *payload, size_t payload_len)
   return ret;
 }
 
-/* Parsse the INTRODUCE2 cell using data which contains everything we need to
+/* Parse the INTRODUCE2 cell using data which contains everything we need to
  * do so and contains the destination buffers of information we extract and
  * compute from the cell. Return 0 on success else a negative value. The
  * service and circ are only used for logging purposes. */


### PR DESCRIPTION
For the bug [here](https://trac.torproject.org/projects/tor/ticket/28066).