### PR TITLE
Allow Tor to enter a "dormant" state

### DIFF
--- a/src/app/config/config.c
+++ b/src/app/config/config.c
@@ -1993,9 +1993,6 @@ options_act(const or_options_t *old_options)
     finish_daemon(options->DataDirectory);
   }
 
-  /* See whether we need to enable/disable our once-a-second timer. */
-  reschedule_per_second_timer();
-
   /* We want to reinit keys as needed before we do much of anything else:
      keys are important, and other things can depend on them. */
   if (transition_affects_workers ||

--- a/src/app/main/main.c
+++ b/src/app/main/main.c
@@ -303,6 +303,19 @@ process_signal(int sig)
       log_heartbeat(time(NULL));
       control_event_signal(sig);
       break;
+    case SIGACTIVE:
+      /* "SIGACTIVE" counts as ersatz user activity. */
+      note_user_activity(approx_time());
+      control_event_signal(sig);
+      break;
+    case SIGDORMANT:
+      /* "SIGDORMANT" means to ignore past user activity */
+      log_notice(LD_GENERAL, "Going dormant because of controller request.");
+      reset_user_activity(0);
+      set_network_participation(false);
+      schedule_rescan_periodic_events();
+      control_event_signal(sig);
+      break;
   }
 }
 
@@ -472,6 +485,8 @@ static struct {
   { SIGNEWNYM, 0, NULL },
   { SIGCLEARDNSCACHE, 0, NULL },
   { SIGHEARTBEAT, 0, NULL },
+  { SIGACTIVE, 0, NULL },
+  { SIGDORMANT, 0, NULL },
   { -1, -1, NULL }
 };
 

--- a/src/core/mainloop/connection.c
+++ b/src/core/mainloop/connection.c
@@ -4429,6 +4429,16 @@ connection_get_by_type_state(int type, int state)
   CONN_GET_TEMPLATE(conn, conn->type == type && conn->state == state);
 }
 
+/**
+ * Return a connection of type <b>type</b> that is not an internally linked
+ * connection, and is not marked for close.
+ **/
+connection_t *
+connection_get_by_type_nonlinked(int type)
+{
+  CONN_GET_TEMPLATE(conn, conn->type == type && !conn->linked);
+}
+
 /** Return a connection of type <b>type</b> that has rendquery equal
  * to <b>rendquery</b>, and that is not marked for close. If state
  * is non-zero, conn must be of that state too.

--- a/src/core/mainloop/connection.c
+++ b/src/core/mainloop/connection.c
@@ -1874,6 +1874,9 @@ connection_init_accepted_conn(connection_t *conn,
       TO_ENTRY_CONN(conn)->nym_epoch = get_signewnym_epoch();
       TO_ENTRY_CONN(conn)->socks_request->listener_type = listener->base_.type;
 
+      /* Any incoming connection on an entry port counts as user activity. */
+      note_user_activity(approx_time());
+
       switch (TO_CONN(listener)->type) {
         case CONN_TYPE_AP_LISTENER:
           conn->state = AP_CONN_STATE_SOCKS_WAIT;

--- a/src/core/mainloop/connection.h
+++ b/src/core/mainloop/connection.h
@@ -240,6 +240,7 @@ size_t connection_get_outbuf_len(connection_t *conn);
 connection_t *connection_get_by_global_id(uint64_t id);
 
 connection_t *connection_get_by_type(int type);
+connection_t *connection_get_by_type_nonlinked(int type);
 MOCK_DECL(connection_t *,connection_get_by_type_addr_port_purpose,(int type,
                                                   const tor_addr_t *addr,
                                                   uint16_t port, int purpose));

--- a/src/core/mainloop/mainloop.c
+++ b/src/core/mainloop/mainloop.c
@@ -1658,7 +1658,7 @@ rescan_periodic_events(const or_options_t *options)
     } else {
       log_debug(LD_GENERAL, "Disabling periodic event %s", item->name);
       if (item->flags & PERIODIC_EVENT_FLAG_RUN_ON_DISABLE) {
-        periodic_event_flush_and_disable(item);
+        periodic_event_schedule_and_disable(item);
       } else {
         periodic_event_disable(item);
       }

--- a/src/core/mainloop/mainloop.c
+++ b/src/core/mainloop/mainloop.c
@@ -1372,6 +1372,7 @@ CALLBACK(write_bridge_ns);
 CALLBACK(write_stats_file);
 CALLBACK(control_per_second_events);
 CALLBACK(second_elapsed);
+CALLBACK(check_network_participation);
 
 #undef CALLBACK
 
@@ -1401,6 +1402,7 @@ STATIC periodic_event_item_t periodic_events[] = {
   CALLBACK(fetch_networkstatus, NET_PARTICIPANT, 0),
   CALLBACK(launch_descriptor_fetches, NET_PARTICIPANT, FL(NEED_NET)),
   CALLBACK(rotate_x509_certificate, NET_PARTICIPANT, 0),
+  CALLBACK(check_network_participation, NET_PARTICIPANT, 0),
 
   /* We need to do these if we're participating in the Tor network, and
    * immediately before we stop. */
@@ -2001,6 +2003,55 @@ add_entropy_callback(time_t now, const or_options_t *options)
   /** How often do we add more entropy to OpenSSL's RNG pool? */
 #define ENTROPY_INTERVAL (60*60)
   return ENTROPY_INTERVAL;
+}
+
+/** Periodic callback: if there has been no network usage in a while,
+ * enter a dormant state. */
+static int
+check_network_participation_callback(time_t now, const or_options_t *options)
+{
+  /* If we're a server, we can't become dormant. */
+  if (server_mode(options)) {
+    note_user_activity(now);
+    goto end;
+  }
+
+  /* If we're running an onion service, we can't become dormant. */
+  /* XXXX this would be nice to change, so that we can be dormant with a
+   * service. */
+  if (hs_service_get_num_services() || rend_num_services()) {
+    note_user_activity(now);
+    goto end;
+  }
+
+  /* XXXX Add an option to never become dormant. */
+
+  /* If we have any currently open entry streams other than "linked"
+   * connections used for directory requests, those count as user activity.
+   */
+  /* XXXX make this configurable? */
+  if (connection_get_by_type_nonlinked(CONN_TYPE_AP) != NULL) {
+    note_user_activity(now);
+    goto end;
+  }
+
+  /** Become dormant if there has been no user activity in this long. */
+  /* XXXX make this configurable! */
+#define BECOME_DORMANT_AFTER_INACTIVITY (24*60*60)
+  if (get_last_user_activity_time() + BECOME_DORMANT_AFTER_INACTIVITY >= now) {
+    log_notice(LD_GENERAL, "No user activity in a long time: becoming"
+               " dormant.");
+    set_network_participation(false);
+    rescan_periodic_events(options);
+    goto end;
+  }
+
+/* XXXX Make this configurable? */
+/** How often do we check whether we have had network activity? */
+#define CHECK_PARTICIPATION_INTERVAL (5*60)
+
+ end:
+  return CHECK_PARTICIPATION_INTERVAL;
 }
 
 /**

--- a/src/core/mainloop/mainloop.c
+++ b/src/core/mainloop/mainloop.c
@@ -1406,8 +1406,6 @@ STATIC periodic_event_item_t periodic_events[] = {
    * immediately before we stop. */
   CALLBACK(clean_caches, NET_PARTICIPANT, FL(FLUSH_ON_DISABLE)),
   CALLBACK(save_state, NET_PARTICIPANT, FL(FLUSH_ON_DISABLE)),
-
-  /* XXXX investigate this. ??? */
   CALLBACK(write_stats_file, NET_PARTICIPANT, FL(FLUSH_ON_DISABLE)),
 
   /* Routers (bridge and relay) only. */

--- a/src/core/mainloop/mainloop.c
+++ b/src/core/mainloop/mainloop.c
@@ -1732,12 +1732,21 @@ safe_timer_diff(time_t now, time_t next)
 }
 
 /** Perform regular maintenance tasks.  This function gets run once per
- * second by second_elapsed_callback().
+ * second.
  */
 static void
