### PR TITLE
hs-v3: Do not close RP circuits when deleting an ephemeral service

### DIFF
--- a/changes/bug28619
+++ b/changes/bug28619
@@ -1,0 +1,6 @@
+  o Minor bugfixes (hidden service v3):
+    - When deleting an ephemeral onion service (DEL_ONION), do not close any
+      rendezvous circuits in order to let the existing client connections
+      finish by themselves or closed by the application. The HS v2 is doing
+      that already so now we have the same behavior for all versions. Fixes
+      bug 28619; bugfix on 0.3.3.1-alpha.

--- a/src/or/hs_service.c
+++ b/src/or/hs_service.c
@@ -3105,8 +3105,10 @@ hs_service_del_ephemeral(const char *address)
     goto err;
   }
 
-  /* Close circuits, remove from map and finally free. */
-  close_service_circuits(service);
+  /* Close introduction circuits, remove from map and finally free. Notice
+   * that the rendezvous circuits aren't closed in order for any existing
+   * connections to finish. We let the application terminate them. */
+  close_service_intro_circuits(service);
   remove_service(hs_service_map, service);
   hs_service_free(service);
 


### PR DESCRIPTION
Bug reported on tor-dev@ and here is the detail explanation of the issue:
https://lists.torproject.org/pipermail/tor-dev/2018-November/013558.html

Fixes bug #28619

Signed-off-by: David Goulet <dgoulet@torproject.org>