### PR TITLE
Rewrite the core of parse_short_policy() to be faster.

### DIFF
--- a/changes/ticket28853
+++ b/changes/ticket28853
@@ -1,0 +1,3 @@
+  o Minor features (performance):
+    - Replace parse_short_policy() with a faster implementation, to improve
+      microdescriptor parsing time. Closes ticket 28853.


### PR DESCRIPTION
The old implementation did some funky out-of-order lexing, and
tended to parse every port twice if the %d-%d pattern didn't match.

Closes ticket 28853.