### PR TITLE
Add an assertion to test_hs_cache.c to appease coverity.

### DIFF
--- a/src/test/test_hs_cache.c
+++ b/src/test/test_hs_cache.c
@@ -244,6 +244,7 @@ helper_fetch_desc_from_hsdir(const ed25519_public_key_t *blinded_key)
 
   /* Simulate an HTTP GET request to the HSDir */
   conn = dir_connection_new(AF_INET);
+  tt_assert(conn);
   tor_addr_from_ipv4h(&conn->base_.addr, 0x7f000001);
   TO_CONN(conn)->linked = 1;/* Pretend the conn is encrypted :) */
   retval = directory_handle_command_get(conn, hsdir_query_str,


### PR DESCRIPTION
Coverity doesn't like to see a path where we test a pointer for
NULL if we have already ready dereferenced the pointer on that
path.  While in this case, the check is not needed, it's best not to
remove checks from the unit tests IMO.  Instead, I'm adding an
earlier check, so that coverity, when analyzing this function, will
think that we have always checked the pointer before dereferencing
it.

Closes ticket 30180; CID 1444641.