### PR TITLE
Remove a needless memset() in get_token_arguments()

### DIFF
--- a/changes/ticket28852
+++ b/changes/ticket28852
@@ -1,0 +1,4 @@
+  o Minor features (performance):
+    - Remove a needless memset() call from get_token_arguments,
+      thereby speeding up the tokenization of directory objects by about
+      20%. Closes ticket 28852.

--- a/src/feature/dirparse/parsecommon.c
+++ b/src/feature/dirparse/parsecommon.c
@@ -169,7 +169,6 @@ get_token_arguments(memarea_t *area, directory_token_t *tok,
   char *cp = mem;
   int j = 0;
   char *args[MAX_ARGS];
-  memset(args, 0, sizeof(args));
   while (*cp) {
     if (j == MAX_ARGS)
       return -1;


### PR DESCRIPTION
I believe we originally added this for "just in case" safety, but it
isn't actually needed -- we never copy uninitialized stack here.
What's more, this one memset is showing up on our startup profiles,
so we ought to remove it.

Closes ticket 28852.