### PR TITLE
Fix coverage script.

### DIFF
--- a/changes/ticket29435
+++ b/changes/ticket29435
@@ -1,0 +1,3 @@
+  o Minor bugfixes (testing):
+    - Fix our gcov wrapper script to look for object files at the
+      correct locations. Fixes bug 29435; bugfix on 0.3.5.1-alpha.

--- a/scripts/test/coverage
+++ b/scripts/test/coverage
@@ -13,8 +13,8 @@ for fn in src/core/*/*.c src/feature/*/*.c src/app/*/*.c src/lib/*/*.c; do
     F=`echo $BN | sed -e 's/\.c$//;'`
     GC="${BN}.gcov"
     # Figure out the object file names
-    ONS=`echo ${DN}/src_*-${F}.o`
-    ONS_WILDCARD_LITERAL="${DN}/src_*-${F}.o"
+    ONS=$(echo "${DN}"/*testing_a-"${F}".o)
+    ONS_WILDCARD_LITERAL="${DN}/*testing_a-${F}.o"
     # If the wildcard didn't expand, no files
     if [ "$ONS" != "${ONS_WILDCARD_LITERAL}" ]
     then


### PR DESCRIPTION
It was looking for object files made with the old automake
directorations, but those changed when we split up our libraries.

Fixes bug 29435; bugfix on 0.3.5.1-alpha.