### PR TITLE
bwauth: Ignore bandwidth file lines with "vote=0"

### DIFF
--- a/changes/ticket29806
+++ b/changes/ticket29806
@@ -1,0 +1,7 @@
+  o Minor features (bandwidth authority):
+    - Make bandwidth authorities to ignore relays that are reported in the
+      bandwidth file with the key-value "vote=0".
+      This change allows to report the relays that were not measured due
+      some failure and diagnose the reasons without being included in the
+      bandwidth authorities vote.
+      Closes ticket 29806.

--- a/src/feature/dirauth/bwauth.c
+++ b/src/feature/dirauth/bwauth.c
@@ -366,7 +366,13 @@ measured_bw_line_parse(measured_bw_line_t *out, const char *orig_line,
   }
 
   do {
-    if (strcmpstart(cp, "bw=") == 0) {
+    // If the line contains vote=0, ignore it.
+    if (strcmpstart(cp, "vote=0") == 0) {
+      log_debug(LD_DIRSERV, "Ignoring bandwidth file line that contains "
+                "vote=0: %s",escaped(orig_line));
+      tor_free(line);
+      return -1;
+    } else if (strcmpstart(cp, "bw=") == 0) {
       int parse_ok = 0;
       char *endptr;
       if (got_bw) {

--- a/src/test/test_dir.c
+++ b/src/test/test_dir.c
@@ -1714,6 +1714,8 @@ test_dir_dirserv_read_measured_bandwidths(void *arg)
     "bw=760 nick=Test rtt=380 time=2018-05-08T16:13:26\n";
   const char *relay_lines_bad =
     "node_id=$68A483E05A2ABDCA6DA5A3EF8DB5177638A\n";
+  const char *relay_lines_ignore =
+    "node_id=$68A483E05A2ABDCA6DA5A3EF8DB5177638A27F80 bw=1024 vote=0\n";
 
   tor_asprintf(&header_lines_v100, "%ld\n", (long)timestamp);
   tor_asprintf(&header_lines_v110_no_terminator, "%ld\n%s", (long)timestamp,
@@ -1978,6 +1980,25 @@ test_dir_dirserv_read_measured_bandwidths(void *arg)
   SMARTLIST_FOREACH(bw_file_headers, char *, c, tor_free(c));
   smartlist_free(bw_file_headers);
   tor_free(bw_file_headers_str);
+
+  /* Test v1.x.x bandwidth line with vote=0.
+   * It will be ignored it and logged it at debug level. */
+  /* Create the bandwidth file */
+  tor_asprintf(&content, "%s%s%s",
+               header_lines_v110, relay_lines_v110, relay_lines_ignore);
+  write_str_to_file(fname, content, 0);
+  tor_free(content);
+
+  /* Read the bandwidth file */
+  bw_file_headers = smartlist_new();
+  setup_full_capture_of_logs(LOG_DEBUG);
+  tt_int_op(0, OP_EQ, dirserv_read_measured_bandwidths(fname, NULL,
+                                                       bw_file_headers));
+  SMARTLIST_FOREACH(bw_file_headers, char *, c, tor_free(c));
+  smartlist_free(bw_file_headers);
+  expect_log_msg_containing("Ignoring bandwidth file line");
+  expect_log_msg_containing("Applied 0 measurements.");
+  teardown_capture_of_logs();
 
  done:
   tor_free(fname);


### PR DESCRIPTION
so that the relays that would be "excluded" from the bandwidth
file because of something failed can be included to diagnose what
failed, without still including these relays in the bandwidth
authorities vote.

Closes #29806.