### PR TITLE
Fix a compiler warning on OpenBSD

### DIFF
--- a/changes/bug29145
+++ b/changes/bug29145
@@ -1,0 +1,3 @@
+  o Minor bugfixes (compilation, testing):
+    - Silence a compiler warning in test-memwipe.c on OpenBSD.  Fixes
+      bug 29145; bugfix on 0.2.9.3-alpha.  Patch from Kris Katterjohn.

--- a/src/test/test-memwipe.c
+++ b/src/test/test-memwipe.c
@@ -39,7 +39,8 @@ const char *s = NULL;
 #ifdef __OpenBSD__
 /* Disable some of OpenBSD's malloc protections for this test. This helps
  * us do bad things, such as access freed buffers, without crashing. */
-const char *malloc_options="sufjj";
+extern const char *malloc_options;
+const char *malloc_options = "sufjj";
 #endif
 
 static unsigned


### PR DESCRIPTION
malloc_options needs to be declared extern (and declaring it extern
means we need to initialize it separately)

Fixes bug 29145; bugfix on 0.2.9.3-alpha

Signed-off-by: Kris Katterjohn <katterjohn@gmail.com>