### PR TITLE
24903 029: When extending a circuit's path length, clear onehop_tunnel.

### DIFF
--- a/changes/bug24903
+++ b/changes/bug24903
@@ -1,0 +1,5 @@
+  o Minor bugfixes (controller, reliability):
+    - Avoid a (nonfatal) assertion failure when extending a one-hop circuit
+      from the controller to become a multihop circuit. Fixes bug 24903;
+      bugfix on 0.2.5.2-alpha.
+

--- a/src/or/control.c
+++ b/src/or/control.c
@@ -3364,6 +3364,9 @@ handle_control_extendcircuit(control_connection_t *conn, uint32_t len,
       tor_assert(info);
     }
     circuit_append_new_exit(circ, info);
+    if (circ->build_state->desired_path_len > 1) {
+      circ->build_state->onehop_tunnel = 0;
+    }
     extend_info_free(info);
     first_node = 0;
   });


### PR DESCRIPTION
There was a nonfatal assertion in pathbias_should_count that would
trigger if onehop_tunnel was set, but the desired_path_length was
greater than 1.  This patch fixes that.  Fixes bug 24903; bugfix on
0.2.5.2-alpha.