### PR TITLE
Bug #29034: Cleanup hs circuit data when hs circs are repurposed.

### DIFF
--- a/changes/bug29034
+++ b/changes/bug29034
@@ -1,0 +1,5 @@
+  o Major bugfixes (Onion service reachability):
+    - Properly clean up the introduction point map and associated state when
+      circuits change purpose from onion service circuits to pathbias,
+      measurement, or other circuit types. This should fix some instances
+      of introduction point failure. Fixes bug 29034; bugfix on 0.3.2.1-alpha.

--- a/src/core/or/circuituse.c
+++ b/src/core/or/circuituse.c
@@ -3042,6 +3042,13 @@ circuit_change_purpose(circuit_t *circ, uint8_t new_purpose)
 
   if (circ->purpose == new_purpose) return;
 
+  /* If our new circuit purpose is not an onion service one, free
+   * any onion service material.. otherwise just clean it up. */
+  if (circuit_purpose_is_hidden_service(circ->purpose) &&
+     !circuit_purpose_is_hidden_service(new_purpose)) {
+    hs_circ_free(circ);
+  }
+
   if (CIRCUIT_IS_ORIGIN(circ)) {
     char old_purpose_desc[80] = "";
 

--- a/src/feature/hs/hs_circuit.c
+++ b/src/feature/hs/hs_circuit.c
@@ -1269,3 +1269,22 @@ hs_circ_cleanup(circuit_t *circ)
     hs_circuitmap_remove_circuit(circ);
   }
 }
+
+/**
+ * We're about to destroy, free, or change the purpose of this circuit
+ * immedaitely. Make sure everything hs-related is cleaned up and freed.
+ */
+void
+hs_circ_free(circuit_t *circ)
+{
+  hs_circ_cleanup(circ);
+
+  if (CIRCUIT_IS_ORIGIN(circ)) {
+    origin_circuit_t *ocirc = TO_ORIGIN_CIRCUIT(circ);
+    crypto_pk_free(ocirc->intro_key);
+    rend_data_free(ocirc->rend_data);
+
+    hs_ident_circuit_free(ocirc->hs_ident);
+    ocirc->hs_ident = NULL;
+  }
+}

--- a/src/feature/hs/hs_circuit.h
+++ b/src/feature/hs/hs_circuit.h
@@ -17,6 +17,10 @@
 /* Cleanup function when the circuit is closed or/and freed. */
 void hs_circ_cleanup(circuit_t *circ);
 
+/* Cleanup function when the circuit is immediately destroyed, freed, or
+ * changes purpose to something not controlled by HS code. */
+void hs_circ_free(circuit_t *circ);
+
 /* Circuit API. */
 int hs_circ_service_intro_has_opened(hs_service_t *service,
                                      hs_service_intro_point_t *ip,


### PR DESCRIPTION
Based on maint-0.3.5 but merges forward cleanly to both 0.4.0 and master.