### PR TITLE
#25110: Warn operators who set MyFamily that they must also set ContactInfo

### DIFF
--- a/changes/ticket25110
+++ b/changes/ticket25110
@@ -1,0 +1,4 @@
+  o Minor bugfixes (logging, configuration):
+    - Warn operators when MyFamily option is set but ContactInfo
+      is missing, as the latter should be set too.
+      Fixes bug 25110; bugfix on 0.3.3.1-alpha.

--- a/src/app/config/config.c
+++ b/src/app/config/config.c
@@ -4179,6 +4179,10 @@ options_validate(or_options_t *old_options, or_options_t *options,
              "You should also make sure you aren't listing this bridge's "
              "fingerprint in any other MyFamily.");
   }
+  if (options->MyFamily_lines && !options->ContactInfo) {
+    log_warn(LD_CONFIG, "MyFamily is set but ContactInfo is not configured. "
+             "ContactInfo should always be set when MyFamily option is too.");
+  }
   if (normalize_nickname_list(&options->MyFamily,
                               options->MyFamily_lines, "MyFamily", msg))
     return -1;


### PR DESCRIPTION
[https://trac.torproject.org/projects/tor/ticket/25110](https://trac.torproject.org/projects/tor/ticket/25110)