### PR TITLE
#28574 for 0.3.4: Explicitly specify path to OpenSSL for Appveyor.

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -34,7 +34,7 @@ install:
      #
      # Use pacman --debug to show package downloads and install locations
      #>
-    Execute-Command "C:\msys64\usr\bin\pacman" -Sy --verbose --needed --noconfirm ${env:mingw_prefix}-libevent ${env:mingw_prefix}-openssl ${env:mingw_prefix}-pkg-config ${env:mingw_prefix}-xz ${env:mingw_prefix}-zstd ;
+    Execute-Command "C:\msys64\usr\bin\pacman" -Sy --verbose --needed --noconfirm ${env:mingw_prefix}-libevent ${env:mingw_prefix}-pkg-config ${env:mingw_prefix}-xz ${env:mingw_prefix}-zstd ;
 
 build_script:
 - ps: >-
@@ -54,7 +54,7 @@ build_script:
              # mingw zstd doesn't come with a pkg-config file, so we manually
              # configure its flags. liblzma just works.
              #>
-            Execute-Bash "ZSTD_CFLAGS='-L/${env:compiler_path}/include' ZSTD_LIBS='-L/${env:compiler_path}/lib -lzstd' ../configure --prefix=/${env:compiler_path} --build=${env:target} --host=${env:target} --disable-asciidoc --enable-fatal-warnings ${env:hardening}"
+            Execute-Bash "ZSTD_CFLAGS='-L/${env:compiler_path}/include' ZSTD_LIBS='-L/${env:compiler_path}/lib -lzstd' ../configure --prefix=/${env:compiler_path} --build=${env:target} --host=${env:target} --with-openssl-dir=/${env:compiler_path} --disable-asciidoc --enable-fatal-warnings ${env:hardening}"
             Execute-Bash "V=1 make -j2"
             Execute-Bash "V=1 make -j2 install"
      }

--- a/changes/ticket28574
+++ b/changes/ticket28574
@@ -1,0 +1,4 @@
+  o Minor bugfixes (continuous integration, Windows):
+    - Explicitly specify the path to the OpenSSL library and do not download
+      OpenSSL from Pacman, but instead use the library that is already provided
+      by AppVeyor. Fixes bug 28574; bugfix on master.


### PR DESCRIPTION
This patch explicitly specifies the path to our OpenSSL dependency and
disables the installation of an external OpenSSL version and instead
uses the OpenSSL version available from the MinGW environments.

See: https://bugs.torproject.org/28574