### PR TITLE
Check hostname before using it in send_resolved_hostname_cell()

### DIFF
--- a/changes/ticket28879
+++ b/changes/ticket28879
@@ -1,0 +1,5 @@
+  o Minor bugfixes (correctness):
+    - Fix an unreached code-path where we checked the value of "hostname"
+      inside send_resolved_hostnam_cell(). Previously, we used it before
+      checking it; now we check it first. Fixes bug 28879; bugfix on
+      0.1.2.7-alpha.

--- a/src/feature/relay/dns.c
+++ b/src/feature/relay/dns.c
@@ -586,8 +586,11 @@ send_resolved_hostname_cell,(edge_connection_t *conn,
   char buf[RELAY_PAYLOAD_SIZE];
   size_t buflen;
   uint32_t ttl;
+
+  if (BUG(!hostname))
+    return;
+
   size_t namelen = strlen(hostname);
-  tor_assert(hostname);
 
   tor_assert(namelen < 256);
   ttl = dns_clip_ttl(conn->address_ttl);


### PR DESCRIPTION
Also, turn an absent hostname into a BUG(), not a crash.

Found by scan-build.

Closes ticket 28879; bugfix on 0.1.2.7-alpha