### PR TITLE
#28077: rust/tor_util: drop unsafe block in cstr!

### DIFF
--- a/changes/ticket28077
+++ b/changes/ticket28077
@@ -1,0 +1,3 @@
+  o Code simplification and refactoring:
+    - Remove unnecessarily unsafe code from the rust macro cstr!. Closes
+      ticket 28077.

--- a/src/rust/tor_util/strings.rs
+++ b/src/rust/tor_util/strings.rs
@@ -105,11 +105,7 @@ macro_rules! cstr {
     ($($bytes:expr),*) => (
         ::std::ffi::CStr::from_bytes_with_nul(
             concat!($($bytes),*, "\0").as_bytes()
-        ).unwrap_or(
-            unsafe{
-                ::std::ffi::CStr::from_bytes_with_nul_unchecked(b"\0")
-            }
-        )
+        ).unwrap_or_default()
     )
 }
 


### PR DESCRIPTION
Let's see what Travis says to this.

https://trac.torproject.org/projects/tor/ticket/28077