### PR TITLE
rust: abort on panic in all profiles

### DIFF
--- a/changes/bug27199
+++ b/changes/bug27199
@@ -1,0 +1,3 @@
+  o Minor bugfixes (rust):
+    - Abort on panic in all build profiles, instead of potentially unwinding
+      into C code. Fixes bug 27199; bugfix on 0.3.3.1-alpha.

--- a/src/rust/Cargo.toml
+++ b/src/rust/Cargo.toml
@@ -1,7 +1,17 @@
 [workspace]
 members = ["tor_util", "protover", "smartlist", "external", "tor_allocate", "tor_rust"]
 
+# Can remove panic="abort" when this issue is fixed:
+# https://github.com/rust-lang/rust/issues/52652
+[profile.dev]
+panic = "abort"
+
 [profile.release]
 debug = true
 panic = "abort"
 
+[profile.test]
+panic = "abort"
+
+[profile.bench]
+panic = "abort"


### PR DESCRIPTION
Until https://github.com/rust-lang/rust/issues/52652 is fixed,
unwinding on panic is potentially unsound in a mixed C/Rust codebase.

The codebase is supposed to be panic-free already, but just to be safe.

This started mattering at commit d1820c1516a31a149fc51a9e5126bf899e4c4e08.

Fixes #27199; bugfix on tor-0.3.3.1-alpha.