### PR TITLE
Always declare groups when building with openssl 1.1.1 APIs

### DIFF
--- a/changes/bug28245
+++ b/changes/bug28245
@@ -1,0 +1,6 @@
+  o Major bugfixes (OpenSSL, portability):
+    - Fix our usage of named groups when running as a TLS 1.3 client in
+      OpenSSL 1.1.1. Previously, we only initialized EC groups when running
+      as a server, which caused clients to fail to negotiate TLS 1.3 with
+      relays. Fixes bug 28245; bugfix on 0.2.9.15 when TLS 1.3 support was
+      added.

--- a/configure.ac
+++ b/configure.ac
@@ -677,6 +677,7 @@ AC_CHECK_FUNCS([ \
 		SSL_get_server_random \
                 SSL_get_client_ciphers \
                 SSL_get_client_random \
+                SSL_CTX_set1_groups_list \
 		SSL_CIPHER_find \
                 SSL_CTX_set_security_level \
 		TLS_method

--- a/src/common/tortls.c
+++ b/src/common/tortls.c
@@ -1217,6 +1217,22 @@ tor_tls_context_new(crypto_pk_t *identity, unsigned int key_lifetime,
     SSL_CTX_set_tmp_dh(result->ctx, crypto_dh_get_dh_(dh));
     crypto_dh_free(dh);
   }
+/* We check for this function in two ways, since it might be either a symbol
+ * or a macro. */
+#if defined(SSL_CTX_set1_groups_list) || defined(HAVE_SSL_CTX_SET1_GROUPS_LIST)
+  {
+    const char *list;
+    if (flags & TOR_TLS_CTX_USE_ECDHE_P224)
+      list = "P-224:P-256";
+    else if (flags & TOR_TLS_CTX_USE_ECDHE_P256)
+      list = "P-256:P-224";
+    else
+      list = "P-256:P-224";
+    int r = SSL_CTX_set1_groups_list(result->ctx, list);
+    if (r < 0)
+      goto error;
+  }
+#else
   if (! is_client) {
     int nid;
     EC_KEY *ec_key;
@@ -1232,6 +1248,7 @@ tor_tls_context_new(crypto_pk_t *identity, unsigned int key_lifetime,
       SSL_CTX_set_tmp_ecdh(result->ctx, ec_key);
     EC_KEY_free(ec_key);
   }
+#endif
   SSL_CTX_set_verify(result->ctx, SSL_VERIFY_PEER,
                      always_accept_verify_cb);
   /* let us realloc bufs that we're writing from */


### PR DESCRIPTION
Failing to do on clients was causing TLS 1.3 negotiation to fail.

Fixes bug 28245; bugfix on 0.2.9.15, when we added TLS 1.3 support.