### PR TITLE
bug28929 Fix typo in bootstrap message

### DIFF
--- a/src/feature/control/control_bootstrap.c
+++ b/src/feature/control/control_bootstrap.c
@@ -73,7 +73,7 @@ static const struct {
   { BOOTSTRAP_STATUS_AP_CONN_DONE_PT, "ap_conn_done_pt",
     "Connected to pluggable transport to build circuits" },
   { BOOTSTRAP_STATUS_AP_CONN_PROXY, "ap_conn_proxy",
-    "Connecting to proxy " },
+    "Connecting to proxy to build circuits" },
   { BOOTSTRAP_STATUS_AP_CONN_DONE_PROXY, "ap_conn_done_proxy",
     "Connected to proxy to build circuits" },
   { BOOTSTRAP_STATUS_AP_CONN, "ap_conn",


### PR DESCRIPTION
The message for the "ap_conn_proxy" bootstrap status tag was missing
some text.  Fixes bug 28929.  Bug not in any released Tor.