### PR TITLE
[Tor Trac #24338]: DirAuths that have IPv6 addresses don't include them in their vote on themself

### DIFF
--- a/changes/bug24338
+++ b/changes/bug24338
@@ -1,0 +1,4 @@
+  o Minor bugfixes (dirauth, ipv6):
+    - If we are a durauth with IPv6 and are marking relays as running, mark
+      ourselves as reachable on IPv6. Fixes bug 24338; bugfix on 0.4.0.2-alpha.
+      Patch by Neel Chauhan


### PR DESCRIPTION
For the ticket [here](https://trac.torproject.org/projects/tor/ticket/24338).