### PR TITLE
Fix crash bug in PT subsystem.

### DIFF
--- a/changes/bug29562
+++ b/changes/bug29562
@@ -1,0 +1,4 @@
+  o Minor bugfixes (pluggable transports):
+    - Fix an assertion failure crash bug when a pluggable transport process is
+      terminated during the bootstrap phase. Fixes bug 29562; bugfix on
+      0.4.0.1-alpha.


### PR DESCRIPTION
This patch fixes a crash bug (assertion failure) in the PT subsystem
that could get triggered if the user cancels bootstrap via the UI in
TorBrowser. This would cause Tor to call `managed_proxy_destroy()` which
called `process_free()` after it had called `process_terminate()`. This
leads to a crash when the various process callbacks returns with data
after the `process_t` have been freed using `process_free()`.

We solve this issue by ensuring that everywhere we call
`process_terminate()` we make sure to detach the `managed_proxy_t` from
the `process_t` (by calling `process_set_data(process, NULL)`) and avoid
calling `process_free()` at all in the transports code. Instead we just
call `process_terminate()` and let the process exit callback in
`managed_proxy_exit_callback()` handle the `process_free()` call by
returning true to the process subsystem.

See: https://bugs.torproject.org/29562