### PR TITLE
bug28524 Update control_free_all() for #27169

### DIFF
--- a/changes/bug28524
+++ b/changes/bug28524
@@ -1,0 +1,4 @@
+  o Minor bugfixes (restart-in-process, boostrap):
+    - Add missing resets of bootstrap tracking state when shutting
+      down (regression caused by ticket 27169).  Fixes bug 28524;
+      bugfix on 0.3.5.1-alpha.

--- a/src/feature/control/control.c
+++ b/src/feature/control/control.c
@@ -7880,8 +7880,12 @@ control_free_all(void)
     flush_queued_events_event = NULL;
   }
   bootstrap_percent = BOOTSTRAP_STATUS_UNDEF;
+  bootstrap_phase = BOOTSTRAP_STATUS_UNDEF;
   notice_bootstrap_percent = 0;
   bootstrap_problems = 0;
+  bootstrap_first_orconn = 0;
+  bootstrap_dir_progress = BOOTSTRAP_STATUS_UNDEF;
+  bootstrap_dir_phase = BOOTSTRAP_STATUS_UNDEF;
   authentication_cookie_is_set = 0;
   global_event_mask = 0;
   disable_log_messages = 0;


### PR DESCRIPTION
Reset the added bootstrap tracking state introduced by ticket 27169.
Fixes bug 28524; bugfix on 0.3.5.1-alpha.