### PR TITLE
dircache: Refactor handle_get_next_bandwidth() to use connection_dir_…

### DIFF
--- a/changes/ticket28816
+++ b/changes/ticket28816
@@ -1,0 +1,4 @@
+  o Code simplification and refactoring:
+    - Introduce a connection_dir_buf_add() helper function that checks for
+      compress_state of dir_connection_t and automatically writes a string to
+      directory connection with or without compression. Resolves issue 28816.

--- a/changes/ticket29897
+++ b/changes/ticket29897
@@ -1,0 +1,3 @@
+  o Code simplification and refactoring:
+    - Refactor handle_get_next_bandwidth() to use connection_dir_buf_add().
+      Implements ticket 29897.

--- a/src/core/mainloop/connection.c
+++ b/src/core/mainloop/connection.c
@@ -4341,6 +4341,23 @@ connection_write_to_buf_impl_,(const char *string, size_t len,
   connection_write_to_buf_commit(conn, written);
 }
 
+/**
+ * Write a <b>string</b> (of size <b>len</b> to directory connection
+ * <b>dir_conn</b>. Apply compression if connection is configured to use
+ * it and finalize it if <b>done</b> is true.
+ */
+void
+connection_dir_buf_add(const char *string, size_t len,
+                       dir_connection_t *dir_conn, int done)
+{
+  if (dir_conn->compress_state != NULL) {
+    connection_buf_add_compress(string, len, dir_conn, done);
+    return;
+  }
+
+  connection_buf_add(string, len, TO_CONN(dir_conn));
+}
+
 void
 connection_buf_add_compress(const char *string, size_t len,
                             dir_connection_t *conn, int done)

--- a/src/core/mainloop/connection.h
+++ b/src/core/mainloop/connection.h
@@ -226,6 +226,8 @@ MOCK_DECL(void, connection_write_to_buf_impl_,
 /* DOCDOC connection_write_to_buf */
 static void connection_buf_add(const char *string, size_t len,
                                     connection_t *conn);
+void connection_dir_buf_add(const char *string, size_t len,
+                            dir_connection_t *dir_conn, int done);
 static inline void
 connection_buf_add(const char *string, size_t len, connection_t *conn)
 {

--- a/src/feature/dircache/dircache.c
+++ b/src/feature/dircache/dircache.c
@@ -1486,13 +1486,10 @@ handle_get_next_bandwidth(dir_connection_t *conn,
         conn->compress_state = tor_compress_new(1, compress_method,
                                         choose_compression_level(len/2));
         log_debug(LD_DIR, "Compressing bandwidth file.");
-        connection_buf_add_compress(bandwidth, len, conn, 0);
-        /* Flush the compression state. */
-        connection_buf_add_compress("", 0, conn, 1);
       } else {
         log_debug(LD_DIR, "Not compressing bandwidth file.");
-        connection_buf_add(bandwidth, len, TO_CONN(conn));
       }
+      connection_dir_buf_add((const char*)bandwidth, len, conn, 1);
       tor_free(bandwidth);
       return 0;
     }


### PR DESCRIPTION
…buf_add()

No changes file required: refactoring on 21377, which is not in any
released version of Tor.

Implements ticket 29897.