### PR TITLE
Appveyor: always show the logs, and upload them as build artifacts

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -60,7 +60,7 @@ test_script:
             Execute-Bash "VERBOSE=1 make -j2 check"
     }
 
-on_failure:
+on_finish:
 - ps: >-
     if ($env:compiler -eq "mingw") {
             $oldpath = ${env:Path} -split ';'
@@ -73,4 +73,6 @@ on_failure:
             Execute-Bash "tail -1000 config.log || true"
             Execute-Bash "cat test-suite.log || true"
     }
+
+on_failure:
 - cmd: C:\Python27\python.exe %APPVEYOR_BUILD_FOLDER%\scripts\test\appveyor-irc-notify.py irc.oftc.net:6697 tor-ci failure

--- a/changes/ticket28459
+++ b/changes/ticket28459
@@ -1,0 +1,4 @@
+  o Minor features (continuous integration, Windows):
+    - Always show the configure and test logs, and upload them as build
+      artifacts, when building for Windows using Appveyor CI.
+      Implements 28459.


### PR DESCRIPTION
Always show the configure and test logs, and upload them as build
artifacts, when building for Windows using Appveyor CI.

Implements 28459.