### PR TITLE
[Tor Trac #29613]: Make relays into exits when ExitRelay is auto and IPv6Exit is 1

### DIFF
--- a/changes/bug29613
+++ b/changes/bug29613
@@ -1,0 +1,5 @@
+  o Minor bugfixes (relay):
+    - If we are are a relay and have IPv6Exit to 1 while ExitRelay is
+      auto, we act as if ExitRelay is 1. Previously, we ignored IPv6Exit
+      if ExitRelay was 0 or auto. Fixes bug 29613; bugfix on 0.3.5.1-alpha.
+      Patch by Neel Chauhan.

--- a/doc/tor.1.txt
+++ b/doc/tor.1.txt
@@ -1939,9 +1939,10 @@ is non-zero):
     ExitPolicy, ReducedExitPolicy, and IPv6Exit options are ignored. +
  +
     If ExitRelay is set to "auto", then Tor checks the ExitPolicy,
-    ReducedExitPolicy, and IPv6Exit options. If either is set, Tor behaves
-    as if ExitRelay were set to 1. If neither exit policy option is set, Tor
-    behaves as if ExitRelay were set to 0. (Default: auto)
+    ReducedExitPolicy, and IPv6Exit options. If at least one of these options
+    is set, Tor behaves as if ExitRelay were set to 1. If none of these exit
+    policy options are set, Tor behaves as if ExitRelay were set to 0.
+    (Default: auto)
 
 [[ExitPolicy]] **ExitPolicy** __policy__,__policy__,__...__::
     Set an exit policy for this server. Each policy is of the form

--- a/doc/tor.1.txt
+++ b/doc/tor.1.txt
@@ -1935,13 +1935,13 @@ is non-zero):
     exit according to the ExitPolicy option, the ReducedExitPolicy option,
     or the default ExitPolicy (if no other exit policy option is specified). +
  +
-    If ExitRelay is set to 0, no traffic is allowed to
-    exit, and the ExitPolicy and ReducedExitPolicy options are ignored. +
+    If ExitRelay is set to 0, no traffic is allowed to exit, and the
+    ExitPolicy, ReducedExitPolicy, and IPv6Exit options are ignored. +
  +
-    If ExitRelay is set to "auto", then Tor checks the ExitPolicy and
-    ReducedExitPolicy options. If either is set, Tor behaves as if ExitRelay
-    were set to 1. If neither exit policy option is set, Tor behaves as if
-    ExitRelay were set to 0. (Default: auto)
+    If ExitRelay is set to "auto", then Tor checks the ExitPolicy,
+    ReducedExitPolicy, and IPv6Exit options. If either is set, Tor behaves
+    as if ExitRelay were set to 1. If neither exit policy option is set, Tor
+    behaves as if ExitRelay were set to 0. (Default: auto)
 
 [[ExitPolicy]] **ExitPolicy** __policy__,__policy__,__...__::
     Set an exit policy for this server. Each policy is of the form
@@ -2136,8 +2136,9 @@ is non-zero):
     (Default: 0)
 
 [[IPv6Exit]] **IPv6Exit** **0**|**1**::
-    If set, and we are an exit node, allow clients to use us for IPv6
-    traffic. (Default: 0)
+    If set, and we are an exit node, allow clients to use us for IPv6 traffic.
+    When this option is set and ExitRelay is auto, we act as if ExitRelay
+    is 1. (Default: 0)
 
 [[MaxOnionQueueDelay]] **MaxOnionQueueDelay** __NUM__ [**msec**|**second**]::
     If we have more onionskins queued for processing than we can process in

--- a/scripts/maint/practracker/exceptions.txt
+++ b/scripts/maint/practracker/exceptions.txt
@@ -117,7 +117,7 @@ problem include-count /src/core/or/connection_or.c 51
 problem function-size /src/core/or/connection_or.c:connection_or_group_set_badness_() 105
 problem function-size /src/core/or/connection_or.c:connection_or_client_learned_peer_id() 144
 problem function-size /src/core/or/connection_or.c:connection_or_compute_authenticate_cell_body() 235
-problem file-size /src/core/or/policies.c 3163
+problem file-size /src/core/or/policies.c 3164
 problem function-size /src/core/or/policies.c:policy_summarize() 107
 problem function-size /src/core/or/protover.c:protover_all_supported() 116
 problem file-size /src/core/or/relay.c 3173

--- a/scripts/maint/practracker/exceptions.txt
+++ b/scripts/maint/practracker/exceptions.txt
@@ -117,7 +117,7 @@ problem include-count /src/core/or/connection_or.c 51
 problem function-size /src/core/or/connection_or.c:connection_or_group_set_badness_() 105
 problem function-size /src/core/or/connection_or.c:connection_or_client_learned_peer_id() 144
 problem function-size /src/core/or/connection_or.c:connection_or_compute_authenticate_cell_body() 235
-problem file-size /src/core/or/policies.c 3164
+problem file-size /src/core/or/policies.c 3171
 problem function-size /src/core/or/policies.c:policy_summarize() 107
 problem function-size /src/core/or/protover.c:protover_all_supported() 116
 problem file-size /src/core/or/relay.c 3173

--- a/src/config/torrc.sample.in
+++ b/src/config/torrc.sample.in
@@ -175,7 +175,7 @@
 ## Uncomment this if you want your relay to be an exit, with the default
 ## exit policy (or whatever exit policy you set below).
 ## (If ReducedExitPolicy, ExitPolicy, or IPv6Exit are set, relays are exits.