-run_scheduled_events(time_t now)
+second_elapsed_callback(periodic_timer_t *timer, void *arg)
 {
+  (void) timer;
+  (void) arg;
+  const time_t now = time(NULL);
   const or_options_t *options = get_options();
+
+  /* We don't need to do this once-per-second any more: time-updating is
+   * only in this callback _because it is a callback_. It should be fine
+   * to disable this callback, and the time will still get updated.
+   */
+  update_current_time(now);
 
   /* 0. See if we've been asked to shut down and our timeout has
    * expired; or if our bandwidth limits are exhausted and we
@@ -2645,28 +2654,6 @@ update_current_time(time_t now)
 
   update_approx_time(now);
   current_second = now;
-}
-
-/** Libevent callback: invoked once every second. */
-static void
-second_elapsed_callback(periodic_timer_t *timer, void *arg)
-{
-  /* XXXX This could be sensibly refactored into multiple callbacks, and we
-   * could use Libevent's timers for this rather than checking the current
-   * time against a bunch of timeouts every second. */
-  time_t now;
-  (void)timer;
-  (void)arg;
-
-  now = time(NULL);
-
-  /* We don't need to do this once-per-second any more: time-updating is
-   * only in this callback _because it is a callback_. It should be fine
-   * to disable this callback, and the time will still get updated.
-   */
-  update_current_time(now);
-
-  run_scheduled_events(now);
 }
 
 #ifdef HAVE_SYSTEMD_209

--- a/src/core/mainloop/mainloop.c
+++ b/src/core/mainloop/mainloop.c
@@ -1708,6 +1708,30 @@ mainloop_schedule_postloop_cleanup(void)
   mainloop_event_activate(postloop_cleanup_ev);
 }
 
+/** Event to run 'scheduled_shutdown_cb' */
+static mainloop_event_t *scheduled_shutdown_ev=NULL;
+
+/** Callback: run a scheduled shutdown */
+static void
+scheduled_shutdown_cb(mainloop_event_t *ev, void *arg)
+{
+  (void)ev;
+  (void)arg;
+  log_notice(LD_GENERAL, "Clean shutdown finished. Exiting.");
+  tor_shutdown_event_loop_and_exit(0);
+}
+
+/** Schedule the mainloop to exit after <b>delay_sec</b> seconds. */
+void
+mainloop_schedule_shutdown(int delay_sec)
+{
+  const struct timeval delay_tv = { delay_sec, 0 };
+  if (! scheduled_shutdown_ev) {
+    scheduled_shutdown_ev = mainloop_event_new(scheduled_shutdown_cb, NULL);
+  }
+  mainloop_event_schedule(scheduled_shutdown_ev, &delay_tv);
+}
+
 #define LONGEST_TIMER_PERIOD (30 * 86400)
 /** Helper: Return the number of seconds between <b>now</b> and <b>next</b>,
  * clipped to the range [1 second, LONGEST_TIMER_PERIOD]. */
@@ -1748,12 +1772,13 @@ second_elapsed_callback(periodic_timer_t *timer, void *arg)
    */
   update_current_time(now);
 
-  /* 0. See if we've been asked to shut down and our timeout has
-   * expired; or if our bandwidth limits are exhausted and we
-   * should hibernate; or if it's time to wake up from hibernation.
+  /* 0. See if our bandwidth limits are exhausted and we should hibernate; or
+   * if it's time to wake up from hibernation; or if we have a scheduled
+   * shutdown and it's time to run it.
+   *
+   * Note: we have redundant mechanisms to handle the
    */
-  // TODO: Refactor or rewrite, or NET_PARTICIPANT. Needs separate wakeup
-  //       handling.
+  // TODO: NET_PARTICIPANT.
   consider_hibernation(now);
 
   /* Maybe enough time elapsed for us to reconsider a circuit. */
@@ -2941,6 +2966,7 @@ tor_mainloop_free_all(void)
   mainloop_event_free(schedule_active_linked_connections_event);
   mainloop_event_free(postloop_cleanup_ev);
   mainloop_event_free(handle_deferred_signewnym_ev);
+  mainloop_event_free(scheduled_shutdown_ev);
 
 #ifdef HAVE_SYSTEMD_209
   periodic_timer_free(systemd_watchdog_timer);

