### PR TITLE
Correctly report PT vs proxy during bootstrap

### DIFF
--- a/changes/bug28925
+++ b/changes/bug28925
@@ -1,0 +1,4 @@
+  o Minor bugfixes (bootstrap reporting):
+    - During bootstrap reporting, correctly distinguish pluggable
+      transports from plain proxies. Fixes bug 28925; bugfix on
+      0.4.0.1-alpha.

--- a/src/core/mainloop/connection.h
+++ b/src/core/mainloop/connection.h
@@ -187,7 +187,7 @@ int connection_proxy_connect(connection_t *conn, int type);
 int connection_read_proxy_handshake(connection_t *conn);
 void log_failed_proxy_connection(connection_t *conn);
 int get_proxy_addrport(tor_addr_t *addr, uint16_t *port, int *proxy_type,
-                       const connection_t *conn);
+                       int *is_pt_out, const connection_t *conn);
 
 int retry_all_listeners(smartlist_t *new_conns,
                         int close_all_noncontrol);

--- a/src/core/or/or_connection_st.h
+++ b/src/core/or/or_connection_st.h
@@ -67,6 +67,8 @@ struct or_connection_t {
    * geoip cache and handled by the DoS mitigation subsystem. We use this to
    * insure we have a coherent count of concurrent connection. */
   unsigned int tracked_for_dos_mitigation : 1;
+  /** True iff this connection is using a pluggable transport */
+  unsigned int is_pt : 1;
 
   uint16_t link_proto; /**< What protocol version are we using? 0 for
                         * "none negotiated yet." */


### PR DESCRIPTION
Previously, or_connection_t did not record whether or not the
connection uses a pluggable transport. Instead, it stored the
underlying proxy protocol of the pluggable transport in
proxy_type. This made bootstrap reporting treat pluggable transport
connections as plain proxy connections.

Store a separate bit indicating whether a pluggable transport is in
use, and decode this during bootstrap reporting.

Fixes bug 28925; bugfix on 0.4.0.1-alpha.