### PR TITLE
#28179 win32 robustness

### DIFF
--- a/src/lib/process/process_win32.c
+++ b/src/lib/process/process_win32.c
@@ -720,30 +720,23 @@ process_win32_cleanup_handle(process_win32_handle_t *handle)
   tor_assert(handle);
 
 #if 0
-  /* FIXME(ahf): My compiler does not set _WIN32_WINNT to a high enough value
-   * for this code to be available. Should we force it? CancelIoEx() is
-   * available from Windows 7 and above. If we decide to require this, we need
-   * to update the checks in all the three I/O completion callbacks to handle
-   * the ERROR_OPERATION_ABORTED as well as ERROR_BROKEN_PIPE. */
-
-#if _WIN32_WINNT >= 0x0600
-  /* This code is only supported from Windows 7 and onwards. */
   BOOL ret;
   DWORD error_code;
 
-  /* Cancel any pending I/O requests. */
-  ret = CancelIoEx(handle->pipe, &handle->overlapped);
+  /* Cancel any pending I/O requests: This means that instead of getting
+   * ERROR_BROKEN_PIPE we get ERROR_OPERATION_ABORTED, but it doesn't seem
+   * like this is needed. */
+  ret = CancelIo(handle->pipe);
 
   if (! ret) {
     error_code = GetLastError();
 
     /* There was no pending I/O requests for our handle. */
     if (error_code != ERROR_NOT_FOUND) {
-      log_warn(LD_PROCESS, "CancelIoEx() failed: %s",
+      log_warn(LD_PROCESS, "CancelIo() failed: %s",
                format_win32_error(error_code));
     }
   }
-#endif
 #endif
 
   /* Close our handle. */

--- a/src/lib/process/process_win32.c
+++ b/src/lib/process/process_win32.c
@@ -365,8 +365,17 @@ process_win32_write(struct process_t *process, buf_t *buffer)
                     process_win32_stdin_write_done);
 
   if (! ret) {
-    log_warn(LD_PROCESS, "WriteFileEx() failed: %s",
-             format_win32_error(GetLastError()));
+    error_code = GetLastError();
+
+    /* No need to log at warning level for these two. */
+    if (error_code == ERROR_HANDLE_EOF || error_code == ERROR_BROKEN_PIPE) {
+      log_debug(LD_PROCESS, "WriteFileEx() returned EOF from pipe: %s",
+                format_win32_error(error_code));
+    } else {
+      log_warn(LD_PROCESS, "WriteFileEx() failed: %s",
+               format_win32_error(error_code));
+    }
+
     win32_process->stdin_handle.reached_eof = true;
     return 0;
   }
@@ -897,8 +906,17 @@ process_win32_read_from_handle(process_win32_handle_t *handle,
                    callback);
 
   if (! ret) {
-    log_warn(LD_PROCESS, "ReadFileEx() failed: %s",
-             format_win32_error(GetLastError()));
+    error_code = GetLastError();
+
+    /* No need to log at warning level for these two. */
+    if (error_code == ERROR_HANDLE_EOF || error_code == ERROR_BROKEN_PIPE) {
+      log_debug(LD_PROCESS, "ReadFileEx() returned EOF from pipe: %s",
+                format_win32_error(error_code));
+    } else {
+      log_warn(LD_PROCESS, "ReadFileEx() failed: %s",
+               format_win32_error(error_code));
+    }
+
     handle->reached_eof = true;
     return bytes_available;
   }

--- a/src/lib/process/process_win32.c
+++ b/src/lib/process/process_win32.c
@@ -367,6 +367,7 @@ process_win32_write(struct process_t *process, buf_t *buffer)
   if (! ret) {
     log_warn(LD_PROCESS, "WriteFileEx() failed: %s",
              format_win32_error(GetLastError()));
+    win32_process->stdin_handle.reached_eof = true;
     return 0;
   }
 
@@ -749,6 +750,7 @@ process_win32_cleanup_handle(process_win32_handle_t *handle)
   if (handle->pipe != INVALID_HANDLE_VALUE) {
     CloseHandle(handle->pipe);
     handle->pipe = INVALID_HANDLE_VALUE;
+    handle->reached_eof = true;
   }
 }
 
@@ -930,6 +932,7 @@ process_win32_read_from_handle(process_win32_handle_t *handle,
   if (! ret) {
     log_warn(LD_PROCESS, "ReadFileEx() failed: %s",
              format_win32_error(GetLastError()));
+    handle->reached_eof = true;
     return bytes_available;
   }
 

--- a/src/lib/process/process_win32.c
+++ b/src/lib/process/process_win32.c
@@ -248,6 +248,11 @@ process_win32_exec(process_t *process)
   win32_process->stderr_handle.pipe = stderr_pipe_read;
   win32_process->stdin_handle.pipe = stdin_pipe_write;
 
+  /* Close our ends of the pipes that is now owned by the child process. */
+  CloseHandle(stdout_pipe_write);
+  CloseHandle(stderr_pipe_write);
+  CloseHandle(stdin_pipe_read);
+
   /* Used by the callback functions from ReadFileEx() and WriteFileEx() such
    * that we can figure out which process_t that was responsible for the event.
    *

--- a/src/test/test_process_slow.c
+++ b/src/test/test_process_slow.c
@@ -242,6 +242,7 @@ test_callbacks(void *arg)
   /* We returned. Let's see what our event loop said. */
   tt_int_op(smartlist_len(process_data->stdout_data), OP_EQ, 12);
   tt_int_op(smartlist_len(process_data->stderr_data), OP_EQ, 3);
+  tt_assert(process_data->did_exit);
   tt_int_op(process_data->exit_code, OP_EQ, 0);
 
   /* Check stdout output. */


### PR DESCRIPTION
I tried to run the test cases for process_t related code in a VM with limited amount of memory and where I also ran a "load heavy" task (compiled Tor with -jN in a while true loop) and made some discoveries:

1. The exit handler would sometimes be called *before* we received the "Broken Pipe" event from `ReadFileEx()`. We now wait until we have received EOF state for both standard out and error before we check whether the process have terminated.
2. We forgot to clean up the child process' end of the pipes after the process have been created.
3. There is no need to log ordinary "end of process" conditions as "warning" log severity.
4. We forgot to set `reached_eof` to true under certain pathological conditions. Together with (1) this could sometimes lead to an error in the slow tests where the process was terminated before all output from the child process had been received by Tor's event loop.
5. Add some additional error checking around ReadFileEx() and WriteFileEx() which is recommended by the MSDN API documentation.

To run a test in PowerShell until it fails one can do:

`while ($true) { .\test-slow.exe slow/process/... ; if ($LastExitCode -ne 0) { break : } }`