### PR TITLE
[Tor Trac #28269]: Make repeated/rate limited HSFETCH queries fail with QUERY_RATE_LIMITED

### DIFF
--- a/changes/bug28269
+++ b/changes/bug28269
@@ -1,0 +1,7 @@
+  o Minor bugfixes (onion services):
+    - If we are launching repeated HSFETCH queries and are rate-limited,
+      we introduce a new controller response QUERY_RATE_LIMITED instead
+      of QUERY_NO_HSDIR, while keeping the latter for when onion service
+      directories are missing a descriptor. Previously, we returned
+      QUERY_NO_HSDIR for both cases. Fixes bug 28269; bugfix on
+      0.3.1.1-alpha. Patch by Neel Chauhan

--- a/src/feature/hs/hs_client.c
+++ b/src/feature/hs/hs_client.c
@@ -434,7 +434,7 @@ pick_hsdir_v3(const ed25519_public_key_t *onion_identity_pk)
 
   /* Pick an HSDir from the responsible ones. The ownership of
    * responsible_hsdirs is given to this function so no need to free it. */
-  hsdir_rs = hs_pick_hsdir(responsible_hsdirs, base64_blinded_pubkey);
+  hsdir_rs = hs_pick_hsdir(responsible_hsdirs, base64_blinded_pubkey, NULL);
 
   return hsdir_rs;
 }

--- a/src/feature/hs/hs_common.c
+++ b/src/feature/hs/hs_common.c
@@ -1635,7 +1635,10 @@ hs_pick_hsdir(smartlist_t *responsible_dirs, const char *req_key_str,
     }
   } SMARTLIST_FOREACH_END(dir);
 
-  rate_limited = rate_limited_count == responsible_dirs_count;
+  if (rate_limited_count > 0 || responsible_dirs_count > 0) {
+    rate_limited = rate_limited_count == responsible_dirs_count;
+  }
+
   excluded_some =
     smartlist_len(usable_responsible_dirs) < smartlist_len(responsible_dirs);
 

