### PR TITLE
ticket28731-035 Log bootstrap tag names

### DIFF
--- a/changes/ticket28731
+++ b/changes/ticket28731
@@ -1,0 +1,4 @@
+  o Minor features (bootstrap):
+    - Add the bootstrap tag name to the log messages, so people
+      troubleshooting connection problems can look up a symbol instead
+      of a number.  Closes ticket 28731.

--- a/src/feature/control/control.c
+++ b/src/feature/control/control.c
@@ -7153,7 +7153,7 @@ control_event_bootstrap_core(int loglevel, bootstrap_status_t status,
     status = progress;
 
   tor_log(loglevel, LD_CONTROL,
-          "Bootstrapped %d%%: %s", status, summary);
+          "Bootstrapped %d%% (%s): %s", status, tag, summary);
   tor_snprintf(buf, sizeof(buf),
                "BOOTSTRAP PROGRESS=%d TAG=%s SUMMARY=\"%s\"",
                status, tag, summary);
@@ -7309,9 +7309,9 @@ control_event_bootstrap_problem(const char *warn, const char *reason,
     hostaddr = tor_strdup("?");
 
   log_fn(severity,
-         LD_CONTROL, "Problem bootstrapping. Stuck at %d%%: %s. (%s; %s; "
+         LD_CONTROL, "Problem bootstrapping. Stuck at %d%% (%s): %s. (%s; %s; "
          "count %d; recommendation %s; host %s at %s)",
-         status, summary, warn, reason,
+         status, tag, summary, warn, reason,
          bootstrap_problems, recommendation,
          or_id, hostaddr);
 


### PR DESCRIPTION
Add the bootstrap tag name to the log messages, so people
troubleshooting connection problems can look up a symbol instead of a
number.  Closes ticket 28731.