### PR TITLE
[Tor Trac #27841]: At intro points, don't close circuits on NACKs

### DIFF
--- a/changes/bug27841
+++ b/changes/bug27841
@@ -1,0 +1,7 @@
+  o Minor bugfixes (onion services):
+    - On an intro point for a version 3 onion service, we do not close
+      an introduction circuit on an NACK. This lets the client decide
+      whether to reuse the circuit or discard it. Previously, we closed
+      intro circuits on NACKs. Fixes bug 27841; bugfix on 0.3.2.1-alpha.
+      Patch by Neel Chaunan
+

--- a/src/or/hs_intropoint.c
+++ b/src/or/hs_intropoint.c
@@ -501,12 +501,6 @@ handle_introduce1(or_circuit_t *client_circ, const uint8_t *request,
     /* Circuit has been closed on failure of transmission. */
     goto done;
   }
-  if (status != HS_INTRO_ACK_STATUS_SUCCESS) {
-    /* We just sent a NACK that is a non success status code so close the
-     * circuit because it's not useful to keep it open. Remember, a client can
-     * only send one INTRODUCE1 cell on a circuit. */
-    circuit_mark_for_close(TO_CIRCUIT(client_circ), END_CIRC_REASON_INTERNAL);
-  }
  done:
   trn_cell_introduce1_free(parsed_cell);
   return ret;


### PR DESCRIPTION
For the bug [here](https://trac.torproject.org/projects/tor/ticket/27841). Based on `maint-0.3.3` based on a request from @dgoulet-tor.