### PR TITLE
Add errno.h include to freespace.c for Android.

### DIFF
--- a/changes/bug28286
+++ b/changes/bug28286
@@ -1,0 +1,3 @@
+  o Minor bugfixes (compilation, Android):
+    - Fix a missing header in freespace.c. Fixes bug 28286; bugfix on
+      0.3.5.1-alpha.

--- a/src/lib/fs/freespace.c
+++ b/src/lib/fs/freespace.c
@@ -19,6 +19,7 @@
 #include <windows.h>
 #endif
 
+#include <errno.h>
 #include <string.h>
 
 /** Return the amount of free disk space we have permission to use, in


### PR DESCRIPTION
Fixes bug 28286; bugfix on 0.3.5.1-alpha.