### PR TITLE
kist: When readding chans, check correct chan's sched_heap_idx

### DIFF
--- a/changes/bug29508
+++ b/changes/bug29508
@@ -1,0 +1,3 @@
+  o Minor bugfixes (scheduler):
+    - When readding channels to the pending list, check the correct channel's
+      sched_heap_idx. Fixes bug 29508; bugfix on 0.3.2.10

--- a/src/core/or/scheduler_kist.c
+++ b/src/core/or/scheduler_kist.c
@@ -724,7 +724,7 @@ kist_scheduler_run(void)
     SMARTLIST_FOREACH_BEGIN(to_readd, channel_t *, readd_chan) {
       scheduler_set_channel_state(readd_chan, SCHED_CHAN_PENDING);
       if (!smartlist_contains(cp, readd_chan)) {
-        if (!SCHED_BUG(chan->sched_heap_idx != -1, chan)) {
+        if (!SCHED_BUG(readd_chan->sched_heap_idx != -1, readd_chan)) {
           /* XXXX Note that the check above is in theory redundant with
            * the smartlist_contains check.  But let's make sure we're
            * not messing anything up, and leave them both for now. */


### PR DESCRIPTION
Closes #29508

Signed-off-by: David Goulet <dgoulet@torproject.org>