### PR TITLE
#28846 implementation

### DIFF
--- a/changes/ticket28180
+++ b/changes/ticket28180
@@ -1,3 +1,3 @@
   o Minor features (pluggable transports):
     - Add support for logging to Tor's logging subsystem from a pluggable
-      transport process. Partial implementation for ticket 28180
+      transport process. Closes ticket 28180

--- a/changes/ticket28846
+++ b/changes/ticket28846
@@ -1,0 +1,3 @@
+  o Minor features (pluggable transports):
+    - Add support for emitting STATUS updates to Tor's control port from a
+      pluggable transport process. Closes ticket 28846.

--- a/src/feature/client/transports.c
+++ b/src/feature/client/transports.c
@@ -1175,14 +1175,14 @@ parse_log_line(const char *line, managed_proxy_t *mp)
   /* Check if we got a message. */
   if (! message) {
     log_warn(LD_PT, "Managed proxy \"%s\" wrote a LOG line without "
-                    "MESSAGE: %s", mp->argv[0], data);
+                    "MESSAGE: %s", mp->argv[0], escaped(data));
     goto done;
   }
 
   /* Check if severity is there and whether it's valid. */
   if (! severity) {
     log_warn(LD_PT, "Managed proxy \"%s\" wrote a LOG line without "
-                    "SEVERITY: %s", mp->argv[0], data);
+                    "SEVERITY: %s", mp->argv[0], escaped(data));
     goto done;
   }
 
@@ -1232,7 +1232,7 @@ parse_status_line(const char *line, managed_proxy_t *mp)
 
   if (! values) {
     log_warn(LD_PT, "Managed proxy \"%s\" wrote an invalid "
-             "STATUS message: %s", mp->argv[0], data);
+             "STATUS message: %s", mp->argv[0], escaped(data));
     goto done;
   }
 
@@ -1242,7 +1242,7 @@ parse_status_line(const char *line, managed_proxy_t *mp)
 
   if (! type) {
     log_warn(LD_PT, "Managed proxy \"%s\" wrote a STATUS line without "
-                    "TYPE: %s", mp->argv[0], data);
+                    "TYPE: %s", mp->argv[0], escaped(data));
     goto done;
   }
 

--- a/src/feature/client/transports.h
+++ b/src/feature/client/transports.h
@@ -147,6 +147,8 @@ STATIC void managed_proxy_stdout_callback(process_t *, const char *, size_t);
 STATIC void managed_proxy_stderr_callback(process_t *, const char *, size_t);
 STATIC bool managed_proxy_exit_callback(process_t *, process_exit_code_t);
 
+STATIC int managed_proxy_severity_parse(const char *);
+
 #endif /* defined(PT_PRIVATE) */
 
 #endif /* !defined(TOR_TRANSPORTS_H) */

--- a/src/feature/client/transports.h
+++ b/src/feature/client/transports.h
@@ -129,6 +129,7 @@ STATIC void parse_env_error(const char *line);
 STATIC void parse_proxy_error(const char *line);
 STATIC void handle_proxy_line(const char *line, managed_proxy_t *mp);
 STATIC void parse_log_line(const char *line, managed_proxy_t *mp);
+STATIC void parse_status_line(const char *line, managed_proxy_t *mp);
 STATIC char *get_transport_options_for_server_proxy(const managed_proxy_t *mp);
 
 STATIC void managed_proxy_destroy(managed_proxy_t *mp,

--- a/src/feature/control/control.c
+++ b/src/feature/control/control.c
@@ -7043,6 +7043,16 @@ control_event_pt_log(const char *log)
                      log);
 }
 
+/** A pluggable transport has emitted a STATUS message found in
+ * <b>status</b>. */
+void
+control_event_pt_status(const char *status)
+{
+  send_control_event(EVENT_PT_STATUS,
+                     "650 PT_STATUS %s\r\n",
+                     status);
+}
+
 /** Convert rendezvous auth type to string for HS_DESC control events
  */
 const char *

--- a/src/feature/control/control.c
+++ b/src/feature/control/control.c
@@ -7033,15 +7033,14 @@ control_event_transport_launched(const char *mode, const char *transport_name,
                      mode, transport_name, fmt_addr(addr), port);
 }
 
-/** A pluggable transport called <b>pt_name</b> has emitted a log
- * message found in <b>message</b>. */
+/** A pluggable transport called <b>pt_name</b> has emitted a log message
+ * found in <b>message</b> at <b>severity</b> log level. */
 void
-control_event_pt_log(const char *pt_name, const char *message)
+control_event_pt_log(const char *log)
 {
   send_control_event(EVENT_PT_LOG,
-                     "650 PT_LOG %s %s\r\n",
-                     pt_name,
-                     message);
+                     "650 PT_LOG %s\r\n",
+                     log);
 }
 
 /** Convert rendezvous auth type to string for HS_DESC control events

--- a/src/feature/control/control.h
+++ b/src/feature/control/control.h
@@ -208,6 +208,7 @@ void control_event_transport_launched(const char *mode,
                                       const char *transport_name,
                                       tor_addr_t *addr, uint16_t port);
 void control_event_pt_log(const char *log);
+void control_event_pt_status(const char *status);
 const char *rend_auth_type_to_string(rend_auth_type_t auth_type);
 MOCK_DECL(const char *, node_describe_longname_by_id,(const char *id_digest));
 void control_event_hs_descriptor_requested(const char *onion_address,
@@ -297,7 +298,8 @@ void control_free_all(void);
 #define EVENT_HS_DESC_CONTENT         0x0022
 #define EVENT_NETWORK_LIVENESS        0x0023
 #define EVENT_PT_LOG                  0x0024
-#define EVENT_MAX_                    0x0024
+#define EVENT_PT_STATUS               0x0025
+#define EVENT_MAX_                    0x0025
 
 /* sizeof(control_connection_t.event_mask) in bits, currently a uint64_t */
 #define EVENT_CAPACITY_               0x0040

--- a/src/feature/control/control.h
+++ b/src/feature/control/control.h
@@ -207,7 +207,7 @@ void control_event_clients_seen(const char *controller_str);
 void control_event_transport_launched(const char *mode,
                                       const char *transport_name,
                                       tor_addr_t *addr, uint16_t port);
-void control_event_pt_log(const char *pt_name, const char *message);
+void control_event_pt_log(const char *log);
 const char *rend_auth_type_to_string(rend_auth_type_t auth_type);
 MOCK_DECL(const char *, node_describe_longname_by_id,(const char *id_digest));
 void control_event_hs_descriptor_requested(const char *onion_address,


### PR DESCRIPTION
These patches does the following:

1. Make the `LOG` message use the new K/V parser and the `config_line_t` encoding format.
2. Add the `STATUS` message.