### PR TITLE
Improve logging for 28614.

### DIFF
--- a/changes/bug28614_better_logging
+++ b/changes/bug28614_better_logging
@@ -1,0 +1,6 @@
+  o Minor bugfixes (logging):
+    - On Windows, when errors cause us to reload a consensus from disk, tell
+      the user that we are retrying at log level "notice". Previously we only
+      logged this information at "info", which was confusing because the
+      errors themselves were logged at "warning". Improves previous fix for
+      28614.  Fixes bug 30004; bugfix on 0.4.0.2-alpha.

--- a/src/feature/nodelist/networkstatus.c
+++ b/src/feature/nodelist/networkstatus.c
@@ -1761,8 +1761,11 @@ reload_consensus_from_file(const char *fname,
                                                flavor, flags, source_dir);
 #ifdef _WIN32
   if (rv < 0 && tor_memstr(map->data, map->size, "\r\n")) {
-    log_info(LD_GENERAL, "Found CRLF in consensus file %s; falling back to "
-             "read_file_to_string.", escaped(fname));
+    log_notice(LD_GENERAL, "Looks like the above failures are probably "
+               "because of a CRLF in consensus file %s; falling back to "
+               "read_file_to_string. Nothing to worry about: this file "
+               "was probably saved by an earlier version of Tor.",
+               escaped(fname));
     char *content = read_file_to_str(fname, RFTS_IGNORE_MISSING, NULL);
     rv = networkstatus_set_current_consensus(content, strlen(content),
                                              flavor, flags, source_dir);


### PR DESCRIPTION
When we fixed 28614, our answer was "if we failed to load the
consensus on windows and it had a CRLF, retry it."  But we logged
the failure at "warn", and we only logged the retry at "info".

Now we log the retry at "notice", with more useful information.

Fixes bug 30004.