### PR TITLE
Stop logging a BUG() warning when tor is waiting for exit descriptors

### DIFF
--- a/changes/bug28656
+++ b/changes/bug28656
@@ -1,0 +1,3 @@
+  o Minor bugfixes (logging):
+    - Stop logging a BUG() warning when tor is waiting for exit descriptors.
+      Fixes bug 28656; bugfix on 0.3.5.1-alpha.

--- a/src/feature/nodelist/nodelist.c
+++ b/src/feature/nodelist/nodelist.c
@@ -2456,8 +2456,11 @@ compute_frac_paths_available(const networkstatus_t *consensus,
      * descriptors for those exits. (The bandwidth weight fraction does not
      * check for descriptors.)
      * If the exit bandwidth fraction is zero, there are no exits in the
-     * consensus at all. So it is safe to replace f_exit with f_mid. */
-    if (f_exit == 0.0) {
+     * consensus at all. So it is safe to replace f_exit with f_mid.
+     *
+     * f_exit is non-negative, but some compilers complain about float and ==
+     */
+    if (f_exit <= 0.0)) {
       f_exit = f_mid;
     }
   }

--- a/src/feature/nodelist/nodelist.c
+++ b/src/feature/nodelist/nodelist.c
@@ -2460,7 +2460,7 @@ compute_frac_paths_available(const networkstatus_t *consensus,
      *
      * f_exit is non-negative, but some compilers complain about float and ==
      */
-    if (f_exit <= 0.0)) {
+    if (f_exit <= 0.0) {
       f_exit = f_mid;
     }
   }

--- a/src/feature/nodelist/nodelist.c
+++ b/src/feature/nodelist/nodelist.c
@@ -2449,12 +2449,15 @@ compute_frac_paths_available(const networkstatus_t *consensus,
       f_exit = f_myexit;
   }
 
-  /* if the consensus has no exits, we can only build onion service paths,
-   * which are G - M - M. So use the middle fraction for the exit fraction. */
+  /* If the consensus has no exits that pass flag, descriptor, and policy
+   * checks, we can only build onion service paths, which are G - M - M. */
   if (router_have_consensus_path() != CONSENSUS_PATH_EXIT) {
-    /* If there are no exits in the consensus, then f_exit is always 0, so
-     * it is safe to replace f_exit with f_mid. */
-    if (!BUG(f_exit > 0.0)) {
+    /* If the exit bandwidth weight fraction is not zero, we need to wait for
+     * descriptors for those exits. (The bandwidth weight fraction does not
+     * check for descriptors.)
+     * If the exit bandwidth fraction is zero, there are no exits in the
+     * consensus at all. So it is safe to replace f_exit with f_mid. */
+    if (f_exit == 0.0) {
       f_exit = f_mid;
     }
   }


### PR DESCRIPTION
Fixes bug 28656; bugfix on 0.3.5.1-alpha.