### PR TITLE
hs-v2: Copy needed information between service on prunning

### DIFF
--- a/changes/bug23790
+++ b/changes/bug23790
@@ -1,0 +1,6 @@
+  o Minor bugfixes (hidden service v2):
+    - When reloading tor (HUP) configured with hidden service(s), some
+      information weren't copy to the new service object. One problem with this
+      was that tor would wait at least the RendPostPeriod time before uploading
+      the descriptor if the reload happened before the descriptor needed to be
+      published. Fixes bug 23790; bugfix on 0.2.1.9-alpha.


### PR DESCRIPTION
Turns out that when reloading a tor configured with hidden service(s), we
weren't copying all the needed information between the old service object to
the new one.

For instance, the desc_is_dirty timestamp wasn't which could lead to the
service uploading its descriptor much later than it would need to.

The replaycache wasn't also moved over and some intro point information as
well.

Fixes #23790

Signed-off-by: David Goulet <dgoulet@torproject.org>