### PR TITLE
#29135: Log an HSDesc we failed to parse at Debug loglevel

### DIFF
--- a/changes/bug29135
+++ b/changes/bug29135
@@ -1,0 +1,5 @@
+  o Minor bugfixes (onion services, logging):
+    - In hs_cache_store_as_client() log an HSDesc we failed to parse at Debug
+      loglevel. Tor used to log it at Warning loglevel, which caused
+      very long log lines to appear for some users. Fixes bug 29135; bugfix on
+      0.3.2.1-alpha.

--- a/src/feature/hs/hs_cache.c
+++ b/src/feature/hs/hs_cache.c
@@ -778,8 +778,8 @@ hs_cache_store_as_client(const char *desc_str,
   /* Create client cache descriptor object */
   client_desc = cache_client_desc_new(desc_str, identity_pk);
   if (!client_desc) {
-    log_warn(LD_GENERAL, "Failed to parse received descriptor %s.",
-             escaped(desc_str));
+    log_warn(LD_GENERAL, "HSDesc parsing failed!");
+    log_debug(LD_GENERAL, "Failed to parse HSDesc: %s.", escaped(desc_str));
     goto err;
   }
 


### PR DESCRIPTION
https://trac.torproject.org/projects/tor/ticket/29135