### PR TITLE
stats: Make PaddingStatistics depend on ExtraInfoStatistics

### DIFF
--- a/changes/bug29017
+++ b/changes/bug29017
@@ -1,0 +1,4 @@
+  o Minor bugfixes (stats):
+    - When ExtraInfoStatistics is 0, stop including PaddingStatistics in
+      relay and bridge extra-info documents. Fixes bug 29017;
+      bugfix on 0.3.1.1-alpha.

--- a/doc/tor.1.txt
+++ b/doc/tor.1.txt
@@ -2266,7 +2266,7 @@ is non-zero):
     extra-info document. (Default: 0)
 
 [[PaddingStatistics]] **PaddingStatistics** **0**|**1**::
-    Relays only.
+    Relays and bridges only.
     When this option is enabled, Tor collects statistics for padding cells
     sent and received by this relay, in addition to total cell counts.
     These statistics are rounded, and omitted if traffic is low. This

--- a/src/or/router.c
+++ b/src/or/router.c
@@ -3304,12 +3304,11 @@ extrainfo_dump_to_string(char **s_out, extrainfo_t *extrainfo,
                         "conn-bi-direct", now, &contents) > 0) {
       smartlist_add(chunks, contents);
     }
-  }
-
-  if (options->PaddingStatistics) {
-    contents = rep_hist_get_padding_count_lines();
-    if (contents)
-      smartlist_add(chunks, contents);
+    if (options->PaddingStatistics) {
+      contents = rep_hist_get_padding_count_lines();
+      if (contents)
+        smartlist_add(chunks, contents);
+    }
   }
 
   /* Add information about the pluggable transports we support. */


### PR DESCRIPTION
When ExtraInfoStatistics is 0, stop including PaddingStatistics in
relay and bridge extra-info documents.

Fixes bug 29017; bugfix on 0.3.1.1-alpha.