### PR TITLE
Test: Fix memory leaks and missing unmocks in entry guard tests

### DIFF
--- a/changes/bug28554
+++ b/changes/bug28554
@@ -1,0 +1,3 @@
+  o Minor bugfixes (unit tests, guard selection):
+    - Stop leaking memory in an entry guard unit test. Fixes bug 28554;
+      bugfix on 0.3.0.1-alpha.

--- a/src/test/test_entrynodes.c
+++ b/src/test/test_entrynodes.c
@@ -2779,13 +2779,16 @@ test_entry_guard_outdated_dirserver_exclusion(void *arg)
                                   digests, 3, 7, 0);
 
     /* ... and check that because we failed to fetch microdescs from all our
-     * primaries, we didnt end up selecting a primary for fetching dir info */
+     * primaries, we didn't end up selecting a primary for fetching dir info */
     expect_log_msg_containing("No primary or confirmed guards available.");
     teardown_capture_of_logs();
   }
 
  done:
+  UNMOCK(networkstatus_get_latest_consensus_by_flavor);
+  UNMOCK(directory_initiate_request);
   smartlist_free(digests);
+  tor_free(mock_ns_val);
   tor_free(args);
   if (conn) {
     tor_free(conn->requested_resource);


### PR DESCRIPTION
test_entry_guard_outdated_dirserver_exclusion leaks memory, and is
missing some unmocks.

Fixes 28554; bugfix on 0.3.0.1-alpha.