### PR TITLE
Stop assuming that /usr/bin/python3 exists

### DIFF
--- a/changes/ticket29913
+++ b/changes/ticket29913
@@ -1,0 +1,4 @@
+  o Minor bugfixes (python):
+    - Stop assuming that /usr/bin/python3 exists. For scripts that work with
+      python2, use /usr/bin/python. Otherwise, use /usr/bin/env python3.
+      Fixes bug 29913; bugfix on 0.2.5.3-alpha.

--- a/scripts/maint/checkIncludes.py
+++ b/scripts/maint/checkIncludes.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/python
 # Copyright 2018 The Tor Project, Inc.  See LICENSE file for licensing info.
 
 """This script looks through all the directories for files matching *.c or

--- a/scripts/maint/practracker/practracker.py
+++ b/scripts/maint/practracker/practracker.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/python
 
 """
 Best-practices tracker for Tor source code.

--- a/scripts/maint/rectify_include_paths.py
+++ b/scripts/maint/rectify_include_paths.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/python
 
 import os
 import os.path

--- a/src/config/mmdb-convert.py
+++ b/src/config/mmdb-convert.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/python
 
 #   This software has been dedicated to the public domain under the CC0
 #   public domain dedication.

--- a/src/test/ope_ref.py
+++ b/src/test/ope_ref.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 # Copyright 2018-2019, The Tor Project, Inc. See LICENSE for licensing info.
 
 # Reference implementation for our rudimentary OPE code, used to


### PR DESCRIPTION
For scripts that work with python2, use /usr/bin/python.
Otherwise, use /usr/bin/env python3.

Fixes bug 29913; bugfix on 0.2.5.3-alpha.