### PR TITLE
Appveyor: Add Windows Server 2016 to tor's build matrix

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -2,6 +2,12 @@ version: 1.0.{build}
 
 clone_depth: 50
 
+image:
+  # Windows Server 2012 R2
+  - Visual Studio 2015
+  # Windows Server 2016
+  - Visual Studio 2017
+
 environment:
   compiler: mingw
 

--- a/changes/ticket28318
+++ b/changes/ticket28318
@@ -1,0 +1,3 @@
+  o Minor features (Windows, continuous integration):
+    - Build tor on Windows Server 2012 R2 and Windows Server 2016 using
+      Appveyor's CI. Closes ticket 28318.


### PR DESCRIPTION
Build tor on Windows Server 2012 R2 and Windows Server 2016 using
Appveyor's CI.

Closes ticket 28318.