### PR TITLE
Ticket 30092: Allow padding machines to specify match probability.

### DIFF
--- a/changes/ticket30092
+++ b/changes/ticket30092
@@ -1,0 +1,5 @@
+  o Minor features (circuit padding):
+    - Add the ability to specify a probability with which matching padding
+      machines will apply to a circuit, to provide defense in depth to our
+      planned client-side onion service circuit obfuscation. Closes ticket
+      30092.

--- a/src/core/or/circuitpadding.c
+++ b/src/core/or/circuitpadding.c
@@ -1615,9 +1615,50 @@ circpad_internal_event_state_length_up(circpad_machine_runtime_t *mi)
 }
 
 /**
+ * Check if a circuit padding machine should toss a coin before applying.
+ *
+ * This function assumes the machine would otherwise apply. So it only
+ * returns 0 if we lose the coin toss. If the machine conditions do not
+ * specify an apply probability, then the machine always applies at this point,
+ * so we return 1.
+ */
+STATIC bool
+circpad_machine_conditions_apply_probability(origin_circuit_t *circ,
+        const circpad_machine_spec_t *machine)
+{
+  /* Check if we have a probability-based condition, and if we've tossed
+   * the coin yet. Do this last, because we only get to toss one coin per
+   * circuit.. We should only toss it if all conditions already applied. */
+  if (machine->conditions.apply_with_probability > 0) {
+    /* If the coin has not been tossed, toss it and record result */
+    if (circ->padding_apply_coin_tossed == PADDING_COIN_NOT_CHECKED) {
+      if (crypto_rand_double() <= machine->conditions.apply_with_probability) {
+        circ->padding_apply_coin_tossed = PADDING_COIN_APPLIED;
+        return 1;
+      } else {
+        circ->padding_apply_coin_tossed = PADDING_COIN_NOT_APPLIED;
+        return 0;
+      }
+    } else if (circ->padding_apply_coin_tossed == PADDING_COIN_APPLIED) {
+      /* We did our coin toss before and won; this machine still applies. */
+      return 1;
+    }
+
+    /* We previously lost the coin toss; this machine does not apply. */
+    tor_assert_nonfatal(circ->padding_apply_coin_tossed ==
+                        PADDING_COIN_NOT_APPLIED);
+    return 0;
+  }
+
+  /* If apply_with_probability is <= 0 (aka not set), it is the same as
+   * "always apply if other conditions are met" */
+  return 1;
+}
+
+/**
  * Returns true if the circuit matches the conditions.
  */
