### PR TITLE
27948-master: Treat backtrace test failures as expected on most BSD-derived systems

### DIFF
--- a/changes/bug27948
+++ b/changes/bug27948
@@ -1,0 +1,6 @@
+  o Minor bugfixes (tests):
+    - Treat backtrace test failures as expected on BSD-derived systems
+      (NetBSD, OpenBSD, and macOS/Darwin) until we solve bug 17808.
+      (FreeBSD failures have been treated as expected since 18204 in 0.2.8.)
+      Fixes bug 27948; bugfix on 0.2.5.2-alpha.
+

--- a/src/test/bt_test.py
+++ b/src/test/bt_test.py
@@ -44,10 +44,12 @@ print("BAD")
 for l in LINES:
     print("{}".format(l), end="")
 
-if sys.platform.startswith('freebsd'):
-    # See bug #17808 if you know how to fix this.
-    print("Test failed; but FreeBSD is known to have backtrace problems.\n"
-          "Treating as 'SKIP'.")
+if (sys.platform.startswith('freebsd') or sys.platform.startswith('netbsd') or
+    sys.platform.startswith('openbsd') or sys.platform.startswith('darwin')):
+    # See bug #17808 if you know how to fix backtraces on BSD-derived systems
+    print("Test failed; but {} is known to have backtrace problems."
+          .format(sys.platform))
+    print("Treating as 'SKIP'.")
     sys.exit(77)
 
 sys.exit(1)


### PR DESCRIPTION
Treat backtrace test failures as expected on NetBSD, OpenBSD, and
macOS/Darwin, until we solve bug 17808.

(FreeBSD failures have been treated as expected since 18204 in 0.2.8.)

Fixes bug 27948; bugfix on 0.2.5.2-alpha.