-## If neither exit policy option is set, relays are non-exits.)
+## If none of these options are set, relays are non-exits.)
 #ExitRelay 1
 
 ## Uncomment this if you want your relay to allow IPv6 exit traffic.

--- a/src/config/torrc.sample.in
+++ b/src/config/torrc.sample.in
@@ -174,13 +174,11 @@
 
 ## Uncomment this if you want your relay to be an exit, with the default
 ## exit policy (or whatever exit policy you set below).
-## (If ReducedExitPolicy or ExitPolicy are set, relays are exits.
+## (If ReducedExitPolicy, ExitPolicy, or IPv6Exit are set, relays are exits.
 ## If neither exit policy option is set, relays are non-exits.)
 #ExitRelay 1
 
 ## Uncomment this if you want your relay to allow IPv6 exit traffic.
-## You must also set ExitRelay, ReducedExitPolicy, or ExitPolicy to make your
-## relay into an exit.
 ## (Relays do not allow any exit traffic by default.)
 #IPv6Exit 1
 

--- a/src/core/or/policies.c
+++ b/src/core/or/policies.c
@@ -1164,6 +1164,15 @@ authdir_policy_badexit_address(uint32_t addr, uint16_t port)
 #define REJECT(arg) \
   STMT_BEGIN *msg = tor_strdup(arg); goto err; STMT_END
 
+/** Check <b>or_options</b> to determine whether or not we are using the
+ * default options for exit policy. Return true if so, false otherwise. */
+static int
+policy_using_default_exit_options(const or_options_t *or_options)
+{
+  return (or_options->ExitPolicy == NULL && or_options->ExitRelay == -1 &&
+          or_options->ReducedExitPolicy == 0 && or_options->IPv6Exit == 0);
+}
+
 /** Config helper: If there's any problem with the policy configuration
  * options in <b>options</b>, return -1 and set <b>msg</b> to a newly
  * allocated description of the error. Else return 0. */
@@ -1183,8 +1192,7 @@ validate_addr_policies(const or_options_t *options, char **msg)
   static int warned_about_nonexit = 0;
 
   if (public_server_mode(options) && !warned_about_nonexit &&
-      options->ExitPolicy == NULL && options->ExitRelay == -1 &&
-      options->ReducedExitPolicy == 0 && options->IPv6Exit == 0) {
+      policy_using_default_exit_options(options)) {
     warned_about_nonexit = 1;
     log_notice(LD_CONFIG, "By default, Tor does not run as an exit relay. "
                "If you want to be an exit relay, "
@@ -2143,8 +2151,7 @@ policies_parse_exit_policy_from_options(const or_options_t *or_options,
   /* Short-circuit for non-exit relays, or for relays where we didn't specify
    * ExitPolicy or ReducedExitPolicy and ExitRelay is auto. */
   if (or_options->ExitRelay == 0 ||
-      (or_options->ExitPolicy == NULL && or_options->ExitRelay == -1 &&
-       or_options->ReducedExitPolicy == 0 && or_options->IPv6Exit == 0)) {
+      policy_using_default_exit_options(or_options)) {
     append_exit_policy_string(result, "reject *4:*");
     append_exit_policy_string(result, "reject *6:*");
     return 0;

--- a/src/core/or/policies.c
+++ b/src/core/or/policies.c
@@ -2149,7 +2149,7 @@ policies_parse_exit_policy_from_options(const or_options_t *or_options,
   int rv = 0;
 
   /* Short-circuit for non-exit relays, or for relays where we didn't specify
-   * ExitPolicy or ReducedExitPolicy and ExitRelay is auto. */
+   * ExitPolicy or ReducedExitPolicy or IPv6Exit and ExitRelay is auto. */
   if (or_options->ExitRelay == 0 ||
       policy_using_default_exit_options(or_options)) {
     append_exit_policy_string(result, "reject *4:*");

--- a/src/core/or/policies.c
+++ b/src/core/or/policies.c
@@ -1182,9 +1182,9 @@ validate_addr_policies(const or_options_t *options, char **msg)
 
   static int warned_about_nonexit = 0;
 
-  if (public_server_mode(options) &&
-      !warned_about_nonexit && options->ExitPolicy == NULL &&
-      options->ExitRelay == -1 && options->ReducedExitPolicy == 0) {
+  if (public_server_mode(options) && !warned_about_nonexit &&
+      options->ExitPolicy == NULL && options->ExitRelay == -1 &&
+      options->ReducedExitPolicy == 0 && options->IPv6Exit == 0) {
     warned_about_nonexit = 1;
     log_notice(LD_CONFIG, "By default, Tor does not run as an exit relay. "
                "If you want to be an exit relay, "
@@ -2142,8 +2142,9 @@ policies_parse_exit_policy_from_options(const or_options_t *or_options,
 
   /* Short-circuit for non-exit relays, or for relays where we didn't specify
    * ExitPolicy or ReducedExitPolicy and ExitRelay is auto. */
-  if (or_options->ExitRelay == 0 || (or_options->ExitPolicy == NULL &&
-      or_options->ExitRelay == -1 && or_options->ReducedExitPolicy == 0)) {
+  if (or_options->ExitRelay == 0 ||
+      (or_options->ExitPolicy == NULL && or_options->ExitRelay == -1 &&
+       or_options->ReducedExitPolicy == 0 && or_options->IPv6Exit == 0)) {
     append_exit_policy_string(result, "reject *4:*");
     append_exit_policy_string(result, "reject *6:*");
     return 0;


### PR DESCRIPTION
For the bug [here](https://trac.torproject.org/projects/tor/ticket/29613).