### PR TITLE
test_routerkeys.c: Always check mkdir() return value

### DIFF
--- a/changes/bug29939
+++ b/changes/bug29939
@@ -1,0 +1,4 @@
+  o Minor bugfixes (unit tests):
+    - In the "routerkeys/*" tests, check the return values of mkdir() for
+      possible failures. Fixes bug 29939; bugfix on 0.2.7.2-alpha. Found by
+      Coverity as CID 1444254.

--- a/src/test/test_routerkeys.c
+++ b/src/test/test_routerkeys.c
@@ -455,11 +455,11 @@ test_routerkeys_ed_keys_init_all(void *arg)
   options->TestingLinkKeySlop = 2*3600;
 
 #ifdef _WIN32
-  mkdir(dir);
-  mkdir(keydir);
+  tt_int_op(0, OP_EQ, mkdir(dir));
+  tt_int_op(0, OP_EQ, mkdir(keydir));
 #else
-  mkdir(dir, 0700);
-  mkdir(keydir, 0700);
+  tt_int_op(0, OP_EQ, mkdir(dir, 0700));
+  tt_int_op(0, OP_EQ, mkdir(keydir, 0700));
 #endif /* defined(_WIN32) */
 
   options->DataDirectory = dir;


### PR DESCRIPTION
After this fix, we have no more unchecked mkdir() calls.

Bug 29939; CID 144254. Bugfix on 0.2.7.2-alpha.