### PR TITLE
Use a tor_abort_() wrapper in our util_bug.h macros

### DIFF
--- a/changes/bug30189
+++ b/changes/bug30189
@@ -1,0 +1,4 @@
+  o Minor bugfixes (compilation, unusual configuration):
+    - Avoid failures when building with ALL_BUGS_ARE_FAILED due to
+      missing declarations of abort(), and prevent other such failures
+      in the future. Fixes bug 30189; bugfix on 0.3.4.1-alpha.

--- a/src/lib/log/util_bug.c
+++ b/src/lib/log/util_bug.c
@@ -19,6 +19,7 @@
 #include "lib/string/printf.h"
 
 #include <string.h>
+#include <stdlib.h>
 
 #ifdef TOR_UNIT_TESTS
 static void (*failed_assertion_cb)(void) = NULL;
@@ -118,6 +119,19 @@ tor_bug_occurred_(const char *fname, unsigned int line,
     failed_assertion_cb();
   }
 #endif
+}
+
+/**
+ * Call the abort() function to kill the current process with a fatal
+ * error.
+ *
+ * (This is a separate function so that we declare it in util_bug.h without
+ * including stdlib in all the users of util_bug.h)
+ **/
+void
+tor_abort_(void)
+{
+  abort();
 }
 
 #ifdef _WIN32

--- a/src/lib/log/util_bug.h
+++ b/src/lib/log/util_bug.h
@@ -99,7 +99,7 @@
   if (ASSERT_PREDICT_LIKELY_(expr)) {                                   \
   } else {                                                              \
     tor_assertion_failed_(SHORT_FILE__, __LINE__, __func__, #expr);     \
-    abort();                                                            \
+    tor_abort_();                                                       \
   } STMT_END
 #endif /* defined(TOR_UNIT_TESTS) && defined(DISABLE_ASSERTS_IN_UNIT_TESTS) */
 
@@ -107,7 +107,7 @@
   STMT_BEGIN {                                                  \
     tor_assertion_failed_(SHORT_FILE__, __LINE__, __func__,     \
                           "line should be unreached");          \
-    abort();                                                    \
+    tor_abort_();                                               \
   } STMT_END
 
 /* Non-fatal bug assertions. The "unreached" variants mean "this line should
@@ -141,7 +141,7 @@
 #define BUG(cond)                                                       \
   (ASSERT_PREDICT_UNLIKELY_(cond) ?                                     \
    (tor_assertion_failed_(SHORT_FILE__,__LINE__,__func__,"!("#cond")"), \
-    abort(), 1)                                                         \
+    tor_abort_(), 1)                                                    \
    : 0)
 #elif defined(TOR_UNIT_TESTS) && defined(DISABLE_ASSERTS_IN_UNIT_TESTS)
 #define tor_assert_nonfatal_unreached() STMT_NIL
@@ -225,6 +225,8 @@ void tor_assertion_failed_(const char *fname, unsigned int line,
 void tor_bug_occurred_(const char *fname, unsigned int line,
                        const char *func, const char *expr,
                        int once);
+
+void tor_abort_(void) ATTR_NORETURN;
 
 #ifdef _WIN32
 #define SHORT_FILE__ (tor_fix_source_file(__FILE__))


### PR DESCRIPTION
Previously, our use of abort() would break anywhere that we didn't
include stdlib.h.  This was especially troublesome in case where
tor_assert_nonfatal() was used with ALL_BUGS_ARE_FATAL, since that
one seldom gets tested.

As an alternative, we could have just made this header include
stdlib.h.  But that seems bloaty.

Fixes bug 30189; bugfix on 0.3.4.1-alpha.