### PR TITLE
bug_occurred: a place where we assumed that "buf" was still a buffer

### DIFF
--- a/src/lib/log/util_bug.c
+++ b/src/lib/log/util_bug.c
@@ -117,7 +117,7 @@ tor_bug_occurred_(const char *fname, unsigned int line,
     }
     log_warn(LD_BUG, "%s:%u: %s: This line should not have been reached.%s",
              fname, line, func, once_str);
-    tor_snprintf(buf, sizeof(buf),
+    tor_asprintf(&buf,
                  "Line unexpectedly reached at %s at %s:%u",
                  func, fname, line);
   } else {


### PR DESCRIPTION
In 9c132a5f9e87a2cd0f we replaced "buf" with a pointer and replaced
one instance of snprintf with asprintf -- but there was still one
snprintf left over, being crashy.

Fixes bug 29967; bug not in any released Tor. This is CID 1444262.