### PR TITLE
[Tor Trac #29519]: Tor from Git on FreeBSD: cc src/test/test-slow leads to "/usr/bin/ld: error: unable to find library -levent"

### DIFF
--- a/src/test/include.am
+++ b/src/test/include.am
@@ -259,7 +259,7 @@ src_test_test_LDADD = \
 src_test_test_slow_CPPFLAGS = $(src_test_test_CPPFLAGS)
 src_test_test_slow_CFLAGS = $(src_test_test_CFLAGS)
 src_test_test_slow_LDADD = $(src_test_test_LDADD)
-src_test_test_slow_LDFLAGS =@TOR_LDFLAGS_openssl@
+src_test_test_slow_LDFLAGS = @TOR_LDFLAGS_openssl@ @TOR_LDFLAGS_libevent@
 
 src_test_test_rng_CPPFLAGS = $(src_test_test_CPPFLAGS)
 src_test_test_rng_CFLAGS = $(src_test_test_CFLAGS)


### PR DESCRIPTION
For the ticket [here](https://trac.torproject.org/projects/tor/ticket/29519).