### PR TITLE
ticket29196 circ: Remove n_mux and p_mux members

### DIFF
--- a/src/core/or/circuit_st.h
+++ b/src/core/or/circuit_st.h
@@ -66,12 +66,6 @@ struct circuit_t {
    */
   circid_t n_circ_id;
 
-  /**
-   * Circuit mux associated with n_chan to which this circuit is attached;
-   * NULL if we have no n_chan.
-   */
-  circuitmux_t *n_mux;
-
   /** Queue of cells waiting to be transmitted on n_chan */
   cell_queue_t n_chan_cells;
 

--- a/src/core/or/circuitlist.c
+++ b/src/core/or/circuitlist.c
@@ -2433,13 +2433,9 @@ marked_circuit_free_cells(circuit_t *circ)
     return;
   }
   cell_queue_clear(&circ->n_chan_cells);
-  if (circ->n_mux)
-    circuitmux_clear_num_cells(circ->n_mux, circ);
   if (! CIRCUIT_IS_ORIGIN(circ)) {
     or_circuit_t *orcirc = TO_OR_CIRCUIT(circ);
     cell_queue_clear(&orcirc->p_chan_cells);
-    if (orcirc->p_mux)
-      circuitmux_clear_num_cells(orcirc->p_mux, circ);
   }
 }
 

--- a/src/core/or/or_circuit_st.h
+++ b/src/core/or/or_circuit_st.h
@@ -33,11 +33,6 @@ struct or_circuit_t {
   cell_queue_t p_chan_cells;
   /** The channel that is previous in this circuit. */
   channel_t *p_chan;
-  /**
-   * Circuit mux associated with p_chan to which this circuit is attached;
-   * NULL if we have no p_chan.
-   */
-  circuitmux_t *p_mux;
   /** Linked list of Exit streams associated with this circuit. */
   edge_connection_t *n_streams;
   /** Linked list of Exit streams associated with this circuit that are

--- a/src/test/test_channel.c
+++ b/src/test/test_channel.c
@@ -598,7 +598,6 @@ test_channel_outbound_cell(void *arg)
   circuit_set_n_circid_chan(TO_CIRCUIT(circ), 42, chan);
   tt_int_op(channel_num_circuits(chan), OP_EQ, 1);
   /* Test the cmux state. */
-  tt_ptr_op(TO_CIRCUIT(circ)->n_mux, OP_EQ, chan->cmux);
   tt_int_op(circuitmux_is_circuit_attached(chan->cmux, TO_CIRCUIT(circ)),
             OP_EQ, 1);
 

--- a/src/test/test_circuitpadding.c
+++ b/src/test/test_circuitpadding.c
@@ -116,7 +116,6 @@ new_fake_orcirc(channel_t *nchan, channel_t *pchan)
 
   //circ->n_chan = nchan;
   circ->n_circ_id = get_unique_circ_id_by_chan(nchan);
-  circ->n_mux = NULL; /* ?? */
   cell_queue_init(&(circ->n_chan_cells));
   circ->n_hop = NULL;
   circ->streams_blocked_on_n_chan = 0;


### PR DESCRIPTION
They are simply not used apart from assigning a pointer and asserting on the
pointer depending on the cell direction.

Closes #29196.

Signed-off-by: David Goulet <dgoulet@torproject.org>