### PR TITLE
Detect and suppress an additional gmtime() warning in test_util.c

### DIFF
--- a/changes/bug29922
+++ b/changes/bug29922
@@ -1,0 +1,4 @@
+  o Minor bugfixes (testing, windows):
+    - Fix a test failure caused by an unexpected bug warning in
+      our test for tor_gmtime_r(-1). Fixes bug 29922;
+      bugfix on 0.2.9.3-alpha.

--- a/src/test/test_util.c
+++ b/src/test/test_util.c
@@ -699,13 +699,6 @@ test_util_time(void *arg)
 
 #define CHECK_TIMEGM_ARG_OUT_OF_RANGE(msg) \
     CHECK_TIMEGM_WARNING("Out-of-range argument to tor_timegm")
-#define CHECK_POSSIBLE_TIMEGM_ARG_OUT_OF_RANGE(msg)             \
-  do {                                                          \
-    if (mock_saved_log_n_entries()) {                           \
-      expect_single_log_msg_containing("Out-of-range argument");\
-    }                                                           \
-    teardown_capture_of_logs();                                 \
-  } while (0)
 
   /* year */
 
@@ -894,7 +887,7 @@ test_util_time(void *arg)
   t_res = -1;
   CAPTURE();
   tor_gmtime_r(&t_res, &b_time);
-  CHECK_POSSIBLE_TIMEGM_ARG_OUT_OF_RANGE();
+  CHECK_POSSIBLE_EINVAL();
   tt_assert(b_time.tm_year == (1970-1900) ||
             b_time.tm_year == (1969-1900));
 

--- a/src/test/test_util.c
+++ b/src/test/test_util.c
@@ -699,6 +699,13 @@ test_util_time(void *arg)
 
 #define CHECK_TIMEGM_ARG_OUT_OF_RANGE(msg) \
     CHECK_TIMEGM_WARNING("Out-of-range argument to tor_timegm")
+#define CHECK_POSSIBLE_TIMEGM_ARG_OUT_OF_RANGE(msg)             \
+  do {                                                          \
+    if (mock_saved_log_n_entries()) {                           \
+      expect_single_log_msg_containing("Out-of-range argument");\
+    }                                                           \
+    teardown_capture_of_logs();                                 \
+  } while (0)
 
   /* year */
 
@@ -885,7 +892,9 @@ test_util_time(void *arg)
    * depending on whether the implementation of the system gmtime(_r)
    * sets struct tm (1) or not (1970) */
   t_res = -1;
+  CAPTURE();
   tor_gmtime_r(&t_res, &b_time);
+  CHECK_POSSIBLE_TIMEGM_ARG_OUT_OF_RANGE();
   tt_assert(b_time.tm_year == (1970-1900) ||
             b_time.tm_year == (1969-1900));
 


### PR DESCRIPTION
Fixes bug 29922; bugfix on 0.2.9.3-alpha when we tried to capture
all these warnings.  No need to backport any farther than 0.3.5,
though -- these warnings don't cause test failures before then.

This one was tricky to find because apparently it only happened on
_some_ windows builds.