### PR TITLE
hs-v3: Always generate the descriptor cookie

### DIFF
--- a/changes/ticket27995
+++ b/changes/ticket27995
@@ -1,0 +1,4 @@
+  o Minor bugfixes (hidden service v3, client authorization):
+    - Fix an assert() when adding a client authorization for the first time
+      and then sending a HUP signal to the service. Before that, tor would
+      stop abruptly. Fixes bug 27995; bugfix on 0.3.5.1-alpha.

--- a/src/feature/hs/hs_service.c
+++ b/src/feature/hs/hs_service.c
@@ -1924,12 +1924,10 @@ build_service_desc_keys(const hs_service_t *service,
     goto end;
   }
 
-  /* Random a descriptor cookie to be used as a part of a key to encrypt the
-   * descriptor, if the client auth is enabled. */
-  if (service->config.is_client_auth_enabled) {
-    crypto_strongest_rand(desc->descriptor_cookie,
-                          sizeof(desc->descriptor_cookie));
-  }
+  /* Random descriptor cookie to be used as a part of a key to encrypt the
+   * descriptor, only if the client auth is enabled will it be used. */
+  crypto_strongest_rand(desc->descriptor_cookie,
+                        sizeof(desc->descriptor_cookie));
 
   /* Success. */
   ret = 0;


### PR DESCRIPTION
It won't be used if there are no authorized client configured. We do that so
we can easily support the addition of a client with a HUP signal which allow
us to avoid more complex code path to generate that cookie if we have at least
one client auth and we had none before.

Fixes #27995

Signed-off-by: David Goulet <dgoulet@torproject.org>