### PR TITLE
Call run_tor_main_loop() in ntmain.c, rather than do_main_loop().

### DIFF
--- a/changes/bug28612
+++ b/changes/bug28612
@@ -1,0 +1,4 @@
+  o Minor bugfixes (windows services):
+    - Make Tor start correctly as an NT service again: previously it
+      was broken by refactoring.  Fixes bug 28612; bugfix on 0.3.5.3-alpha.
+      

--- a/src/app/main/main.c
+++ b/src/app/main/main.c
@@ -1269,7 +1269,7 @@ sandbox_init_filter(void)
   return cfg;
 }
 
-static int
+int
 run_tor_main_loop(void)
 {
   handle_signals();

--- a/src/app/main/main.h
+++ b/src/app/main/main.h
@@ -26,4 +26,6 @@ void tor_free_all(int postfork);
 
 int tor_init(int argc, char **argv);
 
+int run_tor_main_loop(void);
+
 #endif /* !defined(TOR_MAIN_H) */

--- a/src/app/main/ntmain.c
+++ b/src/app/main/ntmain.c
@@ -326,7 +326,7 @@ nt_service_main(void)
         return;
       switch (get_options()->command) {
       case CMD_RUN_TOR:
-        do_main_loop();
+        run_tor_main_loop();
         break;
       case CMD_LIST_FINGERPRINT:
       case CMD_HASH_PASSWORD:

--- a/src/app/main/ntmain.c
+++ b/src/app/main/ntmain.c
@@ -298,7 +298,7 @@ nt_service_body(int argc, char **argv)
   service_status.dwCurrentState = SERVICE_RUNNING;
   service_fns.SetServiceStatus_fn(hStatus, &service_status);
   set_main_thread();
-  do_main_loop();
+  run_tor_main_loop();
   tor_cleanup();
 }
 


### PR DESCRIPTION
Fixes bug 28612; bugfix on 0.3.5.3-alpha.