### PR TITLE
#29175: Allow empty username/password in SOCKS5 username/password auth message (0.3.5)

### DIFF
--- a/changes/bug29175_035
+++ b/changes/bug29175_035
@@ -1,0 +1,4 @@
+  o Major bugfixes (networking):
+    - Gracefully handle empty username/password fields in SOCKS5
+      username/password auth messsage and allow SOCKS5 handshake to
+      continue. Fixes bug 29175; bugfix on 0.3.5.1-alpha.

--- a/src/core/proto/proto_socks.c
+++ b/src/core/proto/proto_socks.c
@@ -450,17 +450,21 @@ parse_socks5_userpass_auth(const uint8_t *raw_data, socks_request_t *req,
     tor_free(req->username);
     req->username = tor_memdup_nulterm(username, usernamelen);
     req->usernamelen = usernamelen;
-
-    req->got_auth = 1;
   }
 
   if (passwordlen && password) {
     tor_free(req->password);
     req->password = tor_memdup_nulterm(password, passwordlen);
     req->passwordlen = passwordlen;
-
-    req->got_auth = 1;
   }
+
+  /**
+   * Yes, we allow username and/or password to be empty. Yes, that does
+   * violate RFC 1929. However, some client software can send a username/
+   * password message with these fields being empty and we want to allow them
+   * to be used with Tor.
+   */
+  req->got_auth = 1;
 
   end:
   socks5_client_userpass_auth_free(trunnel_req);


### PR DESCRIPTION
https://trac.torproject.org/projects/tor/ticket/29175