### PR TITLE
28441: log: stop talking about the Named flag in log messages

### DIFF
--- a/changes/bug28441
+++ b/changes/bug28441
@@ -1,0 +1,4 @@
+  o Minor bugfixes (logging):
+    - Stop talking about the Named flag in log messages. Clients have
+      ignored the Named flag since 0.3.2. Fixes bug 28441;
+      bugfix on 0.3.2.1-alpha.

--- a/src/feature/nodelist/nodelist.c
+++ b/src/feature/nodelist/nodelist.c
@@ -1019,8 +1019,7 @@ node_get_by_nickname,(const char *nickname, unsigned flags))
       } SMARTLIST_FOREACH_END(node);
 
       if (any_unwarned) {
-        log_warn(LD_CONFIG, "There are multiple matches for the name %s, "
-                 "but none is listed as Named in the directory consensus. "
+        log_warn(LD_CONFIG, "There are multiple matches for the name %s. "
                  "Choosing one arbitrarily.", nickname);
       }
     } else if (smartlist_len(matches)==1 && warn_if_unnamed) {


### PR DESCRIPTION
Clients have ignored the Named flag since 0.3.2.

Fixes bug 28441; bugfix on 0.3.2.1-alpha.