### PR TITLE
Log more messages when failing to decode RSA keys

### DIFF
--- a/changes/bug29042
+++ b/changes/bug29042
@@ -1,0 +1,5 @@
+  o Minor bugfixes (logging):
+    - Log more information at "warning" level when unable to read a private
+      key; log more information ad "info" level when unable to read a public
+      key. We had warnings here before, but they were lost during our
+      NSS work. Fixes bug 28981; bugfix on 0.3.5.1-alpha.


### PR DESCRIPTION
We log these messages at INFO level, except when we are reading a
private key from a file, in which case we log at WARN.

This fixes a regression from when we re-wrote our PEM code to be
generic between nss and openssl.

Fixes bug 29042, bugfix on 0.3.5.1-alpha.