### PR TITLE
Do not cache bogus results from classifying client ciphers

### DIFF
--- a/changes/bug30021
+++ b/changes/bug30021
@@ -1,0 +1,8 @@
+  o Minor bugfixes (TLS protocol, integration tests):
+    - When classifying a client's selection of TLS ciphers, if the client
+      ciphers are not yet available, do not cache the result. Previously,
+      we had cached the unavailability of the cipher list and never looked
+      again, which in turn led us to assume that the client only supported
+      the ancient V1 link protocol.  This, in turn, was causing Stem
+      integration tests to stall in some cases.
+      Fixes bug 30021; bugfix on 0.2.4.8-alpha.

--- a/src/common/tortls.c
+++ b/src/common/tortls.c
@@ -1500,7 +1500,7 @@ tor_tls_classify_client_ciphers(const SSL *ssl,
     smartlist_free(elts);
   }
  done:
-  if (tor_tls)
+  if (tor_tls && peer_ciphers)
     return tor_tls->client_cipher_list_type = res;
 
   return res;


### PR DESCRIPTION
When classifying a client's selection of TLS ciphers, if the client
ciphers are not yet available, do not cache the result. Previously,
we had cached the unavailability of the cipher list and never looked
again, which in turn led us to assume that the client only supported
the ancient V1 link protocol.  This, in turn, was causing Stem
integration tests to stall in some cases.  Fixes bug 30021; bugfix
on 0.2.4.8-alpha.