### PR TITLE
bwauth: Actually include the bandwidth-file-digest in authority votes

### DIFF
--- a/changes/bug29959-040
+++ b/changes/bug29959-040
@@ -1,0 +1,3 @@
+  o Minor bugfixes (directory authorities):
+    - Actually include the bandwidth-file-digest line in directory authority
+      votes. Fixes bug 29959; bugfix on 0.4.0.2-alpha.

--- a/src/feature/dirauth/dirvote.c
+++ b/src/feature/dirauth/dirvote.c
@@ -321,7 +321,7 @@ format_networkstatus_vote(crypto_pk_t *private_signing_key,
       /* Encode the digest. */
       char b64_digest_bw_file[BASE64_DIGEST256_LEN+1] = {0};
       if (digest256_to_base64(b64_digest_bw_file,
-                              (const char *)v3_ns->bw_file_digest256)>0) {
+                              (const char *)v3_ns->bw_file_digest256) == 0) {
         /* "bandwidth-file-digest" 1*(SP algorithm "=" digest) NL */
         char *digest_algo_b64_digest_bw_file = NULL;
         tor_asprintf(&digest_algo_b64_digest_bw_file, "%s=%s",


### PR DESCRIPTION
Fixes bug 29959; bugfix on 0.4.0.2-alpha.