### PR TITLE
Mark map_anon_nofork test as skipped in 0.4.0

### DIFF
--- a/src/test/test_util.c
+++ b/src/test/test_util.c
@@ -6360,6 +6360,6 @@ struct testcase_t util_tests[] = {
   UTIL_TEST(get_unquoted_path, 0),
   UTIL_TEST(log_mallinfo, 0),
   UTIL_TEST(map_anon, 0),
-  UTIL_TEST(map_anon_nofork, 0),
+  UTIL_TEST(map_anon_nofork, TT_SKIP /* See bug #29535 */),
   END_OF_TESTCASES
 };


### PR DESCRIPTION
This test fails in some environments; since the code isn't used in
0.4.0, let's disable it for now.

Band-aid solution for #29534; bug not in any released Tor.