### PR TITLE
Re-enable and fix unit test for nofork mappings

### DIFF
--- a/src/lib/malloc/map_anon.h
+++ b/src/lib/malloc/map_anon.h
@@ -34,4 +34,8 @@
 void *tor_mmap_anonymous(size_t sz, unsigned flags);
 void tor_munmap_anonymous(void *mapping, size_t sz);
 
+#ifdef TOR_UNIT_TESTS
+unsigned get_last_anon_map_noinherit(void);
+#endif
+
 #endif /* !defined(TOR_MAP_ANON_H) */


### PR DESCRIPTION
This test was previously written to use the contents of the system
headers to decide whether INHERIT_NONE or INHERIT_ZERO was going to
work.  But that won't work across different environments, such as
(for example) when the kernel doesn't match the headers.  Instead,
we add a testing-only feature to the code to track which of these
options actually worked, and verify that it behaved as we expected.

Closes ticket 29541; bugfix not on any released version of Tor.