-static inline bool
+STATIC bool
 circpad_machine_conditions_met(origin_circuit_t *circ,
                                const circpad_machine_spec_t *machine)
 {
@@ -1644,29 +1685,8 @@ circpad_machine_conditions_met(origin_circuit_t *circ,
   if (circuit_get_cpath_opened_len(circ) < machine->conditions.min_hops)
     return 0;
 
-  /* Check if we have a probability-based condition, and if we've tossed
-   * the coin yet. Do this last, because we only get to toss one coin per
-   * circuit.. We should only toss it if all conditions already applied. */
-  if (machine->conditions.apply_with_probability > 0) {
-    /* If the coin has not been tossed, toss it and record result */
-    if (circ->padding_apply_coin_tossed == PADDING_COIN_NOT_CHECKED) {
-      if (crypto_rand_double() <= machine->conditions.apply_with_probability) {
-        circ->padding_apply_coin_tossed = PADDING_COIN_APPLIED;
-        return 1;
-      } else {
-        circ->padding_apply_coin_tossed = PADDING_COIN_NOT_APPLIED;
-        return 0;
-      }
-    } else if (circ->padding_apply_coin_tossed == PADDING_COIN_APPLIED) {
-      /* We did our coin toss before and won; this machine still applies. */
-      return 1;
-    }
-
-    /* We previously lost the coin toss; this machine does not apply. */
-    tor_assert_nonfatal(circ->padding_apply_coin_tossed ==
-                        PADDING_COIN_NOT_APPLIED);
+  if (!circpad_machine_conditions_apply_probability(circ, machine))
     return 0;
-  }
 
   return 1;
 }

--- a/src/core/or/circuitpadding.c
+++ b/src/core/or/circuitpadding.c
@@ -1644,6 +1644,20 @@ circpad_machine_conditions_met(origin_circuit_t *circ,
   if (circuit_get_cpath_opened_len(circ) < machine->conditions.min_hops)
     return 0;
 
+  /* Check if we have a probability-based condition, and if
+   * we've tossed the coin yet. Do this last, because we only
+   * get to toss one coin per circuit.. We should only toss
+   * it if all conditions already applied. */
+  if (machine->conditions.apply_with_probability > 0 &&
+      !circ->padding_apply_coin_tossed) {
+    if (crypto_rand_double() <= machine->conditions.apply_with_probability) {
+      return 1;
+    }
+
+    circ->padding_apply_coin_tossed = 1;
+    return 0;
+  }
+
   return 1;
 }
 

--- a/src/core/or/circuitpadding.h
+++ b/src/core/or/circuitpadding.h
@@ -749,7 +749,9 @@ extern smartlist_t *relay_padding_machines;
 STATIC void
 register_padding_machine(circpad_machine_spec_t *machine,
                          smartlist_t *machine_list);
-#endif
+STATIC bool
+circpad_machine_conditions_apply_probability(origin_circuit_t *circ,
+        const circpad_machine_spec_t *machine);
 
 #endif
 

--- a/src/core/or/circuitpadding.h
+++ b/src/core/or/circuitpadding.h
@@ -160,6 +160,12 @@ typedef struct circpad_machine_conditions_t {
    *  of the bits set in this bitmask */
   circpad_purpose_mask_t purpose_mask;
 
+  /**
+   * If all of the above conditions are met, apply this machine with
+   * the following probability (0,1.0). 0 means "always", to avoid
+   * dealing with equality comparisons to 1.0 in floating point. */
+  double apply_with_probability;
+
 } circpad_machine_conditions_t;
 
 /**

--- a/src/core/or/origin_circuit_st.h
+++ b/src/core/or/origin_circuit_st.h
@@ -167,7 +167,10 @@ struct origin_circuit_t {
 
   /** If this flag is set, we've already tossed a coin to decide if we should
    * apply a padding machine. Don't toss another. */
-  unsigned padding_apply_coin_tossed : 1;
+  unsigned padding_apply_coin_tossed : 2;
+#define PADDING_COIN_NOT_CHECKED 0
+#define PADDING_COIN_APPLIED 1
+#define PADDING_COIN_NOT_APPLIED 2
 
   /**
    * Tristate variable to guard against pathbias miscounting

--- a/src/core/or/origin_circuit_st.h
+++ b/src/core/or/origin_circuit_st.h
@@ -165,6 +165,10 @@ struct origin_circuit_t {
    * not try to negotiate further circuit padding. */
   unsigned padding_negotiation_failed : 1;
 
+  /** If this flag is set, we've already tossed a coin to decide if we should
+   * apply a padding machine. Don't toss another. */
+  unsigned padding_apply_coin_tossed : 1;
+
   /**
    * Tristate variable to guard against pathbias miscounting
    * due to circuit purpose transitions changing the decision

--- a/src/test/test_circuitpadding.c
+++ b/src/test/test_circuitpadding.c
@@ -172,6 +172,14 @@ free_fake_origin_circuit(origin_circuit_t *circ)
   tor_free(circ);
 }
 
+int random_number = 4;
+void
+crypto_rand_mocked(char *to, size_t len)
+{
+  tor_assert(len == sizeof(int));
+  *(int *)to = random_number;
+}
+
 void dummy_nop_timer(void);
 
 //static int dont_stop_libevent = 0;
@@ -1779,6 +1787,12 @@ test_circuitpadding_conditions(void *arg)
        circuit_package_relay_cell_mock);
   MOCK(node_get_by_id,
        node_get_by_id_mock);
+  MOCK(crypto_rand,
+       crypto_rand_mocked);
+
+  /* Test probability-to-apply machine condition */
+  tt_int_op(circpad_machine_conditions_met(client_side,
+            circ_padding_machine), OP_EQ, 1); 
 
   /* Simulate extend. This should result in the original machine getting
    * added, since the circuit is not built */


### PR DESCRIPTION
Probability selection can only apply once per circuit.