--- a/src/core/mainloop/mainloop.c
+++ b/src/core/mainloop/mainloop.c
@@ -1381,9 +1381,11 @@ CALLBACK(second_elapsed);
 #define FL(name) (PERIODIC_EVENT_FLAG_ ## name)
 
 STATIC periodic_event_item_t periodic_events[] = {
-  /* Everyone needs to run those. */
+  /* Everyone needs to run these. They need to have very long timeouts for
+   * that to be safe. */
   CALLBACK(add_entropy, ALL, 0),
   CALLBACK(heartbeat, ALL, 0),
+  CALLBACK(reset_padding_counts, ALL, 0),
 
   /* This is a legacy catch-all callback that runs once per second if
    * we are online and active. */
@@ -1407,9 +1409,6 @@ STATIC periodic_event_item_t periodic_events[] = {
 
   /* XXXX investigate this. ??? */
   CALLBACK(write_stats_file, NET_PARTICIPANT, FL(FLUSH_ON_DISABLE)),
-
-  /* XXXX investigate this. ???? */
-  CALLBACK(reset_padding_counts, NET_PARTICIPANT, FL(FLUSH_ON_DISABLE)),
 
   /* Routers (bridge and relay) only. */
   CALLBACK(check_descriptor, ROUTER, FL(NEED_NET)),

--- a/src/core/mainloop/mainloop.c
+++ b/src/core/mainloop/mainloop.c
@@ -1375,74 +1375,66 @@ CALLBACK(write_stats_file);
 #undef CALLBACK
 
 /* Now we declare an array of periodic_event_item_t for each periodic event */
-#define CALLBACK(name, r, f) PERIODIC_EVENT(name, r, f)
+#define CALLBACK(name, r, f) \
+  PERIODIC_EVENT(name, PERIODIC_EVENT_ROLE_ ## r, f)
+#define FL(name) (PERIODIC_EVENT_FLAG_ ## name)
 
 STATIC periodic_event_item_t periodic_events[] = {
   /* Everyone needs to run those. */
-  CALLBACK(add_entropy, PERIODIC_EVENT_ROLE_ALL, 0),
-  CALLBACK(check_expired_networkstatus, PERIODIC_EVENT_ROLE_ALL, 0),
-  CALLBACK(clean_caches, PERIODIC_EVENT_ROLE_ALL, 0),
-  CALLBACK(fetch_networkstatus, PERIODIC_EVENT_ROLE_ALL,
-           PERIODIC_EVENT_FLAG_NEED_NET),
-  CALLBACK(heartbeat, PERIODIC_EVENT_ROLE_ALL, 0),
-  CALLBACK(launch_descriptor_fetches, PERIODIC_EVENT_ROLE_ALL,
-           PERIODIC_EVENT_FLAG_NEED_NET),
-  CALLBACK(reset_padding_counts, PERIODIC_EVENT_ROLE_ALL, 0),
-  CALLBACK(retry_listeners, PERIODIC_EVENT_ROLE_ALL,
-           PERIODIC_EVENT_FLAG_NEED_NET),
-  CALLBACK(save_state, PERIODIC_EVENT_ROLE_ALL, 0),
-  CALLBACK(rotate_x509_certificate, PERIODIC_EVENT_ROLE_ALL, 0),
-  CALLBACK(write_stats_file, PERIODIC_EVENT_ROLE_ALL, 0),
+  CALLBACK(add_entropy, ALL, 0),
+  CALLBACK(check_expired_networkstatus, ALL, 0),
+  CALLBACK(clean_caches, ALL, 0),
+  CALLBACK(fetch_networkstatus, ALL, 0),
+  CALLBACK(heartbeat, ALL, 0),
+  CALLBACK(launch_descriptor_fetches, ALL, FL(NEED_NET)),
+  CALLBACK(reset_padding_counts, ALL, 0),
+  CALLBACK(retry_listeners, ALL, FL(NEED_NET)),
+  CALLBACK(save_state, ALL, 0),
+  CALLBACK(rotate_x509_certificate, ALL, 0),
+  CALLBACK(write_stats_file, ALL, 0),
 
   /* Routers (bridge and relay) only. */
-  CALLBACK(check_descriptor, PERIODIC_EVENT_ROLE_ROUTER,
-           PERIODIC_EVENT_FLAG_NEED_NET),
-  CALLBACK(check_ed_keys, PERIODIC_EVENT_ROLE_ROUTER, 0),
-  CALLBACK(check_for_reachability_bw, PERIODIC_EVENT_ROLE_ROUTER,
-           PERIODIC_EVENT_FLAG_NEED_NET),
-  CALLBACK(check_onion_keys_expiry_time, PERIODIC_EVENT_ROLE_ROUTER, 0),
-  CALLBACK(expire_old_ciruits_serverside, PERIODIC_EVENT_ROLE_ROUTER,
-           PERIODIC_EVENT_FLAG_NEED_NET),
-  CALLBACK(reachability_warnings, PERIODIC_EVENT_ROLE_ROUTER,
-           PERIODIC_EVENT_FLAG_NEED_NET),
-  CALLBACK(retry_dns, PERIODIC_EVENT_ROLE_ROUTER, 0),
-  CALLBACK(rotate_onion_key, PERIODIC_EVENT_ROLE_ROUTER, 0),
+  CALLBACK(check_descriptor, ROUTER, FL(NEED_NET)),
+  CALLBACK(check_ed_keys, ROUTER, 0),
+  CALLBACK(check_for_reachability_bw, ROUTER, FL(NEED_NET)),
+  CALLBACK(check_onion_keys_expiry_time, ROUTER, 0),
+  CALLBACK(expire_old_ciruits_serverside, ROUTER, FL(NEED_NET)),
+  CALLBACK(reachability_warnings, ROUTER, FL(NEED_NET)),
+  CALLBACK(retry_dns, ROUTER, 0),
+  CALLBACK(rotate_onion_key, ROUTER, 0),
 
   /* Authorities (bridge and directory) only. */
-  CALLBACK(downrate_stability, PERIODIC_EVENT_ROLE_AUTHORITIES, 0),
-  CALLBACK(launch_reachability_tests, PERIODIC_EVENT_ROLE_AUTHORITIES,
-           PERIODIC_EVENT_FLAG_NEED_NET),
-  CALLBACK(save_stability, PERIODIC_EVENT_ROLE_AUTHORITIES, 0),
+  CALLBACK(downrate_stability, AUTHORITIES, 0),
+  CALLBACK(launch_reachability_tests, AUTHORITIES, FL(NEED_NET)),
+  CALLBACK(save_stability, AUTHORITIES, 0),
 
   /* Directory authority only. */
-  CALLBACK(check_authority_cert, PERIODIC_EVENT_ROLE_DIRAUTH, 0),
-  CALLBACK(dirvote, PERIODIC_EVENT_ROLE_DIRAUTH, PERIODIC_EVENT_FLAG_NEED_NET),
+  CALLBACK(check_authority_cert, DIRAUTH, 0),
+  CALLBACK(dirvote, DIRAUTH, FL(NEED_NET)),
 
   /* Relay only. */
-  CALLBACK(check_canonical_channels, PERIODIC_EVENT_ROLE_RELAY,
-           PERIODIC_EVENT_FLAG_NEED_NET),
-  CALLBACK(check_dns_honesty, PERIODIC_EVENT_ROLE_RELAY,
-           PERIODIC_EVENT_FLAG_NEED_NET),
+  CALLBACK(check_canonical_channels, RELAY, FL(NEED_NET)),
+  CALLBACK(check_dns_honesty, RELAY, FL(NEED_NET)),
 
   /* Hidden Service service only. */
-  CALLBACK(hs_service, PERIODIC_EVENT_ROLE_HS_SERVICE,
-           PERIODIC_EVENT_FLAG_NEED_NET),
+  CALLBACK(hs_service, HS_SERVICE, FL(NEED_NET)),
 
   /* Bridge only. */
-  CALLBACK(record_bridge_stats, PERIODIC_EVENT_ROLE_BRIDGE, 0),
+  CALLBACK(record_bridge_stats, BRIDGE, 0),
 
   /* Client only. */
-  CALLBACK(rend_cache_failure_clean, PERIODIC_EVENT_ROLE_CLIENT, 0),
+  CALLBACK(rend_cache_failure_clean, CLIENT, 0),
 
   /* Bridge Authority only. */
-  CALLBACK(write_bridge_ns, PERIODIC_EVENT_ROLE_BRIDGEAUTH, 0),
+  CALLBACK(write_bridge_ns, BRIDGEAUTH, 0),
 
   /* Directory server only. */
-  CALLBACK(clean_consdiffmgr, PERIODIC_EVENT_ROLE_DIRSERVER, 0),
+  CALLBACK(clean_consdiffmgr, DIRSERVER, 0),
 
   END_OF_PERIODIC_EVENTS
 };
 #undef CALLBACK
+#undef FL
 
 /* These are pointers to members of periodic_events[] that are used to
  * implement particular callbacks.  We keep them separate here so that we

--- a/src/core/mainloop/mainloop.c
+++ b/src/core/mainloop/mainloop.c
@@ -205,7 +205,6 @@ static void connection_start_reading_from_linked_conn(connection_t *conn);
 static int connection_should_read_from_linked_conn(connection_t *conn);
 static void conn_read_callback(evutil_socket_t fd, short event, void *_conn);
 static void conn_write_callback(evutil_socket_t fd, short event, void *_conn);
-static void second_elapsed_callback(periodic_timer_t *timer, void *args);
 static void shutdown_did_not_work_callback(evutil_socket_t fd, short event,
                                            void *arg) ATTR_NORETURN;
 
@@ -1372,6 +1371,7 @@ CALLBACK(save_state);
 CALLBACK(write_bridge_ns);
 CALLBACK(write_stats_file);
 CALLBACK(control_per_second_events);
+CALLBACK(second_elapsed);
 
 #undef CALLBACK
 
@@ -1384,6 +1384,11 @@ STATIC periodic_event_item_t periodic_events[] = {
   /* Everyone needs to run those. */
   CALLBACK(add_entropy, ALL, 0),
   CALLBACK(heartbeat, ALL, 0),
+
+  /* This is a legacy catch-all callback that runs once per second if
+   * we are online and active. */
+  CALLBACK(second_elapsed, NET_PARTICIPANT,
+           FL(NEED_NET)|FL(FLUSH_ON_DISABLE)),
 
   /* XXXX Do we have a reason to do this on a callback? Does it do any good at
    * all?  For now, if we're dormant, we can let our listeners decay. */
@@ -1758,43 +1763,30 @@ safe_timer_diff(time_t now, time_t next)
 /** Perform regular maintenance tasks.  This function gets run once per
  * second.
  */
-static void
-second_elapsed_callback(periodic_timer_t *timer, void *arg)
+static int
+second_elapsed_callback(time_t now, const or_options_t *options)
 {
-  (void) timer;
-  (void) arg;
-  const time_t now = time(NULL);
-  const or_options_t *options = get_options();
-
-  /* We don't need to do this once-per-second any more: time-updating is
-   * only in this callback _because it is a callback_. It should be fine
-   * to disable this callback, and the time will still get updated.
-   */
-  update_current_time(now);
-
-  /* 0. See if our bandwidth limits are exhausted and we should hibernate; or
-   * if it's time to wake up from hibernation; or if we have a scheduled
-   * shutdown and it's time to run it.
+  /* 0. See if our bandwidth limits are exhausted and we should hibernate
    *
-   * Note: we have redundant mechanisms to handle the
+   * Note: we have redundant mechanisms to handle the case where it's
+   * time to wake up from hibernation; or where we have a scheduled
+   * shutdown and it's time to run it, but this will also handle those.
    */
-  // TODO: NET_PARTICIPANT.
   consider_hibernation(now);
 
   /* Maybe enough time elapsed for us to reconsider a circuit. */
-  // TODO: NET_PARTICIPANT
   circuit_upgrade_circuits_from_guard_wait();
 
   if (options->UseBridges && !net_is_disabled()) {
     /* Note: this check uses net_is_disabled(), not should_delay_dir_fetches()
      * -- the latter is only for fetching consensus-derived directory info. */
-    // TODO: client+NET_PARTICIPANT.
+    // TODO: client
     //     Also, schedule this rather than probing 1x / sec
     fetch_bridge_descriptors(options, now);
   }
 
   if (accounting_is_enabled(options)) {
-    // TODO: refactor or rewrite; NET_PARTICIPANT
+    // TODO: refactor or rewrite?
     accounting_run_housekeeping(now);
   }
 
@@ -1814,12 +1806,10 @@ second_elapsed_callback(periodic_timer_t *timer, void *arg)
    *     Do this before step 4, so we can put them back into pending
    *     state to be picked up by the new circuit.
    */
-  // TODO: All expire stuff can become NET_PARTICIPANT, FLUSH_ON_DISABLE
   connection_ap_expire_beginning();
 
   /* 3c. And expire connections that we've held open for too long.
    */
-  // TODO: All expire stuff can become NET_PARTICIPANT, FLUSH_ON_DISABLE
   connection_expire_held_open();
 
   /* 4. Every second, we try a new circuit if there are no valid
@@ -1829,26 +1819,24 @@ second_elapsed_callback(periodic_timer_t *timer, void *arg)
    */
   const int have_dir_info = router_have_minimum_dir_info();
   if (have_dir_info && !net_is_disabled()) {
-    // TODO: NET_PARTICIPANT.
     circuit_build_needed_circs(now);
   } else {
-    // TODO: NET_PARTICIPANT, FLUSH_ON_DISABLE
     circuit_expire_old_circs_as_needed(now);
   }
 
   /* 5. We do housekeeping for each connection... */
-  // TODO: NET_PARTICIPANT
   channel_update_bad_for_new_circs(NULL, 0);
   int i;
   for (i=0;i<smartlist_len(connection_array);i++) {
-    // TODO: NET_PARTICIPANT, FLUSH_ON_DISABLE
     run_connection_housekeeping(i, now);
   }
 
   /* 11b. check pending unconfigured managed proxies */
-  // NET_PARTICIPANT.
   if (!net_is_disabled() && pt_proxies_configuration_pending())
     pt_configure_remaining_proxies();
+
+  /* Run again in a second. */
+  return 1;
 }
 
 /* Periodic callback: rotate the onion keys after the period defined by the
@@ -2585,37 +2573,6 @@ control_per_second_events_callback(time_t now, const or_options_t *options)
   return 1;
 }
 
-/** Timer: used to invoke second_elapsed_callback() once per second. */
-static periodic_timer_t *second_timer = NULL;
-
-/**
- * Enable or disable the per-second timer as appropriate, creating it if
- * necessary.
- */
-void
-reschedule_per_second_timer(void)
-{
-  struct timeval one_second;
-  one_second.tv_sec = 1;
-  one_second.tv_usec = 0;
-
-  if (! second_timer) {
-    second_timer = periodic_timer_new(tor_libevent_get_base(),
-                                      &one_second,
-                                      second_elapsed_callback,
-                                      NULL);
-    tor_assert(second_timer);
-  }
-
-  const bool run_per_second_events = ! net_is_completely_disabled();
-
-  if (run_per_second_events) {
-    periodic_timer_launch(second_timer, &one_second);
-  } else {
-    periodic_timer_disable(second_timer);
-  }
-}
-
 /** Last time that update_current_time was called. */
 static time_t current_second = 0;
 /** Last time that update_current_time updated current_second. */
@@ -2770,9 +2727,6 @@ do_main_loop(void)
    */
   initialize_periodic_events();
   initialize_mainloop_events();
-
-  /* set up once-a-second callback. */
-  reschedule_per_second_timer();
 
 #ifdef HAVE_SYSTEMD_209
   uint64_t watchdog_delay;
@@ -2958,7 +2912,6 @@ tor_mainloop_free_all(void)
   smartlist_free(connection_array);
   smartlist_free(closeable_connection_lst);
   smartlist_free(active_linked_connection_lst);
-  periodic_timer_free(second_timer);
   teardown_periodic_events();
   tor_event_free(shutdown_did_not_work_event);
   tor_event_free(initialize_periodic_events_event);

--- a/src/core/mainloop/mainloop.c
+++ b/src/core/mainloop/mainloop.c
@@ -1520,7 +1520,8 @@ get_my_roles(const or_options_t *options)
                   options->ControlPort_set ||
                   options->OwningControllerFD != UINT64_MAX;
 
-  int is_net_participant = is_participating_on_network();
+  int is_net_participant = is_participating_on_network() ||
+    is_relay || is_hidden_service;
 
   if (is_bridge) roles |= PERIODIC_EVENT_ROLE_BRIDGE;
   if (is_client) roles |= PERIODIC_EVENT_ROLE_CLIENT;

--- a/src/core/mainloop/mainloop.c
+++ b/src/core/mainloop/mainloop.c
@@ -1384,8 +1384,9 @@ STATIC periodic_event_item_t periodic_events[] = {
   CALLBACK(add_entropy, ALL, 0),
   CALLBACK(heartbeat, ALL, 0),
 
-  /* XXXX Do we have a reason to do this on a callback? */
-  CALLBACK(retry_listeners, ALL, FL(NEED_NET)),
+  /* XXXX Do we have a reason to do this on a callback? Does it do any good at
+   * all?  For now, if we're dormant, we can let our listeners decay. */
+  CALLBACK(retry_listeners, NET_PARTICIPANT, FL(NEED_NET)),
 
   /* We need to do these if we're participating in the Tor network. */
   CALLBACK(check_expired_networkstatus, NET_PARTICIPANT, 0),
@@ -1398,10 +1399,10 @@ STATIC periodic_event_item_t periodic_events[] = {
   CALLBACK(clean_caches, NET_PARTICIPANT, FL(FLUSH_ON_DISABLE)),
   CALLBACK(save_state, NET_PARTICIPANT, FL(FLUSH_ON_DISABLE)),
 
-  /* XXXX investigate this. */
+  /* XXXX investigate this. ??? */
   CALLBACK(write_stats_file, NET_PARTICIPANT, FL(FLUSH_ON_DISABLE)),
 
-  /* XXXX investigate this. */
+  /* XXXX investigate this. ???? */
   CALLBACK(reset_padding_counts, NET_PARTICIPANT, FL(FLUSH_ON_DISABLE)),
 
   /* Routers (bridge and relay) only. */
@@ -1428,13 +1429,13 @@ STATIC periodic_event_item_t periodic_events[] = {
   CALLBACK(check_dns_honesty, RELAY, FL(NEED_NET)),
 
   /* Hidden Service service only. */
-  CALLBACK(hs_service, HS_SERVICE, FL(NEED_NET)),
+  CALLBACK(hs_service, HS_SERVICE, FL(NEED_NET)), // XXXX break this down more
 
   /* Bridge only. */
   CALLBACK(record_bridge_stats, BRIDGE, 0),
 
   /* Client only. */
-  /* XXXX this could be restricted to CLIENT even. */
+  /* XXXX this could be restricted to CLIENT+NET_PARTICIPANT */
   CALLBACK(rend_cache_failure_clean, NET_PARTICIPANT, FL(FLUSH_ON_DISABLE)),
 
   /* Bridge Authority only. */
@@ -1735,18 +1736,24 @@ run_scheduled_events(time_t now)
    * expired; or if our bandwidth limits are exhausted and we
    * should hibernate; or if it's time to wake up from hibernation.
    */
+  // TODO: Refactor or rewrite, or NET_PARTICIPANT. Needs separate wakeup
+  //       handling.
   consider_hibernation(now);
 
   /* Maybe enough time elapsed for us to reconsider a circuit. */
+  // TODO: NET_PARTICIPANT
   circuit_upgrade_circuits_from_guard_wait();
 
   if (options->UseBridges && !net_is_disabled()) {
     /* Note: this check uses net_is_disabled(), not should_delay_dir_fetches()
      * -- the latter is only for fetching consensus-derived directory info. */
+    // TODO: client+NET_PARTICIPANT.
+    //     Also, schedule this rather than probing 1x / sec
     fetch_bridge_descriptors(options, now);
   }
 
   if (accounting_is_enabled(options)) {
+    // TODO: refactor or rewrite; NET_PARTICIPANT
     accounting_run_housekeeping(now);
   }
 
@@ -1757,6 +1764,7 @@ run_scheduled_events(time_t now)
    */
   /* (If our circuit build timeout can ever become lower than a second (which
    * it can't, currently), we should do this more often.) */
+  // TODO: All expire stuff can become NET_PARTICIPANT, FLUSH_ON_DISABLE
   circuit_expire_building();
   circuit_expire_waiting_for_better_guard();
 
@@ -1765,10 +1773,12 @@ run_scheduled_events(time_t now)
    *     Do this before step 4, so we can put them back into pending
    *     state to be picked up by the new circuit.
    */
+  // TODO: All expire stuff can become NET_PARTICIPANT, FLUSH_ON_DISABLE
   connection_ap_expire_beginning();
 
   /* 3c. And expire connections that we've held open for too long.
    */
+  // TODO: All expire stuff can become NET_PARTICIPANT, FLUSH_ON_DISABLE
   connection_expire_held_open();
 
   /* 4. Every second, we try a new circuit if there are no valid
@@ -1778,19 +1788,24 @@ run_scheduled_events(time_t now)
    */
   const int have_dir_info = router_have_minimum_dir_info();
   if (have_dir_info && !net_is_disabled()) {
+    // TODO: NET_PARTICIPANT.
     circuit_build_needed_circs(now);
   } else {
+    // TODO: NET_PARTICIPANT, FLUSH_ON_DISABLE
     circuit_expire_old_circs_as_needed(now);
   }
 
   /* 5. We do housekeeping for each connection... */
+  // TODO: NET_PARTICIPANT
   channel_update_bad_for_new_circs(NULL, 0);
   int i;
   for (i=0;i<smartlist_len(connection_array);i++) {
+    // TODO: NET_PARTICIPANT, FLUSH_ON_DISABLE
     run_connection_housekeeping(i, now);
   }
 
   /* 11b. check pending unconfigured managed proxies */
+  // NET_PARTICIPANT.
   if (!net_is_disabled() && pt_proxies_configuration_pending())
     pt_configure_remaining_proxies();
 }
@@ -2630,6 +2645,7 @@ second_elapsed_callback(periodic_timer_t *timer, void *arg)
    */
   update_current_time(now);
 
+  // TODO XXXX Turn this into a separate event.
   /* Maybe some controller events are ready to fire */
   control_per_second_events();
 

--- a/src/core/mainloop/mainloop.c
+++ b/src/core/mainloop/mainloop.c
@@ -2012,16 +2012,14 @@ check_network_participation_callback(time_t now, const or_options_t *options)
 {
   /* If we're a server, we can't become dormant. */
   if (server_mode(options)) {
-    note_user_activity(now);
-    goto end;
+    goto found_activity;
   }
 
   /* If we're running an onion service, we can't become dormant. */
   /* XXXX this would be nice to change, so that we can be dormant with a
    * service. */
   if (hs_service_get_num_services() || rend_num_services()) {
-    note_user_activity(now);
-    goto end;
+    goto found_activity;
   }
 
   /* XXXX Add an option to never become dormant. */
@@ -2031,9 +2029,12 @@ check_network_participation_callback(time_t now, const or_options_t *options)
    */
   /* XXXX make this configurable? */
   if (connection_get_by_type_nonlinked(CONN_TYPE_AP) != NULL) {
-    note_user_activity(now);
-    goto end;
+    goto found_activity;
   }
+
+  /* XXXX Make this configurable? */
+/** How often do we check whether we have had network activity? */
+#define CHECK_PARTICIPATION_INTERVAL (5*60)
 
   /** Become dormant if there has been no user activity in this long. */
   /* XXXX make this configurable! */
@@ -2043,14 +2044,12 @@ check_network_participation_callback(time_t now, const or_options_t *options)
                " dormant.");
     set_network_participation(false);
     rescan_periodic_events(options);
-    goto end;
   }
 
-/* XXXX Make this configurable? */
-/** How often do we check whether we have had network activity? */
-#define CHECK_PARTICIPATION_INTERVAL (5*60)
+  return CHECK_PARTICIPATION_INTERVAL;
 
- end:
+ found_activity:
+  note_user_activity(now);
   return CHECK_PARTICIPATION_INTERVAL;
 }
 

--- a/src/core/mainloop/mainloop.c
+++ b/src/core/mainloop/mainloop.c
@@ -2680,6 +2680,11 @@ update_current_time(time_t now)
   if (seconds_elapsed < -NUM_JUMPED_SECONDS_BEFORE_WARN) {
     // moving back in time is always a bad sign.
     circuit_note_clock_jumped(seconds_elapsed, false);
+
+    /* Don't go dormant just because we jumped in time. */
+    if (is_participating_on_network()) {
+      reset_user_activity(now);
+    }
   } else if (seconds_elapsed >= NUM_JUMPED_SECONDS_BEFORE_WARN) {
     /* Compare the monotonic clock to the result of time(). */
     const int32_t monotime_msec_passed =
@@ -2700,6 +2705,11 @@ update_current_time(time_t now)
 
     if (clock_jumped || seconds_elapsed >= NUM_IDLE_SECONDS_BEFORE_WARN) {
       circuit_note_clock_jumped(seconds_elapsed, ! clock_jumped);
+    }
+
+    /* Don't go dormant just because we jumped in time. */
+    if (is_participating_on_network()) {
+      reset_user_activity(now);
     }
   } else if (seconds_elapsed > 0) {
     stats_n_seconds_working += seconds_elapsed;

--- a/src/core/mainloop/mainloop.c
+++ b/src/core/mainloop/mainloop.c
@@ -1605,7 +1605,11 @@ rescan_periodic_events(const or_options_t *options)
       periodic_event_enable(item);
     } else {
       log_debug(LD_GENERAL, "Disabling periodic event %s", item->name);
-      periodic_event_disable(item);
+      if (item->flags & PERIODIC_EVENT_FLAG_FLUSH_ON_DISABLE) {
+        periodic_event_flush_and_disable(item);
+      } else {
+        periodic_event_disable(item);
+      }
     }
   }
 }

--- a/src/core/mainloop/mainloop.c
+++ b/src/core/mainloop/mainloop.c
@@ -1391,7 +1391,7 @@ STATIC periodic_event_item_t periodic_events[] = {
   /* This is a legacy catch-all callback that runs once per second if
    * we are online and active. */
   CALLBACK(second_elapsed, NET_PARTICIPANT,
-           FL(NEED_NET)|FL(FLUSH_ON_DISABLE)),
+           FL(NEED_NET)|FL(RUN_ON_DISABLE)),
 
   /* XXXX Do we have a reason to do this on a callback? Does it do any good at
    * all?  For now, if we're dormant, we can let our listeners decay. */
@@ -1406,9 +1406,9 @@ STATIC periodic_event_item_t periodic_events[] = {
 
   /* We need to do these if we're participating in the Tor network, and
    * immediately before we stop. */
-  CALLBACK(clean_caches, NET_PARTICIPANT, FL(FLUSH_ON_DISABLE)),
-  CALLBACK(save_state, NET_PARTICIPANT, FL(FLUSH_ON_DISABLE)),
-  CALLBACK(write_stats_file, NET_PARTICIPANT, FL(FLUSH_ON_DISABLE)),
+  CALLBACK(clean_caches, NET_PARTICIPANT, FL(RUN_ON_DISABLE)),
+  CALLBACK(save_state, NET_PARTICIPANT, FL(RUN_ON_DISABLE)),
+  CALLBACK(write_stats_file, NET_PARTICIPANT, FL(RUN_ON_DISABLE)),
 
   /* Routers (bridge and relay) only. */
   CALLBACK(check_descriptor, ROUTER, FL(NEED_NET)),
@@ -1441,7 +1441,7 @@ STATIC periodic_event_item_t periodic_events[] = {
 
   /* Client only. */
   /* XXXX this could be restricted to CLIENT+NET_PARTICIPANT */
-  CALLBACK(rend_cache_failure_clean, NET_PARTICIPANT, FL(FLUSH_ON_DISABLE)),
+  CALLBACK(rend_cache_failure_clean, NET_PARTICIPANT, FL(RUN_ON_DISABLE)),
 
   /* Bridge Authority only. */
   CALLBACK(write_bridge_ns, BRIDGEAUTH, 0),
@@ -1656,7 +1656,7 @@ rescan_periodic_events(const or_options_t *options)
       periodic_event_enable(item);
     } else {
       log_debug(LD_GENERAL, "Disabling periodic event %s", item->name);
-      if (item->flags & PERIODIC_EVENT_FLAG_FLUSH_ON_DISABLE) {
+      if (item->flags & PERIODIC_EVENT_FLAG_RUN_ON_DISABLE) {
         periodic_event_flush_and_disable(item);
       } else {
         periodic_event_disable(item);
@@ -1819,7 +1819,7 @@ second_elapsed_callback(time_t now, const or_options_t *options)
    */
   /* (If our circuit build timeout can ever become lower than a second (which
    * it can't, currently), we should do this more often.) */
-  // TODO: All expire stuff can become NET_PARTICIPANT, FLUSH_ON_DISABLE
+  // TODO: All expire stuff can become NET_PARTICIPANT, RUN_ON_DISABLE
   circuit_expire_building();
   circuit_expire_waiting_for_better_guard();
 

--- a/src/core/mainloop/mainloop.c
+++ b/src/core/mainloop/mainloop.c
@@ -1518,8 +1518,7 @@ get_my_roles(const or_options_t *options)
                   options->ControlPort_set ||
                   options->OwningControllerFD != UINT64_MAX;
 
-  /* We actually want a better definition here for our work on dormancy. */
-  int is_net_participant = ! net_is_disabled();
+  int is_net_participant = is_participating_on_network();
 
   if (is_bridge) roles |= PERIODIC_EVENT_ROLE_BRIDGE;
   if (is_client) roles |= PERIODIC_EVENT_ROLE_CLIENT;
@@ -1595,6 +1594,30 @@ teardown_periodic_events(void)
     periodic_event_destroy(&periodic_events[i]);
   }
   periodic_events_initialized = 0;
+}
+
+static mainloop_event_t *rescan_periodic_events_ev = NULL;
+
+/** Callback: rescan the periodic event list. */
+static void
+rescan_periodic_events_cb(mainloop_event_t *event, void *arg)
+{
+  (void)event;
+  (void)arg;
+  rescan_periodic_events(get_options());
+}
+
+/**
+ * Schedule an event that will rescan which periodic events should run.
+ **/
+void
+schedule_rescan_periodic_events(void)
+{
+  if (!rescan_periodic_events_ev) {
+    rescan_periodic_events_ev =
+      mainloop_event_new(rescan_periodic_events_cb, NULL);
+  }
+  mainloop_event_activate(rescan_periodic_events_ev);
 }
 
 /** Do a pass at all our periodic events, disable those we don't need anymore
@@ -2719,6 +2742,12 @@ initialize_mainloop_events(void)
 int
 do_main_loop(void)
 {
+  /* For now, starting Tor always counts as user activity. Later, we might
+   * have an option to control this.
+   */
+  reset_user_activity(approx_time());
+  set_network_participation(true);
+
   /* initialize the periodic events first, so that code that depends on the
    * events being present does not assert.
    */
@@ -2917,6 +2946,7 @@ tor_mainloop_free_all(void)
   mainloop_event_free(postloop_cleanup_ev);
   mainloop_event_free(handle_deferred_signewnym_ev);
   mainloop_event_free(scheduled_shutdown_ev);
+  mainloop_event_free(rescan_periodic_events_ev);
 
 #ifdef HAVE_SYSTEMD_209
   periodic_timer_free(systemd_watchdog_timer);

--- a/src/core/mainloop/mainloop.c
+++ b/src/core/mainloop/mainloop.c
@@ -1382,16 +1382,27 @@ CALLBACK(write_stats_file);
 STATIC periodic_event_item_t periodic_events[] = {
   /* Everyone needs to run those. */
   CALLBACK(add_entropy, ALL, 0),
-  CALLBACK(check_expired_networkstatus, ALL, 0),
-  CALLBACK(clean_caches, ALL, 0),
-  CALLBACK(fetch_networkstatus, ALL, 0),
   CALLBACK(heartbeat, ALL, 0),
-  CALLBACK(launch_descriptor_fetches, ALL, FL(NEED_NET)),
-  CALLBACK(reset_padding_counts, ALL, 0),
+
+  /* XXXX Do we have a reason to do this on a callback? */
   CALLBACK(retry_listeners, ALL, FL(NEED_NET)),
-  CALLBACK(save_state, ALL, 0),
-  CALLBACK(rotate_x509_certificate, ALL, 0),
-  CALLBACK(write_stats_file, ALL, 0),
+
+  /* We need to do these if we're participating in the Tor network. */
+  CALLBACK(check_expired_networkstatus, NET_PARTICIPANT, 0),
+  CALLBACK(fetch_networkstatus, NET_PARTICIPANT, 0),
+  CALLBACK(launch_descriptor_fetches, NET_PARTICIPANT, FL(NEED_NET)),
+  CALLBACK(rotate_x509_certificate, NET_PARTICIPANT, 0),
+
+  /* We need to do these if we're participating in the Tor network, and
+   * immediately before we stop. */
+  CALLBACK(clean_caches, NET_PARTICIPANT, FL(FLUSH_ON_DISABLE)),
+  CALLBACK(save_state, NET_PARTICIPANT, FL(FLUSH_ON_DISABLE)),
+
+  /* XXXX investigate this. */
+  CALLBACK(write_stats_file, NET_PARTICIPANT, FL(FLUSH_ON_DISABLE)),
+
+  /* XXXX investigate this. */
+  CALLBACK(reset_padding_counts, NET_PARTICIPANT, FL(FLUSH_ON_DISABLE)),
 
   /* Routers (bridge and relay) only. */
   CALLBACK(check_descriptor, ROUTER, FL(NEED_NET)),
@@ -1423,7 +1434,8 @@ STATIC periodic_event_item_t periodic_events[] = {
   CALLBACK(record_bridge_stats, BRIDGE, 0),
 
   /* Client only. */
-  CALLBACK(rend_cache_failure_clean, CLIENT, 0),
+  /* XXXX this could be restricted to CLIENT even. */
+  CALLBACK(rend_cache_failure_clean, NET_PARTICIPANT, FL(FLUSH_ON_DISABLE)),
 
   /* Bridge Authority only. */
   CALLBACK(write_bridge_ns, BRIDGEAUTH, 0),
@@ -1482,7 +1494,7 @@ get_my_roles(const or_options_t *options)
 {
   tor_assert(options);
 
-  int roles = 0;
+  int roles = PERIODIC_EVENT_ROLE_ALL;
   int is_bridge = options->BridgeRelay;
   int is_relay = server_mode(options);
   int is_dirauth = authdir_mode_v3(options);
@@ -1497,6 +1509,9 @@ get_my_roles(const or_options_t *options)
                   options->ControlPort_set ||
                   options->OwningControllerFD != UINT64_MAX;
 
+  /* We actually want a better definition here for our work on dormancy. */
+  int is_net_participant = ! net_is_disabled();
+
   if (is_bridge) roles |= PERIODIC_EVENT_ROLE_BRIDGE;
   if (is_client) roles |= PERIODIC_EVENT_ROLE_CLIENT;
   if (is_relay) roles |= PERIODIC_EVENT_ROLE_RELAY;
@@ -1504,6 +1519,7 @@ get_my_roles(const or_options_t *options)
   if (is_bridgeauth) roles |= PERIODIC_EVENT_ROLE_BRIDGEAUTH;
   if (is_hidden_service) roles |= PERIODIC_EVENT_ROLE_HS_SERVICE;
   if (is_dirserver) roles |= PERIODIC_EVENT_ROLE_DIRSERVER;
+  if (is_net_participant) roles |= PERIODIC_EVENT_ROLE_NET_PARTICIPANT;
 
   return roles;
 }

--- a/src/core/mainloop/mainloop.h
+++ b/src/core/mainloop/mainloop.h
@@ -86,6 +86,8 @@ void reschedule_per_second_timer(void);
 void do_signewnym(time_t);
 time_t get_last_signewnym_time(void);
 
+void mainloop_schedule_shutdown(int delay_sec);
+
 void tor_init_connection_lists(void);
 void initialize_mainloop_events(void);
 void tor_mainloop_free_all(void);

--- a/src/core/mainloop/mainloop.h
+++ b/src/core/mainloop/mainloop.h
@@ -81,7 +81,6 @@ uint64_t get_main_loop_error_count(void);
 uint64_t get_main_loop_idle_count(void);
 
 void periodic_events_on_new_options(const or_options_t *options);
-void reschedule_per_second_timer(void);
 
 void do_signewnym(time_t);
 time_t get_last_signewnym_time(void);

--- a/src/core/mainloop/mainloop.h
+++ b/src/core/mainloop/mainloop.h
@@ -65,6 +65,7 @@ void reschedule_or_state_save(void);
 void reschedule_dirvote(const or_options_t *options);
 void mainloop_schedule_postloop_cleanup(void);
 void rescan_periodic_events(const or_options_t *options);
+void schedule_rescan_periodic_events(void);
 
 void update_current_time(time_t now);
 

--- a/src/core/mainloop/netstatus.c
+++ b/src/core/mainloop/netstatus.c
@@ -51,8 +51,8 @@ note_user_activity(time_t now)
   last_user_activity_seen = MAX(now, last_user_activity_seen);
 
   if (! participating_on_network) {
-    participating_on_network = true;
     log_notice(LD_GENERAL, "Tor is no longer dormant.");
+    set_network_participation(true);
     schedule_rescan_periodic_events();
   }
 }

--- a/src/core/mainloop/netstatus.c
+++ b/src/core/mainloop/netstatus.c
@@ -58,8 +58,11 @@ note_user_activity(time_t now)
 }
 
 /**
- * As note_user_activity, but sets the time without checking whether it is in
- * the past, and without causing any rescan.
+ * Change the time at which "user activitiy" was last seen to <b>now</b>.
+ *
+ * Unlike note_user_actity, this function sets the time without checking
+ * whether it is in the past, and without causing any rescan of periodic events
+ * or change in participation status.
  */
 void
 reset_user_activity(time_t now)

--- a/src/core/mainloop/netstatus.c
+++ b/src/core/mainloop/netstatus.c
@@ -42,8 +42,10 @@ static bool participating_on_network = false;
 
 /**
  * Record the fact that we have seen "user activity" at the time now.  Move
- * "last activity seen" time forwards, but never backwards.  Launch periodic
- * events if we were previously not participating on the network.
+ * "last activity seen" time forwards, but never backwards.
+ *
+ * If we were previously not participating on the network, set our
+ * participation status to true, and launch periodic events as appropriate.
  **/
 void
 note_user_activity(time_t now)

--- a/src/core/mainloop/netstatus.h
+++ b/src/core/mainloop/netstatus.h
@@ -10,4 +10,11 @@
 int net_is_disabled(void);
 int net_is_completely_disabled(void);
 
+void note_user_activity(time_t now);
+void reset_user_activity(time_t now);
+time_t get_last_user_activity_time(void);
+
+void set_network_participation(bool participation);
+bool is_participating_on_network(void);
+
 #endif

--- a/src/core/mainloop/periodic.c
+++ b/src/core/mainloop/periodic.c
@@ -174,7 +174,7 @@ periodic_event_disable(periodic_event_item_t *event)
  * Do nothing if the event was already disabled.
  */
 void
-periodic_event_flush_and_disable(periodic_event_item_t *event)
+periodic_event_schedule_and_disable(periodic_event_item_t *event)
 {
   tor_assert(event);
   if (!periodic_event_is_enabled(event))

--- a/src/core/mainloop/periodic.c
+++ b/src/core/mainloop/periodic.c
@@ -45,10 +45,6 @@ periodic_event_dispatch(mainloop_event_t *ev, void *data)
   periodic_event_item_t *event = data;
   tor_assert(ev == event->ev);
 
-  if (BUG(!periodic_event_is_enabled(event))) {
-    return;
-  }
-
   time_t now = time(NULL);
   update_current_time(now);
   const or_options_t *options = get_options();
@@ -57,7 +53,7 @@ periodic_event_dispatch(mainloop_event_t *ev, void *data)
   int next_interval = 0;
 
   if (!periodic_event_is_enabled(event)) {
-    /* The event got disabled from inside its callback; no need to
+    /* The event got disabled from inside its callback, or before: no need to
      * reschedule. */
     return;
   }
@@ -171,4 +167,20 @@ periodic_event_disable(periodic_event_item_t *event)
   }
   mainloop_event_cancel(event->ev);
   event->enabled = 0;
+}
+
+/**
+ * Disable an event, then schedule it to run once.
+ * Do nothing if the event was already disabled.
+ */
+void
+periodic_event_flush_and_disable(periodic_event_item_t *event)
+{
+  tor_assert(event);
+  if (!periodic_event_is_enabled(event))
+    return;
+
+  periodic_event_disable(event);
+
+  mainloop_event_activate(event->ev);
 }

--- a/src/core/mainloop/periodic.h
+++ b/src/core/mainloop/periodic.h
@@ -16,6 +16,9 @@
 #define PERIODIC_EVENT_ROLE_HS_SERVICE  (1U << 5)
 #define PERIODIC_EVENT_ROLE_DIRSERVER   (1U << 6)
 
+#define PERIODIC_EVENT_ROLE_NET_PARTICIPANT (1U << 7)
+#define PERIODIC_EVENT_ROLE_ALL         (1U << 8)
+
 /* Helper macro to make it a bit less annoying to defined groups of roles that
  * are often used. */
 
@@ -25,10 +28,6 @@
 /* Authorities that is both bridge and directory. */
 #define PERIODIC_EVENT_ROLE_AUTHORITIES \
   (PERIODIC_EVENT_ROLE_BRIDGEAUTH | PERIODIC_EVENT_ROLE_DIRAUTH)
-/* All roles. */
-#define PERIODIC_EVENT_ROLE_ALL \
-  (PERIODIC_EVENT_ROLE_AUTHORITIES | PERIODIC_EVENT_ROLE_CLIENT | \
-   PERIODIC_EVENT_ROLE_HS_SERVICE | PERIODIC_EVENT_ROLE_ROUTER)
 
 /*
  * Event flags which can change the behavior of an event.

--- a/src/core/mainloop/periodic.h
+++ b/src/core/mainloop/periodic.h
@@ -15,9 +15,10 @@
 #define PERIODIC_EVENT_ROLE_BRIDGEAUTH  (1U << 4)
 #define PERIODIC_EVENT_ROLE_HS_SERVICE  (1U << 5)
 #define PERIODIC_EVENT_ROLE_DIRSERVER   (1U << 6)
+#define PERIODIC_EVENT_ROLE_CONTROLEV   (1U << 7)
 
-#define PERIODIC_EVENT_ROLE_NET_PARTICIPANT (1U << 7)
-#define PERIODIC_EVENT_ROLE_ALL         (1U << 8)
+#define PERIODIC_EVENT_ROLE_NET_PARTICIPANT (1U << 8)
+#define PERIODIC_EVENT_ROLE_ALL         (1U << 9)
 
 /* Helper macro to make it a bit less annoying to defined groups of roles that
  * are often used. */

--- a/src/core/mainloop/periodic.h
+++ b/src/core/mainloop/periodic.h
@@ -39,6 +39,11 @@
  * the net_is_disabled() check. */
 #define PERIODIC_EVENT_FLAG_NEED_NET  (1U << 0)
 
+/* Indicate that it the event is enabled, it event needs to be run once before
+ * it becomes disabled.
+ */
+#define PERIODIC_EVENT_FLAG_FLUSH_ON_DISABLE  (1U << 1)
+
 /** Callback function for a periodic event to take action.  The return value
 * influences the next time the function will get called.  Return
 * PERIODIC_EVENT_NO_UPDATE to not update <b>last_action_time</b> and be polled
@@ -83,6 +88,6 @@ void periodic_event_destroy(periodic_event_item_t *event);
 void periodic_event_reschedule(periodic_event_item_t *event);
 void periodic_event_enable(periodic_event_item_t *event);
 void periodic_event_disable(periodic_event_item_t *event);
+void periodic_event_flush_and_disable(periodic_event_item_t *event);
 
 #endif /* !defined(TOR_PERIODIC_H) */
-

--- a/src/core/mainloop/periodic.h
+++ b/src/core/mainloop/periodic.h
@@ -39,10 +39,10 @@
  * the net_is_disabled() check. */
 #define PERIODIC_EVENT_FLAG_NEED_NET  (1U << 0)
 
-/* Indicate that it the event is enabled, it event needs to be run once before
+/* Indicate that if the event is enabled, it needs to be run once before
  * it becomes disabled.
  */
-#define PERIODIC_EVENT_FLAG_FLUSH_ON_DISABLE  (1U << 1)
+#define PERIODIC_EVENT_FLAG_RUN_ON_DISABLE  (1U << 1)
 
 /** Callback function for a periodic event to take action.  The return value
 * influences the next time the function will get called.  Return

--- a/src/core/mainloop/periodic.h
+++ b/src/core/mainloop/periodic.h
@@ -88,6 +88,6 @@ void periodic_event_destroy(periodic_event_item_t *event);
 void periodic_event_reschedule(periodic_event_item_t *event);
 void periodic_event_enable(periodic_event_item_t *event);
 void periodic_event_disable(periodic_event_item_t *event);
-void periodic_event_flush_and_disable(periodic_event_item_t *event);
+void periodic_event_schedule_and_disable(periodic_event_item_t *event);
 
 #endif /* !defined(TOR_PERIODIC_H) */

--- a/src/core/or/or.h
+++ b/src/core/or/or.h
@@ -97,6 +97,8 @@ struct curve25519_public_key_t;
 #define SIGNEWNYM 129
 #define SIGCLEARDNSCACHE 130
 #define SIGHEARTBEAT 131
+#define SIGACTIVE 132
+#define SIGDORMANT 133
 
 #if (SIZEOF_CELL_T != 0)
 /* On Irix, stdlib.h defines a cell_t type, so we need to make sure

--- a/src/feature/client/dnsserv.c
+++ b/src/feature/client/dnsserv.c
@@ -28,6 +28,7 @@
 #include "core/or/connection_edge.h"
 #include "feature/control/control.h"
 #include "core/mainloop/mainloop.h"
+#include "core/mainloop/netstatus.h"
 #include "core/or/policies.h"
 
 #include "feature/control/control_connection_st.h"
@@ -212,6 +213,9 @@ dnsserv_launch_request(const char *name, int reverse,
   entry_connection_t *entry_conn;
   edge_connection_t *conn;
   char *q_name;
+
+  /* Launching a request for a user counts as user activity. */
+  note_user_activity(approx_time());
 
   /* Make a new dummy AP connection, and attach the request to it. */
   entry_conn = entry_connection_new(CONN_TYPE_AP, AF_INET);

--- a/src/feature/control/control.c
+++ b/src/feature/control/control.c
@@ -1681,6 +1681,8 @@ static const struct signal_t signal_table[] = {
   { SIGNEWNYM, "NEWNYM" },
   { SIGCLEARDNSCACHE, "CLEARDNSCACHE"},
   { SIGHEARTBEAT, "HEARTBEAT"},
+  { SIGACTIVE, "ACTIVE" },
+  { SIGDORMANT, "DORMANT" },
   { 0, NULL },
 };
 

--- a/src/feature/control/control.c
+++ b/src/feature/control/control.c
@@ -368,7 +368,7 @@ control_update_global_event_mask(void)
     control_get_bytes_rw_last_sec(&r, &w);
   }
   if (any_old_per_sec_events != control_any_per_second_event_enabled()) {
-    reschedule_per_second_timer();
+    rescan_periodic_events(get_options());
   }
 
 #undef NEWLY_ENABLED

--- a/src/feature/hibernate/hibernate.c
+++ b/src/feature/hibernate/hibernate.c
@@ -66,8 +66,9 @@ static hibernate_state_t hibernate_state = HIBERNATE_STATE_INITIAL;
 /** If are hibernating, when do we plan to wake up? Set to 0 if we
  * aren't hibernating. */
 static time_t hibernate_end_time = 0;
-/** If we are shutting down, when do we plan finally exit? Set to 0 if
- * we aren't shutting down. */
+/** If we are shutting down, when do we plan finally exit? Set to 0 if we
+ * aren't shutting down. (This is obsolete; scheduled shutdowns are supposed
+ * to happen from mainloop_schedule_shutdown() now.) */
 static time_t shutdown_time = 0;
 
 /** A timed event that we'll use when it's time to wake up from
@@ -867,7 +868,13 @@ hibernate_begin(hibernate_state_t new_state, time_t now)
     log_notice(LD_GENERAL,"Interrupt: we have stopped accepting new "
                "connections, and will shut down in %d seconds. Interrupt "
                "again to exit now.", options->ShutdownWaitLength);
-    shutdown_time = time(NULL) + options->ShutdownWaitLength;
+    /* We add an arbitrary delay here so that even if something goes wrong
+     * with the mainloop shutdown code, we can still shutdown from
+     * consider_hibernation() if we call it... but so that the
+     * mainloop_schedule_shutdown() mechanism will be the first one called.
+     */
+    shutdown_time = time(NULL) + options->ShutdownWaitLength + 5;
+    mainloop_schedule_shutdown(options->ShutdownWaitLength);
 #ifdef HAVE_SYSTEMD
     /* tell systemd that we may need more than the default 90 seconds to shut
      * down so they don't kill us. add some extra time to actually finish
@@ -1096,11 +1103,12 @@ consider_hibernation(time_t now)
   hibernate_state_t prev_state = hibernate_state;
 
   /* If we're in 'exiting' mode, then we just shut down after the interval
-   * elapses. */
+   * elapses.  The mainloop was supposed to catch this via
+   * mainloop_schedule_shutdown(), but apparently it didn't. */
   if (hibernate_state == HIBERNATE_STATE_EXITING) {
     tor_assert(shutdown_time);
     if (shutdown_time <= now) {
-      log_notice(LD_GENERAL, "Clean shutdown finished. Exiting.");
+      log_notice(LD_BUG, "Mainloop did not catch shutdown event; exiting.");
       tor_shutdown_event_loop_and_exit(0);
     }
     return; /* if exiting soon, don't worry about bandwidth limits */
@@ -1112,7 +1120,7 @@ consider_hibernation(time_t now)
     if (hibernate_end_time > now && accounting_enabled) {
       /* If we're hibernating, don't wake up until it's time, regardless of
        * whether we're in a new interval. */
-      return ;
+      return;
     } else {
       hibernate_end_time_elapsed(now);
     }

--- a/src/feature/hibernate/hibernate.c
+++ b/src/feature/hibernate/hibernate.c
@@ -1248,8 +1248,6 @@ on_hibernate_state_change(hibernate_state_t prev_state)
   if (prev_state != HIBERNATE_STATE_INITIAL) {
     rescan_periodic_events(get_options());
   }
-
-  reschedule_per_second_timer();
 }
 
 /** Free all resources held by the accounting module */

--- a/src/test/test_compat_libevent.c
+++ b/src/test/test_compat_libevent.c
@@ -187,4 +187,3 @@ struct testcase_t compat_libevent_tests[] = {
     TT_FORK, NULL, NULL },
   END_OF_TESTCASES
 };
