### PR TITLE
#29962:  Cleanup cargo registry before each Rust-enabled build. Also, refrain from caching target/.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,8 +5,9 @@ cache:
   ## cargo: true
   directories:
     - $HOME/.cargo
-    ## where we point CARGO_TARGET_DIR in all our cargo invocations
-    - $TRAVIS_BUILD_DIR/src/rust/target
+
+before_cache:
+  - rm -rf $HOME/.cargo/registry
 
 compiler:
   - gcc

--- a/changes/ticket29962
+++ b/changes/ticket29962
@@ -1,0 +1,3 @@
+  o Minor features (continuous integration):
+    - On Travis Rust builds, cleanup Rust registry and refrain from caching
+      target/ directory to speed up builds. Resolves issue 29962.


### PR DESCRIPTION
https://trac.torproject.org/projects/tor/ticket/29962