### PR TITLE
29144 035: Log the correct "auto" port number for listening sockets

### DIFF
--- a/changes/bug29144
+++ b/changes/bug29144
@@ -1,0 +1,5 @@
+  o Minor bugfixes (logging):
+    - Log the correct port number for listening sockets when "auto" is
+      used to let Tor pick the port number.  Previously, port 0 was
+      logged instead of the actual port number.  Fixes bug 29144;
+      bugfix on 0.3.5.1-alpha.  Patch from Kris Katterjohn.

--- a/src/core/mainloop/connection.c
+++ b/src/core/mainloop/connection.c
@@ -1527,7 +1527,7 @@ connection_listener_new(const struct sockaddr *listensockaddr,
                conn_type_to_string(type), conn->address);
   } else {
     log_notice(LD_NET, "Opened %s on %s",
-               conn_type_to_string(type), fmt_addrport(&addr, usePort));
+               conn_type_to_string(type), fmt_addrport(&addr, gotPort));
   }
   return conn;
 


### PR DESCRIPTION
When "auto" was used for the port number for a listening socket, the
message logged after opening the socket would incorrectly say port 0
instead of the actual port used.

Fixes bug 29144; bugfix on 0.3.5.1-alpha

Signed-off-by: Kris Katterjohn <katterjohn@gmail.com>