### PR TITLE
seccomp2: Add "shutdown" to the list of permitted system calls.

### DIFF
--- a/changes/bug28183
+++ b/changes/bug28183
@@ -1,0 +1,4 @@
+  o Minor bugfixes (Linux seccomp2 sandbox):
+    - Permit the "shutdown()" system call, which is apparently
+      used by OpenSSL under some circumstances. Fixes bug 28183;
+      bugfix on 0.2.5.1-alpha.

--- a/src/common/sandbox.c
+++ b/src/common/sandbox.c
@@ -205,6 +205,7 @@ static int filter_nopar_gen[] = {
 #ifdef __NR_setrlimit
     SCMP_SYS(setrlimit),
 #endif
+    SCMP_SYS(shutdown),
 #ifdef __NR_sigaltstack
     SCMP_SYS(sigaltstack),
 #endif
@@ -2013,4 +2014,3 @@ sandbox_disable_getaddrinfo_cache(void)
 {
 }
 #endif
-


### PR DESCRIPTION
We don't use this syscall, but openssl apparently does.

(This syscall puts a socket into a half-closed state. Don't worry:
It doesn't shut down the system or anything.)

Fixes bug 28183; bugfix on 0.2.5.1-alpha where the sandbox was
introduced.