### PR TITLE
Fix shellcheck warnings in pull-all/merge-all scripts

### DIFF
--- a/scripts/maint/git-merge-forward.sh
+++ b/scripts/maint/git-merge-forward.sh
@@ -53,6 +53,18 @@ RELEASE_040=( "release-0.4.0" "maint-0.4.0" "$GIT_PATH/$TOR_WKT_NAME/release-0.4
 # from that repository.
 ORIGIN_PATH="$GIT_PATH/$TOR_MASTER_NAME"
 
+# SC2034 -- shellcheck thinks that these are unused.  We know better.
+ACTUALLY_THESE_ARE_USED=<<EOF
+${MAINT_034[0]}
+${MAINT_035[0]}
+${MAINT_040[0]}
+${MAINT_MASTER[0]}
+${RELEASE_029[0]}
+${RELEASE_034[0]}
+${RELEASE_035[0]}
+${RELEASE_040[0]}
+EOF
+
 ##########################
 # Git Worktree to manage #
 ##########################

--- a/scripts/maint/git-pull-all.sh
+++ b/scripts/maint/git-pull-all.sh
@@ -52,6 +52,19 @@ RELEASE_040=( "release-0.4.0" "$GIT_PATH/$TOR_WKT_NAME/release-0.4.0" )
 # from that repository.
 ORIGIN_PATH="$GIT_PATH/$TOR_MASTER_NAME"
 
+# SC2034 -- shellcheck thinks that these are unused.  We know better.
+ACTUALLY_THESE_ARE_USED=<<EOF
+${MAINT_029[0]}
+${MAINT_034[0]}
+${MAINT_035[0]}
+${MAINT_040[0]}
+${MAINT_MASTER[0]}
+${RELEASE_029[0]}
+${RELEASE_034[0]}
+${RELEASE_035[0]}
+${RELEASE_040[0]}
+EOF
+
 ##########################
 # Git Worktree to manage #
 ##########################


### PR DESCRIPTION
This appears at first glance to be a shellcheck bug.

Closes 29747.  Bugfix not in any released Tor.