### PR TITLE
#29635: manpage: fix formatting of example on quoting options with spaces

### DIFF
--- a/changes/ticket29635
+++ b/changes/ticket29635
@@ -1,0 +1,3 @@
+  o Minor bugfixes (documentation, manpage):
+    - Use proper formatting when providing an example on quoting options that
+      contain whitespace. Fixes bug 29635; bugfix on 0.2.3.18-rc.

--- a/doc/tor.1.txt
+++ b/doc/tor.1.txt
@@ -147,8 +147,8 @@ instance, you can tell Tor to start listening for SOCKS connections on port
 9999 by passing --SocksPort 9999 or SocksPort 9999 to it on the command line,
 or by putting "SocksPort 9999" in the configuration file.  You will need to
 quote options with spaces in them: if you want Tor to log all debugging
-messages to debug.log, you will probably need to say --Log 'debug file
-debug.log'.
+messages to debug.log, you will probably need to say **--Log** `"debug file
+debug.log"`.
 
 Options on the command line override those in configuration files. See the
 next section for more information.


### PR DESCRIPTION
https://trac.torproject.org/projects/tor/ticket/29635