### PR TITLE
circuit: Don't timeout opened C_INTRODUCING circuit

### DIFF
--- a/changes/bug23681
+++ b/changes/bug23681
@@ -1,0 +1,5 @@
+  o Minor bugfixes (hidden service client):
+    - The introduction circuit was being timed out too quickly while waiting
+      for the rendezvous circuit to complete. Keep the intro circuit around
+      longer instead of timing out and reopening new ones constantly. Fixes
+      bug 23681; bugfix on 0.2.4.8-alpha.


### PR DESCRIPTION
A circuit with purpose C_INTRODUCING means that its state is opened but the
INTRODUCE1 cell hasn't been sent yet. We shouldn't consider that circuit when
looking for timing out "building circuit". We have to wait on the rendezvous
circuit to be opened before sending that cell so the intro circuit needs to be
kept alive for at least that period of time.

This patch makes that the purpose C_INTRODUCING is ignored in the
circuit_expire_building() which means that we let the circuit idle timeout
take care of it if we end up never using it.

Fixes #23681

Signed-off-by: David Goulet <dgoulet@torproject.org>