### PR TITLE
Always initialize addr in parse_port_config()

### DIFF
--- a/changes/ticket28881
+++ b/changes/ticket28881
@@ -1,0 +1,4 @@
+  o Code simplification and refactoring:
+    -  When parsing a port configuratio, make it more
+       obvious to static analyzer tools that we will always initialize the
+       address. Closes ticket 28881.

--- a/src/app/config/config.c
+++ b/src/app/config/config.c
@@ -6913,6 +6913,8 @@ parse_port_config(smartlist_t *out,
 
   for (; ports; ports = ports->next) {
     tor_addr_t addr;
+    tor_addr_make_unspec(&addr);
+
     int port;
     int sessiongroup = SESSION_GROUP_UNSET;
     unsigned isolation = ISO_DEFAULT;


### PR DESCRIPTION
It was always analyzed before use, but scan-build wasn't able to
persuade itself of that.

Closes ticket 28881.