### PR TITLE
bug28925 Correctly report PT vs proxy during bootstrap

### DIFF
--- a/changes/bug28925
+++ b/changes/bug28925
@@ -1,0 +1,4 @@
+  o Minor bugfixes (bootstrap reporting):
+    - During bootstrap reporting, correctly distinguish pluggable
+      transports from plain proxies. Fixes bug 28925; bugfix on
+      0.4.0.1-alpha.

--- a/src/core/mainloop/connection.c
+++ b/src/core/mainloop/connection.c
@@ -5368,7 +5368,7 @@ assert_connection_ok(connection_t *conn, time_t now)
  */
 int
 get_proxy_addrport(tor_addr_t *addr, uint16_t *port, int *proxy_type,
-                   const connection_t *conn)
+                   int *is_pt, const connection_t *conn)
 {
   const or_options_t *options = get_options();
 
@@ -5387,6 +5387,7 @@ get_proxy_addrport(tor_addr_t *addr, uint16_t *port, int *proxy_type,
       tor_addr_copy(addr, &transport->addr);
       *port = transport->port;
       *proxy_type = transport->socks_version;
+      *is_pt = 1;
       return 0;
     }
 
@@ -5423,11 +5424,13 @@ log_failed_proxy_connection(connection_t *conn)
 {
   tor_addr_t proxy_addr;
   uint16_t proxy_port;
-  int proxy_type;
+  int proxy_type, is_pt;
 
-  if (get_proxy_addrport(&proxy_addr, &proxy_port, &proxy_type, conn) != 0)
+  if (get_proxy_addrport(&proxy_addr, &proxy_port, &proxy_type, &is_pt,
+                         conn) != 0)
     return; /* if we have no proxy set up, leave this function. */
 
+  (void)is_pt;
   log_warn(LD_NET,
            "The connection to the %s proxy server at %s just failed. "
            "Make sure that the proxy server is up and running.",

--- a/src/core/mainloop/connection.c
+++ b/src/core/mainloop/connection.c
@@ -5361,17 +5361,20 @@ assert_connection_ok(connection_t *conn, time_t now)
 }
 
 /** Fills <b>addr</b> and <b>port</b> with the details of the global
- *  proxy server we are using.
- *  <b>conn</b> contains the connection we are using the proxy for.
+ *  proxy server we are using. Store a 1 to the int pointed to by
+ *  <b>is_put_out</b> if the connection is using a pluggable
+ *  transport; store 0 otherwise. <b>conn</b> contains the connection
+ *  we are using the proxy for.
  *
  *  Return 0 on success, -1 on failure.
  */
 int
 get_proxy_addrport(tor_addr_t *addr, uint16_t *port, int *proxy_type,
-                   int *is_pt, const connection_t *conn)
+                   int *is_pt_out, const connection_t *conn)
 {
   const or_options_t *options = get_options();
 
+  *is_pt_out = 0;
   /* Client Transport Plugins can use another proxy, but that should be hidden
    * from the rest of tor (as the plugin is responsible for dealing with the
    * proxy), check it first, then check the rest of the proxy types to allow
@@ -5387,7 +5390,7 @@ get_proxy_addrport(tor_addr_t *addr, uint16_t *port, int *proxy_type,
       tor_addr_copy(addr, &transport->addr);
       *port = transport->port;
       *proxy_type = transport->socks_version;
-      *is_pt = 1;
+      *is_pt_out = 1;
       return 0;
     }
 

--- a/src/core/mainloop/connection.h
+++ b/src/core/mainloop/connection.h
@@ -187,7 +187,7 @@ int connection_proxy_connect(connection_t *conn, int type);
 int connection_read_proxy_handshake(connection_t *conn);
 void log_failed_proxy_connection(connection_t *conn);
 int get_proxy_addrport(tor_addr_t *addr, uint16_t *port, int *proxy_type,
-                       const connection_t *conn);
+                       int *is_pt, const connection_t *conn);
 
 int retry_all_listeners(smartlist_t *new_conns,
                         int close_all_noncontrol);

--- a/src/core/mainloop/connection.h
+++ b/src/core/mainloop/connection.h
@@ -187,7 +187,7 @@ int connection_proxy_connect(connection_t *conn, int type);
 int connection_read_proxy_handshake(connection_t *conn);
 void log_failed_proxy_connection(connection_t *conn);
 int get_proxy_addrport(tor_addr_t *addr, uint16_t *port, int *proxy_type,
-                       int *is_pt, const connection_t *conn);
+                       int *is_pt_out, const connection_t *conn);
 
 int retry_all_listeners(smartlist_t *new_conns,
                         int close_all_noncontrol);

--- a/src/core/or/connection_or.c
+++ b/src/core/or/connection_or.c
@@ -441,7 +441,7 @@ connection_or_state_publish(const or_connection_t *conn, uint8_t state)
     /* Do extra decoding because conn->proxy_type indicates the proxy
      * protocol that tor uses to talk with the transport plugin,
      * instead of PROXY_PLUGGABLE. */
-    tor_assert(conn->proxy_type != PROXY_NONE);
+    tor_assert_nonfatal(conn->proxy_type != PROXY_NONE);
     msg.u.state.proxy_type = PROXY_PLUGGABLE;
   } else {
     msg.u.state.proxy_type = conn->proxy_type;

--- a/src/core/or/connection_or.c
+++ b/src/core/or/connection_or.c
@@ -437,7 +437,15 @@ connection_or_state_publish(const or_connection_t *conn, uint8_t state)
 
   msg.type = ORCONN_MSGTYPE_STATE;
   msg.u.state.gid = conn->base_.global_identifier;
-  msg.u.state.proxy_type = conn->proxy_type;
+  if (conn->is_pt) {
+    /* Do extra decoding because conn->proxy_type indicates the proxy
+     * protocol that tor uses to talk with the transport plugin,
+     * instead of PROXY_PLUGGABLE. */
+    tor_assert(conn->proxy_type != PROXY_NONE);
+    msg.u.state.proxy_type = PROXY_PLUGGABLE;
+  } else {
+    msg.u.state.proxy_type = conn->proxy_type;
+  }
   msg.u.state.state = state;
   if (conn->chan) {
     msg.u.state.chan = TLS_CHAN_TO_BASE(conn->chan)->global_identifier;
@@ -1472,7 +1480,7 @@ connection_or_connect, (const tor_addr_t *_addr, uint16_t port,
   int r;
   tor_addr_t proxy_addr;
   uint16_t proxy_port;
-  int proxy_type;
+  int proxy_type, is_pt = 0;
 
   tor_assert(_addr);
   tor_assert(id_digest);
@@ -1516,13 +1524,15 @@ connection_or_connect, (const tor_addr_t *_addr, uint16_t port,
   conn->is_outgoing = 1;
 
   /* If we are using a proxy server, find it and use it. */
-  r = get_proxy_addrport(&proxy_addr, &proxy_port, &proxy_type, TO_CONN(conn));
+  r = get_proxy_addrport(&proxy_addr, &proxy_port, &proxy_type, &is_pt,
+                         TO_CONN(conn));
   if (r == 0) {
     conn->proxy_type = proxy_type;
     if (proxy_type != PROXY_NONE) {
       tor_addr_copy(&addr, &proxy_addr);
       port = proxy_port;
       conn->base_.proxy_state = PROXY_INFANT;
+      conn->is_pt = is_pt;
     }
     connection_or_change_state(conn, OR_CONN_STATE_CONNECTING);
     connection_or_event_status(conn, OR_CONN_EVENT_LAUNCHED, 0);

--- a/src/core/or/or_connection_st.h
+++ b/src/core/or/or_connection_st.h
@@ -67,6 +67,8 @@ struct or_connection_t {
    * geoip cache and handled by the DoS mitigation subsystem. We use this to
    * insure we have a coherent count of concurrent connection. */
   unsigned int tracked_for_dos_mitigation : 1;
+  /** True iff this connection is using a pluggable transport */
+  unsigned int is_pt : 1;
 
   uint16_t link_proto; /**< What protocol version are we using? 0 for
                         * "none negotiated yet." */


### PR DESCRIPTION
Previously, or_connection_t did not record whether or not the
connection uses a pluggable transport. Instead, it stored the
underlying proxy protocol of the pluggable transport in
proxy_type. This made bootstrap reporting treat pluggable transport
connections as plain proxy connections.

Store a separate bit indicating whether a pluggable transport is in
use, and decode this during bootstrap reporting.

Fixes bug 28925; bugfix on 0.4.0.1-alpha.