### PR TITLE
torint: delete a compile-time check that uses SIZEOF_UNSIGNED_INT

### DIFF
--- a/src/lib/cc/torint.h
+++ b/src/lib/cc/torint.h
@@ -129,9 +129,4 @@ typedef int32_t ssize_t;
 #error "sizeof(int) > sizeof(void *) - Tor cannot be built on this platform!"
 #endif
 
-#if SIZEOF_UNSIGNED_INT > SIZEOF_VOID_P
-#error "sizeof(unsigned int) > sizeof(void *) - Tor cannot be built on this \
-platform!"
-#endif
-
 #endif /* !defined(TOR_TORINT_H) */


### PR DESCRIPTION
We do not define SIZEOF_UNSIGNED_INT, so this comparison is always false.
Compilers that support -Wundef issue a diagnostic warning for it.

Fixes bug 29958; bugfix on 29537; not in any released version of Tor.