### PR TITLE
Memoize summarize_protover_flags()

### DIFF
--- a/changes/ticket27225
+++ b/changes/ticket27225
@@ -1,0 +1,5 @@
+  o Minor features (performance):
+    - Avoid parsing the same protocol-versions string over and over
+      in summarize_protocol_flags(). This should save us a huge number
+      of malloc calls on startup, and may reduce memory fragmentation with
+      some allocators. Closes ticket 27225.

--- a/changes/ticket27225
+++ b/changes/ticket27225
@@ -1,5 +1,5 @@
   o Minor features (performance):
     - Avoid parsing the same protocol-versions string over and over
-      in summarize_protocol_flags(). This should save us a huge number
+      in summarize_protover_flags(). This should save us a huge number
       of malloc calls on startup, and may reduce memory fragmentation with
       some allocators. Closes ticket 27225.

--- a/src/app/main/main.c
+++ b/src/app/main/main.c
@@ -33,6 +33,7 @@
 #include "core/or/relay.h"
 #include "core/or/scheduler.h"
 #include "core/or/status.h"
+#include "core/or/versions.h"
 #include "feature/api/tor_api.h"
 #include "feature/api/tor_api_internal.h"
 #include "feature/client/addressmap.h"
@@ -791,6 +792,7 @@ tor_free_all(int postfork)
   dos_free_all();
   circuitmux_ewma_free_all();
   accounting_free_all();
+  protover_summary_cache_free_all();
 
   if (!postfork) {
     config_free_all();

--- a/src/core/or/versions.h
+++ b/src/core/or/versions.h
@@ -41,4 +41,6 @@ void summarize_protover_flags(protover_summary_flags_t *out,
                               const char *protocols,
                               const char *version);
 
+void protover_summary_cache_free_all(void);
+
 #endif /* !defined(TOR_VERSIONS_H) */


### PR DESCRIPTION
Our tests showed that this function is responsible for a huge number
of our malloc/free() calls.  It's a prime candidate for being
memoized.

Closes ticket 27225.