### PR TITLE
#20006: Allow for client auth when responding to HSFETCH

### DIFF
--- a/changes/feature20006
+++ b/changes/feature20006
@@ -1,0 +1,4 @@
+  o Minor features (controller, Onion Services):
+    - Make HSFETCH support Onion Services that have client auth enabled by
+      checking if we previously received auth cookie from HidServAuth
+      configuration entry. Resolves ticket 20006.

--- a/src/feature/control/control.c
+++ b/src/feature/control/control.c
@@ -4473,7 +4473,7 @@ handle_control_hsfetch(control_connection_t *conn, uint32_t len,
   rend_auth_type_t auth_type = REND_NO_AUTH;
   rend_service_authorization_t *auth = NULL;
 
-  char *cookie = NULL;
+  const char *cookie = NULL;
 
   if (hsaddress) {
     auth = rend_client_lookup_service_authorization(hsaddress);

--- a/src/feature/control/control.c
+++ b/src/feature/control/control.c
@@ -4470,8 +4470,23 @@ handle_control_hsfetch(control_connection_t *conn, uint32_t len,
     }
   }
 
-  rend_query = rend_data_client_create(hsaddress, desc_id, NULL,
-                                       REND_NO_AUTH);
+  rend_auth_type_t auth_type = REND_NO_AUTH;
+  rend_service_authorization_t *auth = NULL;
+
+  char *cookie = NULL;
+
+  if (hsaddress) {
+    auth = rend_client_lookup_service_authorization(hsaddress);
+
+    if (auth) {
+      auth_type = auth->auth_type;
+      cookie = (char *)auth->descriptor_cookie;
+    }
+  }
+
+  rend_query = rend_data_client_create(hsaddress, desc_id,
+                                       (const char *)cookie,
+                                       auth_type);
   if (rend_query == NULL) {
     connection_printf_to_buf(conn, "551 Error creating the HS query\r\n");
     goto done;


### PR DESCRIPTION
Until now Tor could not respond to HSFETCH command properly if
target Onion Service had client auth enabled. Now it checks if
we have an entry for requested address in our map of configured auth
cookies. If one is found, auth cookie is used to request HSDesc.

https://trac.torproject.org/projects/tor/ticket/20006