### PR TITLE
man: Document HSv3 client authorization revocation

### DIFF
--- a/changes/ticket28275
+++ b/changes/ticket28275
@@ -1,0 +1,4 @@
+  o Documentation (hidden service v3, man page):
+    - Note in the man page that the only real way to fully revoke an onion
+      service v3 client authorization is by restarting the tor process. Closes
+      ticket 28275.

--- a/doc/tor.1.txt
+++ b/doc/tor.1.txt
@@ -2961,6 +2961,10 @@ Note that once you've configured client authorization, anyone else with the
 address won't be able to access it from this point on. If no authorization is
 configured, the service will be accessible to anyone with the onion address.
 
+Revoking a client can be done by removing their ".auth" file, however the
+revocation will be in effect only after the tor process gets restarted even if
+a SIGHUP takes place.
+
 See the Appendix G in the rend-spec-v3.txt file of
 https://spec.torproject.org/[torspec] for more information.
 


### PR DESCRIPTION
Removing a ".auth" file revokes a client access to the service but the
rendezvous circuit is not closed service side because the service simply
doesn't know which circuit is for which client.

This commit notes in the man page that to fully revoke a client access to the
service, the tor process should be restarted.

Closes #28275

Signed-off-by: David Goulet <dgoulet@torproject.org>