### PR TITLE
protover: reject unexpected commas

### DIFF
--- a/changes/bug27194
+++ b/changes/bug27194
@@ -1,0 +1,3 @@
+  o Minor bugfixes (protover):
+    - Consistently reject extra commas, instead of only rejecting leading commas.
+      Fixes bug 27194; bugfix on 0.2.9.4-alpha.

--- a/src/or/protover.c
+++ b/src/or/protover.c
@@ -212,7 +212,8 @@ parse_single_entry(const char *s, const char *end_of_entry)
     }
 
     s = comma;
-    while (*s == ',' && s < end_of_entry)
+    // Skip the comma separator between ranges. Don't ignore a trailing comma.
+    if (s < (end_of_entry - 1))
       ++s;
   }
 

--- a/src/test/test_protover.c
+++ b/src/test/test_protover.c
@@ -296,6 +296,10 @@ test_protover_vote_roundtrip(void *args)
     { "N-1=1,2", "N-1=1-2" },
     { "-1=4294967295", NULL },
     { "-1=3", "-1=3" },
+    { "Foo=,", NULL },
+    { "Foo=,1", NULL },
+    { "Foo=1,,3", NULL },
+    { "Foo=1,3,", NULL },
     /* junk. */
     { "!!3@*", NULL },
     /* Missing equals sign */


### PR DESCRIPTION
Consistently reject extra commas, instead of only rejecting leading
commas.

Fix on b2b2e1c7f24d9b65059e3d089768d6c49ba4f58f.
Fixes #27194; bugfix on 0.2.9.4-alpha.