### PR TITLE
29612 035: doc: update the man page and sample torrc for ExitRelay

### DIFF
--- a/doc/tor.1.txt
+++ b/doc/tor.1.txt
@@ -1849,15 +1849,16 @@ is non-zero):
 [[ExitRelay]] **ExitRelay** **0**|**1**|**auto**::
     Tells Tor whether to run as an exit relay.  If Tor is running as a
     non-bridge server, and ExitRelay is set to 1, then Tor allows traffic to
-    exit according to the ExitPolicy option (or the default ExitPolicy if
-    none is specified). +
+    exit according to the ExitPolicy option, the ReducedExitPolicy option,
+    or the default ExitPolicy (if no other exit policy option is specified). +
  +
     If ExitRelay is set to 0, no traffic is allowed to
-    exit, and the ExitPolicy option is ignored. +
+    exit, and the ExitPolicy and ReducedExitPolicy options are ignored. +
  +
-    If ExitRelay is set to "auto", then Tor behaves as if it were set to 1, but
-    warns the user if this would cause traffic to exit.  In a future version,
-    the default value will be 0. (Default: auto)
+    If ExitRelay is set to "auto", then Tor checks the ExitPolicy and
+    ReducedExitPolicy options. If either is set, Tor behaves as if ExitRelay
+    were set to 1. If neither exit policy option is set, Tor behaves as if
+    ExitRelay were set to 0. (Default: auto)
 
 [[ExitPolicy]] **ExitPolicy** __policy__,__policy__,__...__::
     Set an exit policy for this server. Each policy is of the form

--- a/src/config/torrc.sample.in
+++ b/src/config/torrc.sample.in
@@ -1,5 +1,5 @@
 ## Configuration file for a typical Tor user
-## Last updated 22 December 2017 for Tor 0.3.2.8-rc.
+## Last updated 28 February 2019 for Tor 0.3.5.1-alpha.
 ## (may or may not work for much older or much newer versions of Tor.)
 ##
 ## Lines that begin with "## " try to explain what's going on. Lines
@@ -172,14 +172,25 @@
 ## Note: do not use MyFamily on bridge relays.
 #MyFamily $keyid,$keyid,...
 
-## Uncomment this if you do *not* want your relay to allow any exit traffic.
-## (Relays allow exit traffic by default.)
-#ExitRelay 0
+## Uncomment this if you want your relay to be an exit, with the default
+## exit policy (or whatever exit policy you set below).
+## (If ReducedExitPolicy or ExitPolicy are set, relays are exits.
+## If neither exit policy option is set, relays are non-exits.)
+#ExitRelay 1
 
 ## Uncomment this if you want your relay to allow IPv6 exit traffic.
-## (Relays only allow IPv4 exit traffic by default.)
+## You must also set ExitRelay, ReducedExitPolicy, or ExitPolicy to make your
+## relay into an exit.
+## (Relays do not allow any exit traffic by default.)
 #IPv6Exit 1
 
+## Uncomment this if you want your relay to be an exit, with a reduced set
+## of exit ports.
+#ReducedExitPolicy 1
+
+## Uncomment these lines if you want your relay to be an exit, with the
+## specified set of exit IPs and ports.
+##
 ## A comma-separated list of exit policies. They're considered first
 ## to last, and the first match wins.
 ##


### PR DESCRIPTION
We changed the default of ExitRelay in #21530 in 0.3.5.1-alpha, but
forgot to update the documentation.

Closes 29612.