### PR TITLE
Add circuit time check before logging about relaxing circuit time

### DIFF
--- a/changes/bug28698
+++ b/changes/bug28698
@@ -1,0 +1,3 @@
+  o Minor bugfix (logging):
+    - Avoid logging about relaxing circuits when their time is fixed.
+      Fixes bug 28698; bugfix on 0.2.4.7-alpha


### PR DESCRIPTION
Signed-off-by: José M. Guisado <guigom@riseup.net>