### PR TITLE
test: Fix a warning underflow in rend_cache/clean

### DIFF
--- a/src/test/test_rendcache.c
+++ b/src/test/test_rendcache.c
@@ -788,7 +788,9 @@ test_rend_cache_clean(void *data)
   desc_two->pk = pk_generate(1);
 
   strmap_set_lc(rend_cache, "foo1", one);
+  rend_cache_increment_allocation(rend_cache_entry_allocation(one));
   strmap_set_lc(rend_cache, "foo2", two);
+  rend_cache_increment_allocation(rend_cache_entry_allocation(two));
 
   rend_cache_clean(time(NULL), REND_CACHE_TYPE_CLIENT);
   tt_int_op(strmap_size(rend_cache), OP_EQ, 0);
@@ -806,7 +808,9 @@ test_rend_cache_clean(void *data)
   desc_one->pk = pk_generate(0);
   desc_two->pk = pk_generate(1);
 
+  rend_cache_increment_allocation(rend_cache_entry_allocation(one));
   strmap_set_lc(rend_cache, "foo1", one);
+  rend_cache_increment_allocation(rend_cache_entry_allocation(two));
   strmap_set_lc(rend_cache, "foo2", two);
 
   rend_cache_clean(time(NULL), REND_CACHE_TYPE_CLIENT);


### PR DESCRIPTION
Because the test is adding entries to the "rend_cache" directly, the
rend_cache_increment_allocation() was never called which made the
rend_cache_clean() call trigger that underflow warning:

rend_cache/clean: [forking] Nov 29 09:55:04.024 [warn] rend_cache_decrement_allocation(): Bug: Underflow in rend_cache_decrement_allocation (on Tor 0.4.0.0-alpha-dev 2240fe63feb9a8cf)

The test is still good and valid.

Fixes #28660

Signed-off-by: David Goulet <dgoulet@torproject.org>