### PR TITLE
Ticket21377 035 01 WIP

### DIFF
--- a/src/feature/dircache/dircache.c
+++ b/src/feature/dircache/dircache.c
@@ -1447,7 +1447,6 @@ static int
 handle_get_next_bandwidth(dir_connection_t *conn,
                           const get_handler_args_t *args)
 {
-  (void)args;
   log_debug(LD_DIR, "Getting next bandwidth.");
   const or_options_t *options = get_options();
   const compress_method_t compress_method =

--- a/src/feature/dircache/dircache.c
+++ b/src/feature/dircache/dircache.c
@@ -1451,7 +1451,8 @@ handle_get_next_bandwidth(dir_connection_t *conn,
   const or_options_t *options = get_options();
   if (options->V3BandwidthsFile) {
     int lifetime = 60;
-    char *bandwidth =  read_file_to_str(options->V3BandwidthsFile, 0, NULL);
+    char *bandwidth = read_file_to_str(options->V3BandwidthsFile,
+                                       RFTS_IGNORE_MISSING, NULL);
     size_t len = strlen(bandwidth);
     write_http_response_header(conn, len, NO_METHOD, lifetime);
     connection_buf_add(bandwidth, len, TO_CONN(conn));

--- a/src/feature/dircache/dircache.c
+++ b/src/feature/dircache/dircache.c
@@ -1453,13 +1453,15 @@ handle_get_next_bandwidth(dir_connection_t *conn,
     int lifetime = 60;
     char *bandwidth = read_file_to_str(options->V3BandwidthsFile,
                                        RFTS_IGNORE_MISSING, NULL);
-    size_t len = strlen(bandwidth);
-    write_http_response_header(conn, len, NO_METHOD, lifetime);
-    connection_buf_add(bandwidth, len, TO_CONN(conn));
-    tor_free(bandwidth);
-  } else {
-    write_short_http_response(conn, 404, "Not found");
+    if (bandwidth != NULL) {
+      site_t len = strlen(bandwidth);
+      write_http_response_header(conn, len, NO_METHOD, lifetime);
+      connection_buf_add(bandwidth, len, TO_CONN(conn));
+      tor_free(bandwidth);
+      return 0;
+    }
   }
+  write_short_http_response(conn, 404, "Not found");
   return 0;
 }
 

--- a/src/feature/dircache/dircache.c
+++ b/src/feature/dircache/dircache.c
@@ -443,7 +443,7 @@ directory_handle_command_get,(dir_connection_t *conn, const char *headers,
 
   /* Remove all methods that we don't both support. */
   compression_methods_supported &= tor_compress_get_supported_method_bitmask();
-
+  log_debug(LD_DIR, "compression supported %i", compression_methods_supported);
   get_handler_args_t args;
   args.url = url;
   args.headers = headers;

--- a/src/feature/dircache/dircache.c
+++ b/src/feature/dircache/dircache.c
@@ -1451,9 +1451,9 @@ handle_get_next_bandwidth(dir_connection_t *conn,
   const or_options_t *options = get_options();
   const compress_method_t compress_method =
     find_best_compression_method(args->compression_supported, 1);
-  // this will log: [notice] compress_method 2
+  // this will log: [debug] compress_method 2
   // ie, ZLIB_METHOD
-  log_notice(LD_DIR, "compress_method %d", compress_method);
+  log_debug(LD_DIR, "compress_method %d", compress_method);
 
   if (options->V3BandwidthsFile) {
     char *bandwidth = read_file_to_str(options->V3BandwidthsFile,

--- a/src/feature/dircache/dircache.c
+++ b/src/feature/dircache/dircache.c
@@ -49,7 +49,8 @@
 #define ROUTERDESC_BY_DIGEST_CACHE_LIFETIME (48*60*60)
 #define ROBOTS_CACHE_LIFETIME (24*60*60)
 #define MICRODESC_CACHE_LIFETIME (48*60*60)
-
+/* Bandwidth files change every hour. */
+#define BANDWIDTH_CACHE_LIFETIME (30*60)
 /** Parse an HTTP request string <b>headers</b> of the form
  * \verbatim
  * "\%s [http[s]://]\%s HTTP/1..."
@@ -1453,12 +1454,12 @@ handle_get_next_bandwidth(dir_connection_t *conn,
     find_best_compression_method(args->compression_supported, 1);
 
   if (options->V3BandwidthsFile) {
-    int lifetime = 60;
     char *bandwidth = read_file_to_str(options->V3BandwidthsFile,
                                        RFTS_IGNORE_MISSING, NULL);
     if (bandwidth != NULL) {
       size_t len = strlen(bandwidth);
-      write_http_response_header(conn, len, compress_method, lifetime);
+      write_http_response_header(conn, len, compress_method,
+                                 BANDWIDTH_CACHE_LIFETIME);
       if (compress_method != NO_METHOD)
         conn->compress_state = tor_compress_new(1, compress_method,
                                         choose_compression_level(len));

--- a/src/feature/dircache/dircache.c
+++ b/src/feature/dircache/dircache.c
@@ -1451,17 +1451,20 @@ handle_get_next_bandwidth(dir_connection_t *conn,
   const or_options_t *options = get_options();
   const compress_method_t compress_method =
     find_best_compression_method(args->compression_supported, 1);
+  // this will log: [notice] compress_method 2
+  // ie, ZLIB_METHOD
+  log_notice(LD_DIR, "compress_method %d", compress_method);
 
   if (options->V3BandwidthsFile) {
     char *bandwidth = read_file_to_str(options->V3BandwidthsFile,
                                        RFTS_IGNORE_MISSING, NULL);
     if (bandwidth != NULL) {
-      size_t len = strlen(bandwidth);
+      ssize_t len = strlen(bandwidth);
       write_http_response_header(conn, compress_method != NO_METHOD ? -1 : len,
                                  compress_method, BANDWIDTH_CACHE_LIFETIME);
       if (compress_method != NO_METHOD)
         conn->compress_state = tor_compress_new(1, compress_method,
-                                        choose_compression_level(len));
+                                        choose_compression_level(len/2));
       connection_buf_add(bandwidth, len, TO_CONN(conn));
       tor_free(bandwidth);
       return 0;

--- a/src/feature/dircache/dircache.c
+++ b/src/feature/dircache/dircache.c
@@ -1457,8 +1457,8 @@ handle_get_next_bandwidth(dir_connection_t *conn,
                                        RFTS_IGNORE_MISSING, NULL);
     if (bandwidth != NULL) {
       size_t len = strlen(bandwidth);
-      write_http_response_header(conn, len, compress_method,
-                                 BANDWIDTH_CACHE_LIFETIME);
+      write_http_response_header(conn, compress_method != NO_METHOD ? -1 : len,
+                                 compress_method, BANDWIDTH_CACHE_LIFETIME);
       if (compress_method != NO_METHOD)
         conn->compress_state = tor_compress_new(1, compress_method,
                                         choose_compression_level(len));

--- a/src/feature/dircache/dircache.c
+++ b/src/feature/dircache/dircache.c
@@ -1462,10 +1462,16 @@ handle_get_next_bandwidth(dir_connection_t *conn,
       ssize_t len = strlen(bandwidth);
       write_http_response_header(conn, compress_method != NO_METHOD ? -1 : len,
                                  compress_method, BANDWIDTH_CACHE_LIFETIME);
-      if (compress_method != NO_METHOD)
+      if (compress_method != NO_METHOD) {
         conn->compress_state = tor_compress_new(1, compress_method,
                                         choose_compression_level(len/2));
-      connection_buf_add(bandwidth, len, TO_CONN(conn));
+        log_debug(LD_DIR, "Calling connection_buf_add_compress.");
+        connection_buf_add_compress(bandwidth, len, conn, 0);
+        connection_buf_add_compress("", 0, conn, 1);
+      } else {
+        log_debug(LD_DIR, "compress_method was NO_METHOD, not compressing.");
+        connection_buf_add(bandwidth, len, TO_CONN(conn));
+      }
       tor_free(bandwidth);
       return 0;
     }

--- a/src/test/test_dir_handle_get.c
+++ b/src/test/test_dir_handle_get.c
@@ -2558,7 +2558,8 @@ test_dir_handle_get_status_vote_next_bandwidth(void* data)
 
   // !!, if it's compressed, this should not be the case
   tt_int_op(comp_body_used, OP_EQ, strlen(comp_body));
-  tt_str_op(content, OP_EQ, comp_body);
+  // This will fail, content and comp_body are the same, though they shouldn't
+  // tt_str_op(content, OP_NE, comp_body);
 
   compress_method_t compression = detect_compression_method(comp_body,
                                                             comp_body_used);

--- a/src/test/test_dir_handle_get.c
+++ b/src/test/test_dir_handle_get.c
@@ -2537,6 +2537,25 @@ test_dir_handle_get_status_vote_next_bandwidth(void* data)
   tt_int_op(body_used, OP_EQ, strlen(body));
   tt_str_op(content, OP_EQ, body);
 
+  tor_free(header);
+  tor_free(body);
+
+  /* Request the file using compression, the result should be the same. */
+  tt_int_op(0, OP_EQ, directory_handle_command_get(conn,
+    GET("/tor/status-vote/next/bandwidth.z"), NULL, 0));
+
+  fetch_from_buf_http(TO_CONN(conn)->outbuf, &header, MAX_HEADERS_SIZE,
+                      &body, &body_used, strlen(content)+1, 0);
+
+  tt_assert(header);
+  tt_ptr_op(strstr(header, "HTTP/1.0 200 OK\r\n"), OP_EQ, header);
+  tt_assert(strstr(header, "Content-Encoding: deflate\r\n"));
+  tt_assert(strstr(header, "Content-Length: 167\r\n"));
+
+  tt_int_op(body_used, OP_EQ, strlen(body));
+  tt_str_op(content, OP_EQ, body);
+  goto done;
+
   done:
     UNMOCK(get_options);
     UNMOCK(connection_write_to_buf_impl_);

--- a/src/test/test_dir_handle_get.c
+++ b/src/test/test_dir_handle_get.c
@@ -2570,7 +2570,6 @@ test_dir_handle_get_status_vote_next_bandwidth(void* data)
 
   tor_free(comp_body);
 
-
  done:
   UNMOCK(get_options);
   UNMOCK(connection_write_to_buf_impl_);

--- a/src/test/test_dir_handle_get.c
+++ b/src/test/test_dir_handle_get.c
@@ -2524,6 +2524,16 @@ test_dir_handle_get_status_vote_next_bandwidth(void* data)
   tt_assert(strstr(header, "Content-Encoding: identity\r\n"));
   tt_assert(strstr(header, "Content-Length: 167\r\n"));
 
+  /* Check cache lifetime */
+  char expbuf[RFC1123_TIME_LEN+1];
+  time_t now = time(NULL);
+  /* BANDWIDTH_CACHE_LIFETIME is defined in dircache.c. */
+  format_rfc1123_time(expbuf, (time_t)(now + 30*60));
+  char *expires = NULL;
+  /* Change to 'Cache-control: max-age=%d' if using http/1.1. */
+  tor_asprintf(&expires, "Expires: %s\r\n", expbuf);
+  tt_assert(strstr(header, expires));
+
   tt_int_op(body_used, OP_EQ, strlen(body));
   tt_str_op(content, OP_EQ, body);
 
@@ -2533,6 +2543,7 @@ test_dir_handle_get_status_vote_next_bandwidth(void* data)
     connection_free_minimal(TO_CONN(conn));
     tor_free(header);
     tor_free(body);
+    tor_free(expires);
     or_options_free(mock_options); mock_options = NULL;
 }
 

--- a/src/test/test_dir_handle_get.c
+++ b/src/test/test_dir_handle_get.c
@@ -2553,7 +2553,7 @@ test_dir_handle_get_status_vote_next_bandwidth(void* data)
   tt_assert(header);
   tt_ptr_op(strstr(header, "HTTP/1.0 200 OK\r\n"), OP_EQ, header);
   tt_assert(strstr(header, "Content-Encoding: deflate\r\n"));
-  log_notice(LD_DIR, "%s", header);
+  log_debug(LD_DIR, "%s", header);
   // assert there is no content-lenght
 
   // !!, if it's compressed, this should not be the case
@@ -2562,9 +2562,9 @@ test_dir_handle_get_status_vote_next_bandwidth(void* data)
 
   compress_method_t compression = detect_compression_method(comp_body,
                                                             comp_body_used);
-  // this will log: [notice] 5
+  // this will log: [debug] 5
   // ie, UNKNOWN_METHOD
-  log_notice(LD_DIR, "%d", compression);
+  log_debug(LD_DIR, "%d", compression);
 
   tor_free(comp_body);
 

--- a/src/test/test_dir_handle_get.c
+++ b/src/test/test_dir_handle_get.c
@@ -2559,6 +2559,7 @@ test_dir_handle_get_status_vote_next_bandwidth(void* data)
   // !!, if it's compressed, this should not be the case
   tt_int_op(comp_body_used, OP_EQ, strlen(comp_body));
   // This will fail, content and comp_body are the same, though they shouldn't
+  // nickm comment: can't compare compressed bytes with tt_str_op nor strcmp
   // tt_str_op(content, OP_NE, comp_body);
 
   compress_method_t compression = detect_compression_method(comp_body,

--- a/src/test/test_dir_handle_get.c
+++ b/src/test/test_dir_handle_get.c
@@ -2223,6 +2223,31 @@ test_dir_handle_get_status_vote_next_authority_not_found(void* data)
     tor_free(header);
 }
 
+static void
+test_dir_handle_get_status_vote_next_bandwidth_not_found(void* data)
+{
+  dir_connection_t *conn = NULL;
+  char *header = NULL;
+  (void) data;
+
+  MOCK(connection_write_to_buf_impl_, connection_write_to_buf_mock);
+
+  conn = new_dir_conn();
+
+  tt_int_op(0, OP_EQ, directory_handle_command_get(conn,
+    GET("/tor/status-vote/next/bandwdith"), NULL, 0));
+
+  fetch_from_buf_http(TO_CONN(conn)->outbuf, &header, MAX_HEADERS_SIZE,
+                      NULL, NULL, 1, 0);
+  tt_assert(header);
+  tt_str_op(NOT_FOUND, OP_EQ, header);
+
+  done:
+    UNMOCK(connection_write_to_buf_impl_);
+    connection_free_minimal(TO_CONN(conn));
+    tor_free(header);
+}
+
 NS_DECL(const char*,
 dirvote_get_pending_consensus, (consensus_flavor_t flav));
 
@@ -2463,6 +2488,55 @@ test_dir_handle_get_status_vote_next_authority(void* data)
 }
 
 static void
+test_dir_handle_get_status_vote_next_bandwidth(void* data)
+{
+  dir_connection_t *conn = NULL;
+  char *header = NULL, *body = NULL;
+  size_t body_used = 0;
+  (void) data;
+
+  const char *content =
+    "1541171221\n"
+    "node_id=$68A483E05A2ABDCA6DA5A3EF8DB5177638A27F80 "
+    "master_key_ed25519=YaqV4vbvPYKucElk297eVdNArDz9HtIwUoIeo0+cVIpQ "
+    "bw=760 nick=Test time=2018-05-08T16:13:26\n";
+
+  init_mock_options();
+  MOCK(get_options, mock_get_options);
+  mock_options->V3BandwidthsFile = tor_strdup(
+    get_fname_rnd("V3BandwidthsFile")
+  );
+
+  write_str_to_file(mock_options->V3BandwidthsFile, content, 0);
+
+  MOCK(connection_write_to_buf_impl_, connection_write_to_buf_mock);
+
+  conn = new_dir_conn();
+  tt_int_op(0, OP_EQ, directory_handle_command_get(conn,
+    GET("/tor/status-vote/next/bandwidth"), NULL, 0));
+
+  fetch_from_buf_http(TO_CONN(conn)->outbuf, &header, MAX_HEADERS_SIZE,
+                      &body, &body_used, strlen(content)+1, 0);
+
+  tt_assert(header);
+  tt_ptr_op(strstr(header, "HTTP/1.0 200 OK\r\n"), OP_EQ, header);
+  tt_assert(strstr(header, "Content-Type: text/plain\r\n"));
+  tt_assert(strstr(header, "Content-Encoding: identity\r\n"));
+  tt_assert(strstr(header, "Content-Length: 167\r\n"));
+
+  tt_int_op(body_used, OP_EQ, strlen(body));
+  tt_str_op(content, OP_EQ, body);
+
+  done:
+    UNMOCK(get_options);
+    UNMOCK(connection_write_to_buf_impl_);
+    connection_free_minimal(TO_CONN(conn));
+    tor_free(header);
+    tor_free(body);
+    or_options_free(mock_options); mock_options = NULL;
+}
+
+static void
 test_dir_handle_get_status_vote_current_authority(void* data)
 {
   dir_connection_t *conn = NULL;
@@ -2637,6 +2711,8 @@ struct testcase_t dir_handle_get_tests[] = {
   DIR_HANDLE_CMD(status_vote_current_authority, 0),
   DIR_HANDLE_CMD(status_vote_next_authority_not_found, 0),
   DIR_HANDLE_CMD(status_vote_next_authority, 0),
+  DIR_HANDLE_CMD(status_vote_next_bandwidth_not_found, 0),
+  DIR_HANDLE_CMD(status_vote_next_bandwidth, 0),
   DIR_HANDLE_CMD(status_vote_current_consensus_ns_not_enough_sigs, TT_FORK),
   DIR_HANDLE_CMD(status_vote_current_consensus_ns_not_found, TT_FORK),
   DIR_HANDLE_CMD(status_vote_current_consensus_too_old, TT_FORK),

--- a/src/test/test_dir_handle_get.c
+++ b/src/test/test_dir_handle_get.c
@@ -2554,16 +2554,15 @@ test_dir_handle_get_status_vote_next_bandwidth(void* data)
 
   tt_int_op(body_used, OP_EQ, strlen(body));
   tt_str_op(content, OP_EQ, body);
-  goto done;
 
-  done:
-    UNMOCK(get_options);
-    UNMOCK(connection_write_to_buf_impl_);
-    connection_free_minimal(TO_CONN(conn));
-    tor_free(header);
-    tor_free(body);
-    tor_free(expires);
-    or_options_free(mock_options); mock_options = NULL;
+ done:
+  UNMOCK(get_options);
+  UNMOCK(connection_write_to_buf_impl_);
+  connection_free_minimal(TO_CONN(conn));
+  tor_free(header);
+  tor_free(body);
+  tor_free(expires);
+  or_options_free(mock_options);
 }
 
 static void

--- a/src/test/test_dir_handle_get.c
+++ b/src/test/test_dir_handle_get.c
@@ -2566,7 +2566,7 @@ test_dir_handle_get_status_vote_next_bandwidth(void* data)
                                                             comp_body_used);
   // this will log: [debug] 5
   // ie, UNKNOWN_METHOD
-  log_debug(LD_DIR, "%d", compression);
+  log_debug(LD_DIR, "detect_compression_method: %d", compression);
 
   tor_free(comp_body);
 


### PR DESCRIPTION
This branch is not intended to be merged, but to debug why the bandwidth file content is not being compressed.
appveyor fails in a different test, but i don't think CI messages are useful for this.

What has being useful for me is to run `src/test/test --debug dir_handle_get/status_vote_next_bandwidth`. This is the relevant output:

```
ec 20 11:39:04.229 [debug] directory_handle_command_get__real(): Received GET command.
Dec 20 11:39:04.229 [debug] directory_handle_command_get__real(): rewritten url as '"/tor/status-vote/next/bandwidth.z"'.
Dec 20 11:39:04.229 [debug] directory_handle_command_get__real(): compression supported 5
Dec 20 11:39:04.229 [debug] handle_get_next_bandwidth(): Getting next bandwidth.
Dec 20 11:39:04.229 [debug] handle_get_next_bandwidth(): compress_method 2
Dec 20 11:39:04.230 [debug] handle_get_next_bandwidth(): Calling connection_buf_add_compress.
Dec 20 11:39:04.230 [debug] fetch_from_buf_http(): headerlen 149, bodylen 167.
Dec 20 11:39:04.230 [debug] test_dir_handle_get_status_vote_next_bandwidth(): HTTP/1.0 200 OK
Date: Thu, 20 Dec 2018 11:39:04 GMT
Content-Type: text/plain
Content-Encoding: deflate
Expires: Thu, 20 Dec 2018 12:09:04 GMT
```
