### PR TITLE
Windows: correctly identify relays running on Windows 8, 8.1, and 10

### DIFF
--- a/changes/bug28096
+++ b/changes/bug28096
@@ -1,0 +1,6 @@
+  o Minor bugfixes (Windows):
+    - Correctly identify Windows 8.1 and Windows 10 (or later) when tor
+      is launched with a Windows application compatibility manifest for these
+      versions of Windows. When tor is not launched with a manifest
+      (the default), report "Windows 8 or later".
+      Fixes bug 28096; bugfix on 0.2.2.34; reported by Keifer Bly.

--- a/src/common/compat.c
+++ b/src/common/compat.c
@@ -2693,18 +2693,23 @@ MOCK_IMPL(const char *, get_uname, (void))
         static struct {
           unsigned major; unsigned minor; const char *version;
         } win_version_table[] = {
-          { 6, 2, "Windows 8" },
-          { 6, 1, "Windows 7" },
-          { 6, 0, "Windows Vista" },
-          { 5, 2, "Windows Server 2003" },
-          { 5, 1, "Windows XP" },
-          { 5, 0, "Windows 2000" },
-          /* { 4, 0, "Windows NT 4.0" }, */
-          { 4, 90, "Windows Me" },
-          { 4, 10, "Windows 98" },
-          /* { 4, 0, "Windows 95" } */
-          { 3, 51, "Windows NT 3.51" },
-          { 0, 0, NULL }
+          /* As of Windows 8.1, GetVersionEx returns Windows 8 (6.2) for
+           * applications without an app compatibility manifest. tor doesn't
+           * provide a manifest in its distribution. */
+          { 10,  0, "Windows 10 or later" },
+          {  6,  3, "Windows 8.1 or later" },
+          {  6,  2, "Windows 8 or later" },
+          {  6,  1, "Windows 7" },
+          {  6,  0, "Windows Vista" },
+          {  5,  2, "Windows Server 2003" },
+          {  5,  1, "Windows XP" },
+          {  5,  0, "Windows 2000" },
+          /* {  4,  0, "Windows NT 4.0" }, */
+          {  4, 90, "Windows Me" },
+          {  4, 10, "Windows 98" },
+          /* {  4,  0, "Windows 95" } */
+          {  3, 51, "Windows NT 3.51" },
+          {  0,  0, NULL }
         };
         memset(&info, 0, sizeof(info));
         info.dwOSVersionInfoSize = sizeof(info);
@@ -2731,8 +2736,8 @@ MOCK_IMPL(const char *, get_uname, (void))
         if (plat) {
           strlcpy(uname_result, plat, sizeof(uname_result));
         } else {
-          if (info.dwMajorVersion > 6 ||
-              (info.dwMajorVersion==6 && info.dwMinorVersion>2))
+          if (info.dwMajorVersion > 10 ||
+              (info.dwMajorVersion == 10 && info.dwMinorVersion > 0))
             tor_snprintf(uname_result, sizeof(uname_result),
                          "Very recent version of Windows [major=%d,minor=%d]",
                          (int)info.dwMajorVersion,(int)info.dwMinorVersion);


### PR DESCRIPTION
Correctly identify Windows 8.1 and Windows 10 (or later) when tor
is launched with a Windows application compatibility manifest for these
versions of Windows.

When tor is not launched with a manifest (the default), report
"Windows 8 or later".

Fixes bug 28096; bugfix on 0.2.2.34; reported by Keifer Bly.