### PR TITLE
Fix tor_ersatz_socketpair on IPv6-only systems

### DIFF
--- a/changes/bug28995
+++ b/changes/bug28995
@@ -1,0 +1,5 @@
+  o Minor bugfix (IPv6):
+    Fix tor_ersatz_socketpair on IPv6-only systems.  Previously,
+    the IPv6 socket was bound using an address family of AF_INET
+    instead of AF_INET6.  Fixes bug 28995; bugfix on 0.3.5.1-alpha.
+    Patch from Kris Katterjohn.

--- a/src/lib/net/socketpair.c
+++ b/src/lib/net/socketpair.c
@@ -62,7 +62,7 @@ get_local_listener(int family, int type)
     len = sizeof(sin);
   } else {
     sa = (struct sockaddr *) &sin6;
-    sin6.sin6_family = AF_INET;
+    sin6.sin6_family = AF_INET6;
     sin6.sin6_addr.s6_addr[15] = 1;
     len = sizeof(sin6);
   }


### PR DESCRIPTION
Trac ticket: https://trac.torproject.org/projects/tor/ticket/28995

This replaces PR #631 