### PR TITLE
Travis: Terminate test-stem if it takes more than 15 minutes to run

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -131,6 +131,9 @@ addons:
       - docbook-xsl
       - docbook-xml
       - xmlto
+      ## Utilities
+      ## preventing or diagnosing hangs
+      - timelimit
   ## (OSX only)
   homebrew:
     packages:
@@ -154,6 +157,9 @@ addons:
       ## Always installed, because manual brew installs are hard to get right
       - asciidoc
       - xmlto
+      ## Utilities
+      ## preventing or diagnosing hangs
+      - timelimit
 
 ## (OSX only) Use the default OSX image
 ## See https://docs.travis-ci.com/user/reference/osx#os-x-version
@@ -202,7 +208,8 @@ script:
   - ./configure $CONFIGURE_FLAGS
   ## We run `make check` because that's what https://jenkins.torproject.org does.
   - if [[ "$DISTCHECK" == "" && "$TEST_STEM" == "" ]]; then make check; fi
-  - if [[ "$TEST_STEM" != "" ]]; then make src/app/tor test-stem; fi
+  ## Diagnostic for bug 29437: kill stem if it hangs for 15 minutes
+  - if [[ "$TEST_STEM" != "" ]]; then timelimit -p -t 540 -T 30 make src/app/tor test-stem; fi
   - if [[ "$DISTCHECK" != "" && "$TEST_STEM" == "" ]]; then make distcheck DISTCHECK_CONFIGURE_FLAGS="$CONFIGURE_FLAGS"; fi
 
 after_failure:

--- a/changes/bug30011
+++ b/changes/bug30011
@@ -1,0 +1,4 @@
+  o Minor bugfixes (CI):
+    - Terminate test-stem if it takes more than 9.5 minutes to run.
+      (Travis terminates the job after 10 minutes of no output.)
+      Diagnostic for 29437. Fixes bug 30011; bugfix on 0.3.5.4-alpha.


### PR DESCRIPTION
Diagnostic for 29437.

Fixes bug 30011; bugfix on 0.3.5.4-alpha.