-

--- a/src/test/test_periodic_event.c
+++ b/src/test/test_periodic_event.c
@@ -172,7 +172,8 @@ test_pe_launch(void *arg)
 
   for (int i = 0; periodic_events[i].name; ++i) {
     periodic_event_item_t *item = &periodic_events[i];
-    tt_int_op(periodic_event_is_enabled(item), OP_EQ, 1);
+    tt_int_op(periodic_event_is_enabled(item), OP_EQ,
+              (item->roles != PERIODIC_EVENT_ROLE_CONTROLEV));
   }
 
  done:

--- a/src/test/test_periodic_event.c
+++ b/src/test/test_periodic_event.c
@@ -51,6 +51,8 @@ test_pe_initialize(void *arg)
    * need to run the main loop and then wait for a second delaying the unit
    * tests. Instead, we'll test the callback work indepedently elsewhere. */
   initialize_periodic_events();
+  set_network_participation(false);
+  rescan_periodic_events(get_options());
 
   /* Validate that all events have been set up. */
   for (int i = 0; periodic_events[i].name; ++i) {
@@ -82,6 +84,8 @@ test_pe_launch(void *arg)
    * network gets enabled. */
   consider_hibernation(time(NULL));
 
+  set_network_participation(true);
+
   /* Hack: We'll set a dumb fn() of each events so they don't get called when
    * dispatching them. We just want to test the state of the callbacks, not
    * the whole code path. */
@@ -93,6 +97,7 @@ test_pe_launch(void *arg)
   options = get_options_mutable();
   options->SocksPort_set = 1;
   periodic_events_on_new_options(options);
+
 #if 0
   /* Lets make sure that before intialization, we can't scan the periodic
    * events list and launch them. Lets try by being a Client. */
@@ -148,6 +153,7 @@ test_pe_launch(void *arg)
   options->SocksPort_set = 0;
   options->ORPort_set = 0;
   options->DisableNetwork = 1;
+  set_network_participation(false);
   periodic_events_on_new_options(options);
 
   for (int i = 0; periodic_events[i].name; ++i) {
@@ -162,6 +168,7 @@ test_pe_launch(void *arg)
   options->BridgeRelay = 1; options->AuthoritativeDir = 1;
   options->V3AuthoritativeDir = 1; options->BridgeAuthoritativeDir = 1;
   options->DisableNetwork = 0;
+  set_network_participation(true);
   register_dummy_hidden_service(&service);
   periodic_events_on_new_options(options);
   /* Note down the reference because we need to remove this service from the
@@ -195,8 +202,10 @@ test_pe_get_roles(void *arg)
 
   or_options_t *options = get_options_mutable();
   tt_assert(options);
+  set_network_participation(true);
 
-  const int ALL = PERIODIC_EVENT_ROLE_ALL;
+  const int ALL = PERIODIC_EVENT_ROLE_ALL |
+    PERIODIC_EVENT_ROLE_NET_PARTICIPANT;
 
   /* Nothing configured, should be no roles. */
   tt_assert(net_is_disabled());


### PR DESCRIPTION
The idea here is to make a state where the network is still enabled, but we don't run periodic events or directory fetches or circuit builds.