### PR TITLE
#29702:  Use empty torrc file when launching tor in test_rebind.py

### DIFF
--- a/changes/ticket29702
+++ b/changes/ticket29702
@@ -1,0 +1,4 @@
+  o Testing:
+    - Specify torrc path (with empty file) when launching tor from
+      test_rebind.py; refrain from relying on default torrc path. Resolves
+      issue 29702.

--- a/src/test/test_rebind.py
+++ b/src/test/test_rebind.py
@@ -83,13 +83,17 @@ if not os.path.exists(sys.argv[2]):
 tor_path = sys.argv[1]
 data_dir = sys.argv[2]
 
+empty_torrc_path = os.path.join(data_dir, 'empty_torrc')
+open(empty_torrc_path, 'w').close()
+
 tor_process = subprocess.Popen([tor_path,
                                '-DataDirectory', data_dir,
                                '-ControlPort', '127.0.0.1:{}'.format(control_port),
                                '-SOCKSPort', '127.0.0.1:{}'.format(socks_port),
                                '-Log', 'debug stdout',
                                '-LogTimeGranularity', '1',
-                               '-FetchServerDescriptors', '0'],
+                               '-FetchServerDescriptors', '0',
+                               '-f', empty_torrc_path],
                                stdout=subprocess.PIPE,
                                stderr=subprocess.PIPE)
 


### PR DESCRIPTION
https://trac.torproject.org/projects/tor/ticket/29702