### PR TITLE
29599 029: test/shared-random: Stop leaking shared random state in the unit tests

### DIFF
--- a/changes/bug29599
+++ b/changes/bug29599
@@ -1,0 +1,3 @@
+  o Minor bugfixes (memory management, testing):
+    - Stop leaking parts of the shared random state in the shared-random unit
+      tests. Fixes bug 29599; bugfix on 0.2.9.1-alpha.

--- a/src/test/test_shared_random.c
+++ b/src/test/test_shared_random.c
@@ -594,8 +594,8 @@ test_vote(void *arg)
   }
 
  done:
-  sr_commit_free(our_commit);
   UNMOCK(trusteddirserver_get_by_v3_auth_digest);
+  sr_state_free();
 }
 
 static const char *sr_state_str = "Version 1\n"
@@ -829,6 +829,7 @@ test_sr_compute_srv(void *arg)
 
  done:
   UNMOCK(trusteddirserver_get_by_v3_auth_digest);
+  sr_state_free();
 }
 
 /** Return a minimal vote document with a current SRV value set to
@@ -1094,7 +1095,7 @@ test_state_transition(void *arg)
   }
 
  done:
-  return;
+  sr_state_free();
 }
 
 static void


### PR DESCRIPTION
Stop leaking parts of the shared random state in the shared-random unit
tests.

Fixes bug 29599; bugfix on 0.2.9.1-alpha.