### PR TITLE
doc: Fix an incorrect comment about calling FreeLibrary() on Windows

### DIFF
--- a/src/lib/time/compat_time.c
+++ b/src/lib/time/compat_time.c
@@ -522,7 +522,9 @@ monotime_init_internal(void)
     GetTickCount64_fn = (GetTickCount64_fn_t)
       GetProcAddress(h, "GetTickCount64");
   }
-  // FreeLibrary(h) ?
+  // We can't call FreeLibrary(h) here, because freeing the handle may
+  // unload the library, and cause future calls to GetTickCount64_fn()
+  // to fail. See 29642 for details.
 }
 
 void


### PR DESCRIPTION
There's an incorrect comment in compat_time.c that suggests we call
FreeLibrary() before we're done using the library's functions.
See 29642 for background.

Closes ticket 29643.