### PR TITLE
Appveyor: Run "make test" in Appveyor's CI, before running "make check"

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -67,6 +67,8 @@ test_script:
             $buildpath = @("C:\msys64\${env:compiler_path}\bin") + $oldpath
             $env:Path = $buildpath -join ';'
             Set-Location "${env:build}"
+            <# diagnostic for test hang in 29645: see which test is hanging #>
+            Execute-Bash "VERBOSE=1 make -j2 test"
             Execute-Bash "VERBOSE=1 make -j2 check"
     }
 

--- a/changes/bug29645
+++ b/changes/bug29645
@@ -1,0 +1,4 @@
+  o Testing (CI):
+    - Run "make test" in Appveyor's CI, before running "make check".
+      The extra "make test" lets us see the hanging test on the console.
+      Diagnostic for ticket 29645.


### PR DESCRIPTION
This is a diagnostic for bug 29645, so we can work out which test is
hanging.

Fixes bug 29645; bugfix on 0.3.4.1-alpha.