### PR TITLE
bug28435 Fix Doxyfile for 0.3.5 source tree moves

### DIFF
--- a/Doxyfile.in
+++ b/Doxyfile.in
@@ -555,7 +555,7 @@ FILE_PATTERNS          = *.c \
 # should be searched for input files as well. Possible values are YES and NO.
 # If left blank NO is used.
 
-RECURSIVE              = NO
+RECURSIVE              = YES
 
 # The EXCLUDE tag can be used to specify files and/or directories that should
 # excluded from the INPUT source files. This way you can easily exclude a

--- a/changes/bug28435
+++ b/changes/bug28435
@@ -1,0 +1,3 @@
+  o Minor bugfixes (documentation):
+    - Make Doxygen work again after the 0.3.5 source tree moves.
+      Fixes bug 28435; bugfix on 0.3.5.1-alpha.


### PR DESCRIPTION
Make Doxygen work again after the 0.3.5 source tree moves.  Fixes bug
28435; bugfix on 0.3.5.1-alpha.