### PR TITLE
Fix CID 1444119

### DIFF
--- a/changes/cid1444119
+++ b/changes/cid1444119
@@ -1,0 +1,3 @@
+  o Minor bugfixes (C correctness):
+    - Fix an unlikely memory leak in consensus_diff_apply(). Fixes bug 29824;
+      bugfix on 0.3.1.1-alpha. This is Coverity warning CID 1444119.

--- a/src/or/consdiff.c
+++ b/src/or/consdiff.c
@@ -1385,7 +1385,7 @@ consensus_diff_apply(const char *consensus,
 
   r1 = consensus_compute_digest_as_signed(consensus, &d1);
   if (BUG(r1 < 0))
-    return NULL; // LCOV_EXCL_LINE
+    goto done;
 
   lines1 = smartlist_new();
   lines2 = smartlist_new();


### PR DESCRIPTION
Let's use the same function exit point for BUG() codepath that we're using
for every other exit condition. That way, we're not forgetting to clean up
the memarea.