### PR TITLE
Fix a memory leak in tor-resolve.c

### DIFF
--- a/changes/bug30151
+++ b/changes/bug30151
@@ -1,0 +1,5 @@
+  o Minor bugfixes (tor-resolve):
+    - Fix a memory leak in tor-resolve that could happen if Tor gave it a
+      malformed SOCKS response.  (Memory leaks in tor-resolve don't actually
+      matter, but it's good to fix them anyway.)  Fixes bug 30151; bugfix on
+      0.4.0.1-alpha.

--- a/src/tools/tor-resolve.c
+++ b/src/tools/tor-resolve.c
@@ -424,6 +424,7 @@ do_resolve(const char *hostname,
     if (parsed < 2) {
       log_err(LD_NET, "Failed to parse SOCKS5 method selection "
                       "message");
+      socks5_server_method_free(m);
       goto err;
     }
 


### PR DESCRIPTION
Closes bug 30151/coverity CID 1441830. Bugfix on 0.4.0.1-alpha when
we started doing trunnel parsing in tor-resolve.c.