### PR TITLE
Fix a memory leak on failure to create keys directory.

### DIFF
--- a/changes/bug30148
+++ b/changes/bug30148
@@ -1,0 +1,4 @@
+  o Minor bugfixes (memory leak):
+    - Avoid a minor memory leak that could occur on relays when
+      creating a keys directory failed. Fixes bug 30148; bugfix on
+      0.3.3.1-alpha.

--- a/src/or/routerkeys.c
+++ b/src/or/routerkeys.c
@@ -816,7 +816,7 @@ load_ed_keys(const or_options_t *options, time_t now)
 
     /* Check/Create the key directory */
     if (create_keys_directory(options) < 0)
-      return -1;
+      goto err;
 
     char *fname;
     if (options->master_key_fname) {
@@ -1403,4 +1403,3 @@ routerkeys_free_all(void)
   rsa_ed_crosscert = NULL; // redundant
   rsa_ed_crosscert_len = 0;
 }
-


### PR DESCRIPTION
Fixes bug 30148, which is also CID 1437429 and CID 1437454. Bugfix
on 0.3.3.1-alpha, when separate key directories became a thing.