### PR TITLE
test/sr: Free SRVs before replacing them in test_sr_setup_srv()

### DIFF
--- a/changes/bug29706_minimal
+++ b/changes/bug29706_minimal
@@ -1,0 +1,4 @@
+  o Minor bugfixes (memory management, testing):
+    - Stop leaking parts of the shared random state in the shared-random unit
+      tests. The previous fix in 29599 was incomplete.
+      Fixes bug 29706; bugfix on 0.2.9.1-alpha.

--- a/src/or/shared_random_state.c
+++ b/src/or/shared_random_state.c
@@ -1007,7 +1007,7 @@ state_query(sr_state_action_t action, sr_state_object_t obj_type,
 
 /* Delete the current SRV value from the state freeing it and the value is set
  * to NULL meaning empty. */
-static void
+STATIC void
 state_del_current_srv(void)
 {
   state_query(SR_STATE_ACTION_DEL, SR_STATE_OBJ_CURSRV, NULL, NULL);
@@ -1015,7 +1015,7 @@ state_del_current_srv(void)
 
 /* Delete the previous SRV value from the state freeing it and the value is
  * set to NULL meaning empty. */
-static void
+STATIC void
 state_del_previous_srv(void)
 {
   state_query(SR_STATE_ACTION_DEL, SR_STATE_OBJ_PREVSRV, NULL, NULL);

--- a/src/or/shared_random_state.h
+++ b/src/or/shared_random_state.h
@@ -140,6 +140,8 @@ STATIC int is_phase_transition(sr_phase_t next_phase);
 
 STATIC void set_sr_phase(sr_phase_t phase);
 STATIC sr_state_t *get_sr_state(void);
+STATIC void state_del_previous_srv(void);
+STATIC void state_del_current_srv(void);
 
 #endif /* TOR_UNIT_TESTS */
 

--- a/src/test/test_shared_random.c
+++ b/src/test/test_shared_random.c
@@ -461,6 +461,8 @@ test_sr_setup_srv(int also_current)
          "ZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZ",
          sizeof(srv->value));
 
+ /* sr_state_set_previous_srv() does not free() the old previous srv. */
+ state_del_previous_srv();
  sr_state_set_previous_srv(srv);
 
  if (also_current) {
@@ -470,6 +472,8 @@ test_sr_setup_srv(int also_current)
           "NNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNN",
           sizeof(srv->value));
 
+   /* sr_state_set_previous_srv() does not free() the old current srv. */
+   state_del_current_srv();
    sr_state_set_current_srv(srv);
  }
 }

--- a/src/test/test_shared_random.c
+++ b/src/test/test_shared_random.c
@@ -54,6 +54,9 @@ init_authority_state(void)
    * the phase we are currently in which uses "now" as the starting
    * timestamp. Delete it before we do any testing below. */
   sr_state_delete_commits();
+  /* It's also possible that a current SRV has been generated, if we are at
+   * state transition time. But let's just forget about that SRV. */
+  sr_state_clean_srvs();
 
  done:
   UNMOCK(get_my_v3_authority_cert);
@@ -449,20 +452,26 @@ test_encoding(void *arg)
   ;
 }
 
-/** Setup some SRVs in our SR state. If <b>also_current</b> is set, then set
- *  both current and previous SRVs.
- *  Helper of test_vote() and test_sr_compute_srv(). */
+/** Setup some SRVs in our SR state.
+ *  If <b>also_current</b> is set, then set both current and previous SRVs.
+ *  Otherwise, just set the previous SRV. (And clear the current SRV.)
+ *
+ * You must call sr_state_free() to free the state at the end of each test
+ * function (on pass or fail). */
 static void
 test_sr_setup_srv(int also_current)
 {
+  /* Clear both SRVs before starting.
+   * In 0.3.5 and earlier, sr_state_set_previous_srv() and
+   * sr_state_set_current_srv() do not free() the old srvs. */
+  sr_state_clean_srvs();
+
   sr_srv_t *srv = tor_malloc_zero(sizeof(sr_srv_t));
   srv->num_reveals = 42;
   memcpy(srv->value,
          "ZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZ",
          sizeof(srv->value));
 
- /* sr_state_set_previous_srv() does not free() the old previous srv. */
- state_del_previous_srv();
  sr_state_set_previous_srv(srv);
 
  if (also_current) {
@@ -472,8 +481,6 @@ test_sr_setup_srv(int also_current)
           "NNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNN",
           sizeof(srv->value));
 
-   /* sr_state_set_previous_srv() does not free() the old current srv. */
-   state_del_current_srv();
    sr_state_set_current_srv(srv);
  }
 }


### PR DESCRIPTION
Stop leaking parts of the shared random state in the shared-random unit
tests. The previous fix in 29599 was incomplete.

Fixes bug 29706; bugfix on 0.2.9.1-alpha.