### PR TITLE
rend: stop warning when clients send multiple rend establish cells

### DIFF
--- a/src/or/rendmid.c
+++ b/src/or/rendmid.c
@@ -242,9 +242,9 @@ rend_mid_establish_rendezvous(or_circuit_t *circ, const uint8_t *request,
            (unsigned)circ->p_circ_id);
 
   if (circ->base_.purpose != CIRCUIT_PURPOSE_OR) {
-    log_warn(LD_PROTOCOL,
-             "Tried to establish rendezvous on non-OR circuit with purpose %s",
-             circuit_purpose_to_string(circ->base_.purpose));
+    log_fn(LOG_PROTOCOL_WARN, LD_PROTOCOL,
+           "Tried to establish rendezvous on non-OR circuit with purpose %s",
+           circuit_purpose_to_string(circ->base_.purpose));
     goto err;
   }
 


### PR DESCRIPTION
Instead, make "Tried to establish rendezvous on non-OR circuit" into a protocol warning.

Bug fix on TODO.