### PR TITLE
Fix incorrect OpenBSD macro tests (this fixes a testsuite failure)

### DIFF
--- a/changes/bug28938
+++ b/changes/bug28938
@@ -1,0 +1,4 @@
+  o Minor bugfixes (compilation):
+    - Fix missing headers required for proper detection of
+      OpenBSD.  Fixes bug 28938; bugfix on 0.3.5.1-alpha.
+      Patch from Kris Katterjohn.

--- a/src/app/config/config.c
+++ b/src/app/config/config.c
@@ -132,6 +132,9 @@
 #ifdef HAVE_SYS_STAT_H
 #include <sys/stat.h>
 #endif
+#ifdef HAVE_SYS_PARAM_H
+#include <sys/param.h>
+#endif
 #ifdef HAVE_UNISTD_H
 #include <unistd.h>
 #endif

--- a/src/core/or/connection_edge.c
+++ b/src/core/or/connection_edge.c
@@ -140,6 +140,9 @@
 #ifdef HAVE_SYS_IOCTL_H
 #include <sys/ioctl.h>
 #endif
+#ifdef HAVE_SYS_PARAM_H
+#include <sys/param.h>
+#endif
 
 #if defined(HAVE_NET_IF_H) && defined(HAVE_NET_PFVAR_H)
 #include <net/if.h>

--- a/src/ext/byteorder.h
+++ b/src/ext/byteorder.h
@@ -29,6 +29,10 @@
     Jean-Philippe Aumasson (https://131002.net/siphash/siphash24.c)
 */
 
+#ifdef HAVE_SYS_PARAM_H
+#include <sys/param.h>
+#endif
+
 /* This code is extracted from csiphash.h */
 
 #if defined(__BYTE_ORDER__) && defined(__ORDER_LITTLE_ENDIAN__) &&      \

--- a/src/ext/ed25519/donna/ed25519-donna-portable-identify.h
+++ b/src/ext/ed25519/donna/ed25519-donna-portable-identify.h
@@ -14,7 +14,7 @@
 			#define OS_OSX
 		#elif defined(macintosh) || defined(Macintosh)
 			#define OS_MAC
-		#elif defined(__OpenBSD__)
+		#elif defined(OpenBSD)
 			#define OS_OPENBSD
 		#endif
 	#endif

--- a/src/ext/trunnel/trunnel.c
+++ b/src/ext/trunnel/trunnel.c
@@ -14,6 +14,10 @@
 #include <stdlib.h>
 #include <string.h>
 
+#ifdef HAVE_SYS_PARAM_H
+#include <sys/param.h>
+#endif
+
 #if defined(__BYTE_ORDER__) && defined(__ORDER_LITTLE_ENDIAN__) && \
 	__BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__
 #  define IS_LITTLE_ENDIAN 1
@@ -31,7 +35,7 @@
 #    define IS_LITTLE_ENDIAN
 #  endif
 #else
-# if defined(__FreeBSD__) || defined(__NetBSD__) || defined(__OpenBSD__)
+# if defined(__FreeBSD__) || defined(__NetBSD__) || defined(OpenBSD)
 #  include <sys/endian.h>
 # else
 #  include <endian.h>

--- a/src/lib/err/backtrace.c
+++ b/src/lib/err/backtrace.c
@@ -32,6 +32,9 @@
 #ifdef HAVE_SIGNAL_H
 #include <signal.h>
 #endif
+#ifdef HAVE_SYS_PARAM_H
+#include <sys/param.h>
+#endif
 #include <errno.h>
 #include <stdlib.h>
 #include <string.h>

--- a/src/lib/net/inaddr_st.h
+++ b/src/lib/net/inaddr_st.h
@@ -28,6 +28,9 @@
 #ifdef HAVE_SYS_SOCKET_H
 #include <sys/socket.h>
 #endif
+#ifdef HAVE_SYS_PARAM_H
+#include <sys/param.h>
+#endif
 
 #ifdef _WIN32
 #include <winsock2.h>
@@ -60,7 +63,7 @@ struct in6_addr
 /** @{ */
 /** Many BSD variants seem not to define these. */
 #if defined(__APPLE__) || defined(__darwin__) || \
-  defined(__FreeBSD__) || defined(__NetBSD__) || defined(__OpenBSD__)
+  defined(__FreeBSD__) || defined(__NetBSD__) || defined(OpenBSD)
 #ifndef s6_addr16
 #define s6_addr16 __u6_addr.__u6_addr16
 #endif

--- a/src/test/test-memwipe.c
+++ b/src/test/test-memwipe.c
@@ -12,6 +12,10 @@
 #include <sys/types.h>
 #include <stdlib.h>
 
+#ifdef HAVE_SYS_PARAM_H
+#include <sys/param.h>
+#endif
+
 static unsigned fill_a_buffer_memset(void) __attribute__((noinline));
 static unsigned fill_a_buffer_memwipe(void) __attribute__((noinline));
 static unsigned fill_a_buffer_nothing(void) __attribute__((noinline));

--- a/src/test/test_options.c
+++ b/src/test/test_options.c
@@ -23,6 +23,10 @@
 #include "test/test_helpers.h"
 #include "lib/net/resolve.h"
 
+#ifdef HAVE_SYS_PARAM_H
+#include <sys/param.h>
+#endif
+
 #define NS_MODULE test_options
 
 typedef struct {


### PR DESCRIPTION
Trac ticket:  https://trac.torproject.org/projects/tor/ticket/28938

To reviewers: I did not include `sys/param.h` in `src/ext/ed25519/donna/ed25519-donna-portable-identify.h` because it was already included there.

Thanks!