### PR TITLE
Stop running stem's unit tests as part of "make test-stem"

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -139,7 +139,7 @@ need-stem-path:
 	fi
 
 test-stem: need-stem-path $(TESTING_TOR_BINARY)
-	@$(PYTHON) "$$STEM_SOURCE_DIR"/run_tests.py --tor "$(TESTING_TOR_BINARY)" --all --log notice --target RUN_ALL;
+	@$(PYTHON) "$$STEM_SOURCE_DIR"/run_tests.py --tor "$(TESTING_TOR_BINARY)" --integ --log notice --target RUN_ALL;
 
 test-stem-full: need-stem-path $(TESTING_TOR_BINARY)
 	@$(PYTHON) "$$STEM_SOURCE_DIR"/run_tests.py --tor "$(TESTING_TOR_BINARY)" --all --log notice --target RUN_ALL,ONLINE -v;

--- a/changes/bug28568
+++ b/changes/bug28568
@@ -1,0 +1,4 @@
+  o Minor bugfixes (testing):
+    - Stop running stem's unit tests as part of "make test-stem". But continue
+      to run stem's unit and online tests during "make test-stem-full".
+      Fixes bug 28568; bugfix on 0.2.6.3-alpha.


### PR DESCRIPTION
But continue to run stem's unit and online tests during
"make test-stem-full".

Fixes bug 28568; bugfix on 0.2.6.3-alpha.