### PR TITLE
Fix a compiler warning in aes.c.

### DIFF
--- a/changes/bug28413
+++ b/changes/bug28413
@@ -1,0 +1,4 @@
+  o Minor bugfixes (compilation):
+    - Initialize a variable in aes_new_cipher(), since some compilers
+      cannot tell that we always initialize it before use. Fixes bug 28413;
+      bugfix on 0.2.9.3-alpha.

--- a/src/common/aes.c
+++ b/src/common/aes.c
@@ -99,12 +99,12 @@ aes_cnt_cipher_t *
 aes_new_cipher(const uint8_t *key, const uint8_t *iv, int key_bits)
 {
   EVP_CIPHER_CTX *cipher = EVP_CIPHER_CTX_new();
-  const EVP_CIPHER *c;
+  const EVP_CIPHER *c = NULL;
   switch (key_bits) {
     case 128: c = EVP_aes_128_ctr(); break;
     case 192: c = EVP_aes_192_ctr(); break;
     case 256: c = EVP_aes_256_ctr(); break;
-    default: tor_assert(0); // LCOV_EXCL_LINE
+    default: tor_assert_unreached(); // LCOV_EXCL_LINE
   }
   EVP_EncryptInit(cipher, c, key, iv);
   return (aes_cnt_cipher_t *) cipher;
@@ -402,4 +402,3 @@ aes_set_iv(aes_cnt_cipher_t *cipher, const uint8_t *iv)
 }
 
 #endif
-


### PR DESCRIPTION
Apparently some freebsd compilers can't tell that 'c' will never
be used uninitialized.

Fixes bug 28413; bugfix on 0.2.9.3-alpha when we added support for
longer AES keys to this function.