### PR TITLE
#29061: Use setrlimit instead of ulimit -c in backtrace tests

### DIFF
--- a/changes/bug29061
+++ b/changes/bug29061
@@ -1,0 +1,4 @@
+  o Minor bugfixes (testing):
+    - Call setrlimit() to disable core dumps in test_bt_cl.c instead of
+      using `ulimit -c` in test_bt.sh, which violates POSIX shell
+      compatibility. Fixes bug 29061; bugfix on 0.3.5.1-alpha.

--- a/src/test/test_bt.sh
+++ b/src/test/test_bt.sh
@@ -3,8 +3,6 @@
 
 exitcode=0
 
-ulimit -c 0
-
 export ASAN_OPTIONS="handle_segv=0:allow_user_segv_handler=1"
 "${builddir:-.}/src/test/test-bt-cl" backtraces || exit $?
 "${builddir:-.}/src/test/test-bt-cl" assert 2>&1 | "${PYTHON:-python}" "${abs_top_srcdir:-.}/src/test/bt_test.py" || exitcode="$?"

--- a/src/test/test_bt_cl.c
+++ b/src/test/test_bt_cl.c
@@ -4,6 +4,7 @@
 #include "orconfig.h"
 #include <stdio.h>
 #include <stdlib.h>
+#include <sys/resource.h>
 
 /* To prevent 'assert' from going away. */
 #undef TOR_COVERAGE
@@ -87,6 +88,9 @@ main(int argc, char **argv)
          "\"backtraces\" or \"none\"");
     return 1;
   }
+
+  struct rlimit rlim = { .rlim_cur = 0, .rlim_max = 0 };
+  setrlimit(RLIMIT_CORE, &rlim);
 
 #if !(defined(HAVE_EXECINFO_H) && defined(HAVE_BACKTRACE) && \
    defined(HAVE_BACKTRACE_SYMBOLS_FD) && defined(HAVE_SIGACTION))

--- a/src/test/test_bt_cl.c
+++ b/src/test/test_bt_cl.c
@@ -4,7 +4,9 @@
 #include "orconfig.h"
 #include <stdio.h>
 #include <stdlib.h>
+#ifdef HAVE_SYS_RESOURCE_H
 #include <sys/resource.h>
+#endif
 
 /* To prevent 'assert' from going away. */
 #undef TOR_COVERAGE
@@ -89,8 +91,10 @@ main(int argc, char **argv)
     return 1;
   }
 
+#ifdef HAVE_SYS_RESOURCE_H
   struct rlimit rlim = { .rlim_cur = 0, .rlim_max = 0 };
   setrlimit(RLIMIT_CORE, &rlim);
+#endif
 
 #if !(defined(HAVE_EXECINFO_H) && defined(HAVE_BACKTRACE) && \
    defined(HAVE_BACKTRACE_SYMBOLS_FD) && defined(HAVE_SIGACTION))


### PR DESCRIPTION
https://trac.torproject.org/projects/tor/ticket/29061