--- a/src/feature/hs/hs_common.c
+++ b/src/feature/hs/hs_common.c
@@ -1598,14 +1598,14 @@ hs_purge_last_hid_serv_requests(void)
  *  NULL if no HSDirs are worth trying right now. */
 routerstatus_t *
 hs_pick_hsdir(smartlist_t *responsible_dirs, const char *req_key_str,
-              int *is_rate_limited)
+              bool *is_rate_limited)
 {
   smartlist_t *usable_responsible_dirs = smartlist_new();
   const or_options_t *options = get_options();
   routerstatus_t *hs_dir;
   time_t now = time(NULL);
   int excluded_some;
-  int rate_limited;
+  bool rate_limited;
   int rate_limited_count = 0;
   int responsible_dirs_count = smartlist_len(responsible_dirs);
 

--- a/src/feature/hs/hs_common.c
+++ b/src/feature/hs/hs_common.c
@@ -1605,7 +1605,7 @@ hs_pick_hsdir(smartlist_t *responsible_dirs, const char *req_key_str,
   routerstatus_t *hs_dir;
   time_t now = time(NULL);
   int excluded_some;
-  bool rate_limited;
+  bool rate_limited = false;
   int rate_limited_count = 0;
   int responsible_dirs_count = smartlist_len(responsible_dirs);
 

--- a/src/feature/hs/hs_common.h
+++ b/src/feature/hs/hs_common.h
@@ -241,7 +241,7 @@ void hs_get_responsible_hsdirs(const struct ed25519_public_key_t *blinded_pk,
                               int use_second_hsdir_index,
                               int for_fetching, smartlist_t *responsible_dirs);
 routerstatus_t *hs_pick_hsdir(smartlist_t *responsible_dirs,
-                              const char *req_key_str);
+                              const char *req_key_str, int *is_rate_limited);
 
 time_t hs_hsdir_requery_period(const or_options_t *options);
 time_t hs_lookup_last_hid_serv_request(routerstatus_t *hs_dir,

--- a/src/feature/hs/hs_common.h
+++ b/src/feature/hs/hs_common.h
@@ -241,7 +241,7 @@ void hs_get_responsible_hsdirs(const struct ed25519_public_key_t *blinded_pk,
                               int use_second_hsdir_index,
                               int for_fetching, smartlist_t *responsible_dirs);
 routerstatus_t *hs_pick_hsdir(smartlist_t *responsible_dirs,
-                              const char *req_key_str, int *is_rate_limited);
+                              const char *req_key_str, bool *is_rate_limited);
 
 time_t hs_hsdir_requery_period(const or_options_t *options);
 time_t hs_lookup_last_hid_serv_request(routerstatus_t *hs_dir,

--- a/src/feature/rend/rendclient.c
+++ b/src/feature/rend/rendclient.c
@@ -469,7 +469,7 @@ directory_get_from_hs_dir(const char *desc_id,
 
   /* Automatically pick an hs dir if none given. */
   if (!rs_hsdir) {
-    int rate_limited;
+    bool rate_limited;
 
     /* Determine responsible dirs. Even if we can't get all we want, work with
      * the ones we have. If it's empty, we'll notice in hs_pick_hsdir(). */

--- a/src/feature/rend/rendclient.c
+++ b/src/feature/rend/rendclient.c
@@ -469,16 +469,19 @@ directory_get_from_hs_dir(const char *desc_id,
 
   /* Automatically pick an hs dir if none given. */
   if (!rs_hsdir) {
+    int rate_limited;
+
     /* Determine responsible dirs. Even if we can't get all we want, work with
      * the ones we have. If it's empty, we'll notice in hs_pick_hsdir(). */
     smartlist_t *responsible_dirs = smartlist_new();
     hid_serv_get_responsible_directories(responsible_dirs, desc_id);
 
-    hs_dir = hs_pick_hsdir(responsible_dirs, desc_id_base32);
+    hs_dir = hs_pick_hsdir(responsible_dirs, desc_id_base32, &rate_limited);
     if (!hs_dir) {
       /* No suitable hs dir can be found, stop right now. */
-      control_event_hsv2_descriptor_failed(rend_query, NULL,
-                                           "QUERY_NO_HSDIR");
+      const char *query_response = (rate_limited) ? "QUERY_RATE_LIMITED" :
+                                                    "QUERY_NO_HSDIR";
+      control_event_hsv2_descriptor_failed(rend_query, NULL, query_response);
       control_event_hs_descriptor_content(rend_data_get_address(rend_query),
                                           desc_id_base32, NULL, NULL);
       return 0;

--- a/src/feature/rend/rendclient.c
+++ b/src/feature/rend/rendclient.c
@@ -469,7 +469,7 @@ directory_get_from_hs_dir(const char *desc_id,
 
   /* Automatically pick an hs dir if none given. */
   if (!rs_hsdir) {
-    bool rate_limited;
+    bool rate_limited = false;
 
     /* Determine responsible dirs. Even if we can't get all we want, work with
      * the ones we have. If it's empty, we'll notice in hs_pick_hsdir(). */

--- a/src/test/test_hs.c
+++ b/src/test/test_hs.c
@@ -323,6 +323,16 @@ test_hs_desc_event(void *arg)
   tt_str_op(received_msg,OP_EQ, expected_msg);
   tor_free(received_msg);
 
+  /* test HSDir rate limited */
+  rend_query.auth_type = REND_NO_AUTH;
+  control_event_hsv2_descriptor_failed(&rend_query.base_, NULL,
+                                     "QUERY_RATE_LIMITED");
+  expected_msg = "650 HS_DESC FAILED "STR_HS_ADDR" NO_AUTH " \
+                 "UNKNOWN REASON=QUERY_RATE_LIMITED\r\n";
+  tt_assert(received_msg);
+  tt_str_op(received_msg,OP_EQ, expected_msg);
+  tor_free(received_msg);
+
   /* Test invalid content with no HSDir fingerprint. */
   char *exp_msg;
   control_event_hs_descriptor_content(rend_query.onion_address,


### PR DESCRIPTION
For the bug [here](https://trac.torproject.org/projects/tor/ticket/28269).