### PR TITLE
Create a temporary directory for tor's DataDirectory in test_rebind.

### DIFF
--- a/src/test/test_rebind.py
+++ b/src/test/test_rebind.py
@@ -67,12 +67,19 @@ socks_port = pick_random_port()
 assert control_port != 0
 assert socks_port != 0
 
+if len(sys.argv) < 3:
+     fail('Usage: %s <path-to-tor> <data-dir>' % sys.argv[0])
+
 if not os.path.exists(sys.argv[1]):
     fail('ERROR: cannot find tor at %s' % sys.argv[1])
+if not os.path.exists(sys.argv[2]):
+    fail('ERROR: cannot find datadir at %s' % sys.argv[2])
 
 tor_path = sys.argv[1]
+data_dir = sys.argv[2]
 
 tor_process = subprocess.Popen([tor_path,
+                               '-DataDirectory', data_dir,
                                '-ControlPort', '127.0.0.1:{}'.format(control_port),
                                '-SOCKSPort', '127.0.0.1:{}'.format(socks_port),
                                '-FetchServerDescriptors', '0'],
@@ -81,9 +88,6 @@ tor_process = subprocess.Popen([tor_path,
 
 if tor_process == None:
     fail('ERROR: running tor failed')
-
-if len(sys.argv) < 2:
-     fail('Usage: %s <path-to-tor>' % sys.argv[0])
 
 wait_for_log('Opened Control listener on')
 

--- a/src/test/test_rebind.sh
+++ b/src/test/test_rebind.sh
@@ -14,6 +14,19 @@ fi
 
 exitcode=0
 
-"${PYTHON:-python}" "${abs_top_srcdir:-.}/src/test/test_rebind.py" "${TESTING_TOR_BINARY}" || exitcode=1
+tmpdir=
+clean () { test -n "$tmpdir" && test -d "$tmpdir" && rm -rf "$tmpdir" || :; }
+trap clean EXIT HUP INT TERM
+
+tmpdir="`mktemp -d -t tor_rebind_test.XXXXXX`"
+if [ -z "$tmpdir" ]; then
+  echo >&2 mktemp failed
+  exit 2
+elif [ ! -d "$tmpdir" ]; then
+  echo >&2 mktemp failed to make a directory
+  exit 3
+fi
+
+"${PYTHON:-python}" "${abs_top_srcdir:-.}/src/test/test_rebind.py" "${TESTING_TOR_BINARY}" "$tmpdir" || exitcode=1
 
 exit ${exitcode}


### PR DESCRIPTION
Fixes #28562.

While here, put the argument count test and usage message _before_ we
attempt to read from sys.argv.