### PR TITLE
Bug #28485: Add missing library to build tor-print-ed-signing-cert.

### DIFF
--- a/changes/bug28485
+++ b/changes/bug28485
@@ -1,0 +1,3 @@
+  o Minor bugfixes (compilation):
+    - Add missing dependency on libgdi32.dll for tor-print-ed-signing-cert.exe
+      on Windows. Fixes bug 28485; bugfix on 0.3.5.1-alpha.

--- a/src/tools/include.am
+++ b/src/tools/include.am
@@ -41,7 +41,7 @@ src_tools_tor_print_ed_signing_cert_LDADD = \
         $(TOR_CRYPTO_LIBS) \
         $(TOR_UTIL_LIBS) \
 	@TOR_LIB_MATH@ $(TOR_LIBS_CRYPTLIB) \
-	@TOR_LIB_WS32@ @TOR_LIB_USERENV@
+	@TOR_LIB_WS32@ @TOR_LIB_USERENV@ @TOR_LIB_GDI@
 
 if USE_NSS
 # ...


### PR DESCRIPTION
To succesful compile tor-print-ed-signing-cert.exe on Windows we
sometimes need to include the @TOR_LIB_GDI@ library.

See: https://bugs.torproject.org/28485