### PR TITLE
25116 029: Make circuit_log_ancient_one_hop_circuits() ignore established servic…

### DIFF
--- a/changes/bug25116
+++ b/changes/bug25116
@@ -1,0 +1,4 @@
+  o Minor bugfixes (hidden service, heartbeat):
+    - Don't log in the heartbeat any long term established one hop rendezvous
+      points if tor is a single onion service. Fixes bug 25116; bugfix on
+      0.2.9.6-rc;

--- a/src/or/circuituse.c
+++ b/src/or/circuituse.c
@@ -808,10 +808,10 @@ circuit_log_ancient_one_hop_circuits(int age)
     if (circ->timestamp_created.tv_sec >= cutoff)
       continue;
     /* Single Onion Services deliberately make long term one-hop intro
-     * connections. We only ignore active intro point connections, if we take
-     * a long time establishing, that's worth logging. */
+     * and rendezvous connections. Don't log the established ones. */
     if (rend_service_allow_non_anonymous_connection(options) &&
-        circ->purpose == CIRCUIT_PURPOSE_S_INTRO)
+        (circ->purpose == CIRCUIT_PURPOSE_S_INTRO ||
+         circ->purpose == CIRCUIT_PURPOSE_S_REND_JOINED))
       continue;
     /* Tor2web deliberately makes long term one-hop rend connections,
      * particularly when Tor2webRendezvousPoints is used. We only ignore


### PR DESCRIPTION
…e rendezvous

Services can keep rendezvous circuits for a while so don't log them if tor is
a single onion service.

Fixes #25116

Signed-off-by: David Goulet <dgoulet@torproject.org>