### PR TITLE
Update pre-commit.git-hook for ticket 29553

### DIFF
--- a/changes/ticket29553
+++ b/changes/ticket29553
@@ -1,0 +1,5 @@
+  o Minor bugfixes (developer tools):
+    - Update our pre-commit.git-hook script to work correctly on older Tor
+      branches and release branches without any changes files,
+      and to actually exit when something fails.  Fixes bug 29553; bugfix on
+      0.4.0.2-alpha.

--- a/scripts/maint/pre-commit.git-hook
+++ b/scripts/maint/pre-commit.git-hook
@@ -10,16 +10,31 @@ workdir=$(git rev-parse --show-toplevel)
 
 cd "$workdir" || exit 1
 
-python scripts/maint/lintChanges.py ./changes/*
+set -e
 
-perl scripts/maint/checkSpace.pl -C \
-src/lib/*/*.[ch] \
-src/core/*/*.[ch] \
-src/feature/*/*.[ch] \
-src/app/*/*.[ch] \
-src/test/*.[ch] \
-src/test/*/*.[ch] \
-src/tools/*.[ch]
+if [ ! -z "ls ./changes/*" ]; then
+    python scripts/maint/lintChanges.py ./changes/*
+fi
+
+if [ -d src/lib ]; then
+    # This is the layout in 0.3.5
+    perl scripts/maint/checkSpace.pl -C \
+         src/lib/*/*.[ch] \
+         src/core/*/*.[ch] \
+         src/feature/*/*.[ch] \
+         src/app/*/*.[ch] \
+         src/test/*.[ch] \
+         src/test/*/*.[ch] \
+         src/tools/*.[ch]
+elif [ -d src/common]; then
+    # This was the layout before 0.3.5
+    perl scripts/maint/checkSpace.pl -C \
+         src/common/*/*.[ch] \
+         src/or/*/*.[ch] \
+         src/test/*.[ch] \
+         src/test/*/*.[ch] \
+         src/tools/*.[ch]
+fi
 
 if test -e scripts/maint/checkIncludes.py; then
     python scripts/maint/checkIncludes.py


### PR DESCRIPTION
 - handle older source layout
 - handle empty changes directories
 - "set -e" so that  we exit if there's a problem.