### PR TITLE
[Tor Trac #24546]: Remove tor_addr_is_v4() and switch to comparing tor_addr_family()

### DIFF
--- a/changes/bug24546
+++ b/changes/bug24546
@@ -1,0 +1,5 @@
+  o Minor bugfixes (networking):
+    - Remove tor_addr_is_v4() to check for an IPv4 address and switch to
+      checking the address family directly with tor_addr_family(). Also, we
+      remove support for IPv4-mapped IPv6 addresses in tor_addr_is_v4().
+      Fixes bug 24546; bugfix on 0.2.0.3-alpha. Patch by Neel Chauhan.

--- a/scripts/maint/practracker/exceptions.txt
+++ b/scripts/maint/practracker/exceptions.txt
@@ -29,7 +29,7 @@
 #
 # Remember: It is better to fix the problem than to add a new exception!
 
-problem file-size /src/app/config/config.c 8490
+problem file-size /src/app/config/config.c 8492
 problem include-count /src/app/config/config.c 86
 problem function-size /src/app/config/config.c:options_act_reversible() 296
 problem function-size /src/app/config/config.c:options_act() 588

--- a/src/app/config/config.c
+++ b/src/app/config/config.c
@@ -7661,10 +7661,12 @@ get_first_listener_addrport_string(int listener_type)
       /* If a listener is listening on INADDR_ANY, assume that it's
          also listening on 127.0.0.1, and point the transport proxy
          there: */
-      if (tor_addr_is_null(&cfg->addr))
-        address = tor_addr_is_v4(&cfg->addr) ? ipv4_localhost : ipv6_localhost;
-      else
+      if (tor_addr_is_null(&cfg->addr)) {
+        address = (tor_addr_family(&cfg->addr) == AF_INET) ? ipv4_localhost :
+                                                             ipv6_localhost;
+      } else {
         address = fmt_and_decorate_addr(&cfg->addr);
+      }
 
       /* If a listener is configured with port 'auto', we are forced
          to iterate all listener connections and find out in which

--- a/src/core/or/policies.c
+++ b/src/core/or/policies.c
@@ -1656,7 +1656,7 @@ addr_policy_append_reject_addr_filter(smartlist_t **dest,
   if (tor_addr_is_public_for_reject(addr)) {
 
     /* Reject IPv4 addresses and IPv6 addresses based on the filters */
-    int is_ipv4 = tor_addr_is_v4(addr);
+    int is_ipv4 = tor_addr_family(addr) == AF_INET;
     if ((is_ipv4 && ipv4_rules) || (!is_ipv4 && ipv6_rules)) {
       addr_policy_append_reject_addr(dest, addr);
     }

--- a/src/core/or/policies.c
+++ b/src/core/or/policies.c
@@ -1656,7 +1656,7 @@ addr_policy_append_reject_addr_filter(smartlist_t **dest,
   if (tor_addr_is_public_for_reject(addr)) {
 
     /* Reject IPv4 addresses and IPv6 addresses based on the filters */
-    int is_ipv4 = tor_addr_family(addr) == AF_INET;
+    int is_ipv4 = (tor_addr_family(addr) == AF_INET);
     if ((is_ipv4 && ipv4_rules) || (!is_ipv4 && ipv6_rules)) {
       addr_policy_append_reject_addr(dest, addr);
     }

--- a/src/feature/nodelist/nodelist.c
+++ b/src/feature/nodelist/nodelist.c
@@ -1218,7 +1218,7 @@ node_get_link_specifier_smartlist(const node_t *node, bool direct_conn)
   /* We expect the node's primary address to be a valid IPv4 address.
    * This conforms to the protocol, which requires either an IPv4 or IPv6
    * address (or both). */
-  if (BUG(!tor_addr_is_v4(&ap.addr)) ||
+  if (BUG(tor_addr_family(&ap.addr) != AF_INET) ||
       BUG(!tor_addr_port_is_valid_ap(&ap, 0))) {
     return lspecs;
   }

--- a/src/lib/net/address.c
+++ b/src/lib/net/address.c
@@ -632,7 +632,7 @@ tor_addr_parse_mask_ports(const char *s,
     goto err;
   }
 
-  v4map = tor_addr_family(addr_out) == AF_INET;
+  v4map = (family == AF_INET);
 
   /* Parse mask */
   if (maskbits_out) {

--- a/src/lib/net/address.c
+++ b/src/lib/net/address.c
@@ -632,7 +632,7 @@ tor_addr_parse_mask_ports(const char *s,
     goto err;
   }
 
-  v4map = tor_addr_is_v4(addr_out);
+  v4map = tor_addr_family(addr_out) == AF_INET;
 
   /* Parse mask */
   if (maskbits_out) {
@@ -725,15 +725,6 @@ tor_addr_parse_mask_ports(const char *s,
  err:
   tor_free(base);
   return -1;
-}
-
-/** Return true iff address <b>addr</b> is native IPv4. Else, return false. */
-int
-tor_addr_is_v4(const tor_addr_t *addr)
-{
-  tor_assert(addr);
-
-  return tor_addr_family(addr) == AF_INET;
 }
 
 /** Determine whether an address <b>addr</b> is null, either all zeroes or
@@ -1027,9 +1018,9 @@ tor_addr_compare_masked(const tor_addr_t *addr1, const tor_addr_t *addr2,
   if (mbits == 0)
     return 0;
 
-  if (family1 == AF_INET6 && tor_addr_is_v4(addr1))
+  if (family1 == AF_INET6 && tor_addr_family(addr1) == AF_INET)
     v_family1 = AF_INET;
-  if (family2 == AF_INET6 && tor_addr_is_v4(addr2))
+  if (family2 == AF_INET6 && tor_addr_family(addr2) == AF_INET)
     v_family2 = AF_INET;
   if (v_family1 == v_family2) {
     /* One or both addresses are a mapped ipv4 address. */

--- a/src/lib/net/address.c
+++ b/src/lib/net/address.c
@@ -261,10 +261,6 @@ tor_addr_is_internal_(const tor_addr_t *addr, int for_listening,
   tor_assert(addr);
   sa_family_t v_family = tor_addr_family(addr);
 
-  if (v_family == AF_INET) {
-    iph4 = tor_addr_to_ipv4h(addr);
-  }
-
   if (v_family == AF_INET6) {
     const uint32_t *a32 = tor_addr_to_in6_addr32(addr);
     iph6[0] = ntohl(a32[0]);
@@ -285,6 +281,8 @@ tor_addr_is_internal_(const tor_addr_t *addr, int for_listening,
 
     return 0;
   } else if (v_family == AF_INET) {
+    iph4 = tor_addr_to_ipv4h(addr);
+
     /* special case for binding to 0.0.0.0 or 100.64/10 (RFC6598) */
     if (for_listening && (!iph4 || ((iph4 & 0xffc00000) == 0x64400000)))
       return 0;

--- a/src/lib/net/address.c
+++ b/src/lib/net/address.c
@@ -263,18 +263,6 @@ tor_addr_is_internal_(const tor_addr_t *addr, int for_listening,
 
   if (v_family == AF_INET) {
     iph4 = tor_addr_to_ipv4h(addr);
-  } else if (v_family == AF_INET6) {
-    if (tor_addr_is_v4(addr)) { /* v4-mapped */
-      uint32_t *addr32 = NULL;
-      v_family = AF_INET;
-      // Work around an incorrect NULL pointer dereference warning in
-      // "clang --analyze" due to limited analysis depth
-      addr32 = tor_addr_to_in6_addr32(addr);
-      // To improve performance, wrap this assertion in:
-      // #if !defined(__clang_analyzer__) || PARANOIA
-      tor_assert(addr32);
-      iph4 = ntohl(addr32[3]);
-    }
   }
 
   if (v_family == AF_INET6) {
@@ -739,27 +727,13 @@ tor_addr_parse_mask_ports(const char *s,
   return -1;
 }
 
-/** Determine whether an address is IPv4, either native or IPv4-mapped IPv6.
- * Note that this is about representation only, as any decent stack will
- * reject IPv4-mapped addresses received on the wire (and won't use them
- * on the wire either).
- */
+/** Return true iff address <b>addr</b> is native IPv4. Else, return false. */
 int
 tor_addr_is_v4(const tor_addr_t *addr)
 {
   tor_assert(addr);
 
-  if (tor_addr_family(addr) == AF_INET)
-    return 1;
-
-  if (tor_addr_family(addr) == AF_INET6) {
-    /* First two don't need to be ordered */
-    uint32_t *a32 = tor_addr_to_in6_addr32(addr);
-    if (a32[0] == 0 && a32[1] == 0 && ntohl(a32[2]) == 0x0000ffffu)
-      return 1;
-  }
-
-  return 0; /* Not IPv4 - unknown family or a full-blood IPv6 address */
+  return tor_addr_family(addr) == AF_INET;
 }
 
 /** Determine whether an address <b>addr</b> is null, either all zeroes or

--- a/src/lib/net/address.c
+++ b/src/lib/net/address.c
@@ -533,7 +533,7 @@ tor_addr_parse_mask_ports(const char *s,
 {
   char *base = NULL, *address, *mask = NULL, *port = NULL, *rbracket = NULL;
   char *endptr;
-  int any_flag=0, v4map=0;
+  int any_flag=0;
   sa_family_t family;
   struct in6_addr in6_tmp;
   struct in_addr in_tmp = { .s_addr = 0 };
@@ -630,7 +630,7 @@ tor_addr_parse_mask_ports(const char *s,
     goto err;
   }
 
-  v4map = (family == AF_INET);
+  int v4map = (family == AF_INET);
 
   /* Parse mask */
   if (maskbits_out) {

--- a/src/lib/net/address.c
+++ b/src/lib/net/address.c
@@ -665,16 +665,6 @@ tor_addr_parse_mask_ports(const char *s,
           goto err;
         }
       }
-      if (family == AF_INET6 && v4map) {
-        if (bits > 32 && bits < 96) { /* Crazy */
-          log_warn(LD_GENERAL,
-                   "Bad mask bits %d for V4-mapped V6 address; rejecting.",
-                   bits);
-          goto err;
-        }
-        /* XXXX_IP6 is this really what we want? */
-        bits = 96 + bits%32; /* map v4-mapped masks onto 96-128 bits */
-      }
       if (any_flag) {
         log_warn(LD_GENERAL,
                  "Found bit prefix with wildcard address; rejecting");

--- a/src/lib/net/address.h
+++ b/src/lib/net/address.h
@@ -246,7 +246,6 @@ int tor_addr_compare_masked(const tor_addr_t *addr1, const tor_addr_t *addr2,
 uint64_t tor_addr_hash(const tor_addr_t *addr);
 struct sipkey;
 uint64_t tor_addr_keyed_hash(const struct sipkey *key, const tor_addr_t *addr);
-int tor_addr_is_v4(const tor_addr_t *addr);
 int tor_addr_is_internal_(const tor_addr_t *ip, int for_listening,
                           const char *filename, int lineno);
 #define tor_addr_is_internal(addr, for_listening) \

--- a/src/test/test_addr.c
+++ b/src/test/test_addr.c
@@ -362,50 +362,6 @@ test_addr_ip6_helpers(void *arg)
   test_external_ip("2001::", 0);
   test_external_ip("ffff::", 0);
 
-  test_external_ip("::ffff:0.0.0.0", 1);
-  test_internal_ip("::ffff:0.0.0.0", 0);
-  test_internal_ip("::ffff:0.255.255.255", 0);
-  test_external_ip("::ffff:1.0.0.0", 0);
-
-  test_external_ip("::ffff:9.255.255.255", 0);
-  test_internal_ip("::ffff:10.0.0.0", 0);
-  test_internal_ip("::ffff:10.255.255.255", 0);
-  test_external_ip("::ffff:11.0.0.0", 0);
-
-  test_external_ip("::ffff:126.255.255.255", 0);
-  test_internal_ip("::ffff:127.0.0.0", 0);
-  test_internal_ip("::ffff:127.255.255.255", 0);
-  test_external_ip("::ffff:128.0.0.0", 0);
-
-  test_external_ip("::ffff:172.15.255.255", 0);
-  test_internal_ip("::ffff:172.16.0.0", 0);
-  test_internal_ip("::ffff:172.31.255.255", 0);
-  test_external_ip("::ffff:172.32.0.0", 0);
-
-  test_external_ip("::ffff:192.167.255.255", 0);
-  test_internal_ip("::ffff:192.168.0.0", 0);
-  test_internal_ip("::ffff:192.168.255.255", 0);
-  test_external_ip("::ffff:192.169.0.0", 0);
-
-  test_external_ip("::ffff:169.253.255.255", 0);
-  test_internal_ip("::ffff:169.254.0.0", 0);
-  test_internal_ip("::ffff:169.254.255.255", 0);
-  test_external_ip("::ffff:169.255.0.0", 0);
-
-  /* tor_addr_compare(tor_addr_t x2) */
-  test_addr_compare("ffff::", OP_EQ, "ffff::0");
-  test_addr_compare("0::3:2:1", OP_LT, "0::ffff:0.3.2.1");
-  test_addr_compare("0::2:2:1", OP_LT, "0::ffff:0.3.2.1");
-  test_addr_compare("0::ffff:0.3.2.1", OP_GT, "0::0:0:0");
-  test_addr_compare("0::ffff:5.2.2.1", OP_LT,
-                    "::ffff:6.0.0.0"); /* XXXX wrong. */
-  tor_addr_parse_mask_ports("[::ffff:2.3.4.5]", 0, &t1, NULL, NULL, NULL);
-  tor_addr_parse_mask_ports("2.3.4.5", 0, &t2, NULL, NULL, NULL);
-  tt_int_op(tor_addr_compare(&t1, &t2, CMP_SEMANTIC), OP_EQ, 0);
-  tor_addr_parse_mask_ports("[::ffff:2.3.4.4]", 0, &t1, NULL, NULL, NULL);
-  tor_addr_parse_mask_ports("2.3.4.5", 0, &t2, NULL, NULL, NULL);
-  tt_int_op(tor_addr_compare(&t1, &t2, CMP_SEMANTIC), OP_LT, 0);
-
   /* test compare_masked */
   test_addr_compare_masked("ffff::", OP_EQ, "ffff::0", 128);
   test_addr_compare_masked("ffff::", OP_EQ, "ffff::0", 64);

--- a/src/test/test_address.c
+++ b/src/test/test_address.c
@@ -144,7 +144,7 @@ static int
 smartlist_contains_ipv4_tor_addr(smartlist_t *smartlist)
 {
   SMARTLIST_FOREACH_BEGIN(smartlist, tor_addr_t *, tor_addr) {
-    if (tor_addr_is_v4(tor_addr)) {
+    if (tor_addr_family(tor_addr) == AF_INET) {
       return 1;
     }
   } SMARTLIST_FOREACH_END(tor_addr);
@@ -160,7 +160,7 @@ smartlist_contains_ipv6_tor_addr(smartlist_t *smartlist)
 {
   SMARTLIST_FOREACH_BEGIN(smartlist, tor_addr_t *, tor_addr) {
     /* Since there's no tor_addr_is_v6, assume all non-v4s are v6 */
-    if (!tor_addr_is_v4(tor_addr)) {
+    if (tor_addr_family(tor_addr) != AF_INET) {
       return 1;
     }
   } SMARTLIST_FOREACH_END(tor_addr);
@@ -1000,7 +1000,7 @@ test_address_get_if_addrs(void *arg)
     tt_assert(!tor_addr_is_multicast(&tor_addr));
     /* The address may or may not be an internal address */
 
-    tt_assert(tor_addr_is_v4(&tor_addr));
+    tt_assert(tor_addr_family(&tor_addr) == AF_INET);
   }
 
  done:
@@ -1023,7 +1023,7 @@ test_address_get_if_addrs6(void *arg)
     tt_assert(!tor_addr_is_multicast(&tor_addr));
     /* The address may or may not be an internal address */
 
-    tt_assert(!tor_addr_is_v4(&tor_addr));
+    tt_assert(tor_addr_family(&tor_addr) != AF_INET);
   }
 
  done:

--- a/src/test/test_connection.c
+++ b/src/test/test_connection.c
@@ -84,7 +84,7 @@ test_conn_lookup_addr_helper(const char *address, int family, tor_addr_t *addr)
   /* XXXX - should we retry on transient failure? */
   tt_int_op(rv, OP_EQ, 0);
   tt_assert(tor_addr_is_loopback(addr));
-  tt_assert(tor_addr_is_v4(addr));
+  tt_assert(tor_addr_family(addr) == AF_INET);
 
   return;
 


### PR DESCRIPTION
For the ticket [here](https://trac.torproject.org/projects/tor/ticket/24546).