### PR TITLE
#29874: Pass NULL to lpApplicationName in CreateProcessA().

### DIFF
--- a/changes/bug29874
+++ b/changes/bug29874
@@ -1,0 +1,4 @@
+  o Minor bugfixes (pluggable transports):
+    - Restore old behaviour when it comes to discovering the path of a given
+      Pluggable Transport exe-file. Fixes bug 29874; bugfix on 0.4.0.1-alpha.
+

--- a/src/lib/process/process_win32.c
+++ b/src/lib/process/process_win32.c
@@ -152,11 +152,6 @@ process_win32_exec(process_t *process)
   HANDLE stdin_pipe_read = NULL;
   HANDLE stdin_pipe_write = NULL;
   BOOL ret = FALSE;
-  const char *filename = process_get_command(process);
-
-  /* Not much we can do if we haven't been told what to start. */
-  if (BUG(filename == NULL))
-    return PROCESS_STATUS_ERROR;
 
   /* Setup our security attributes. */
   SECURITY_ATTRIBUTES security_attributes;
@@ -211,7 +206,7 @@ process_win32_exec(process_t *process)
   char *joined_argv = tor_join_win_cmdline((const char **)argv);
 
   /* Create the child process */
-  ret = CreateProcessA(filename,
+  ret = CreateProcessA(NULL,
                        joined_argv,
                        NULL,
                        NULL,


### PR DESCRIPTION
When NULL is given to lpApplicationName we enable Windows' "magical"
path interpretation logic, which makes Tor 0.4.x behave in the same way
as previous Tor versions did when it comes to executing binaries in
different system paths.

For more information about this have a look at the CreateProcessA()
documentation on MSDN -- especially the string interpretation example is
useful to understand this issue.

This bug was introduced in commit bfb94dd2ca8.

See: https://bugs.torproject.org/29874