### PR TITLE
Stop looking for scripts in the build directory during "make shellcheck"

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -220,7 +220,7 @@ shellcheck:
 	if command -v shellcheck; then \
 	        find $(top_srcdir)/scripts/ -name "*.sh" -exec shellcheck {} +; \
 	        if [ -d "$(top_srcdir)/scripts/test" ]; then \
-                        shellcheck $(top_srcdir)/scripts/test/cov-diff $(top_builddir)/scripts/test/coverage; \
+                        shellcheck $(top_srcdir)/scripts/test/cov-diff $(top_srcdir)/scripts/test/coverage; \
                 fi; \
 	fi
 

--- a/changes/bug30263
+++ b/changes/bug30263
@@ -1,0 +1,3 @@
+  o Minor bugfixes (shellcheck):
+    - Stop looking for scripts in the build directory during
+      "make shellcheck". Fixes bug 30263; bugfix on 0.4.0.1-alpha.


### PR DESCRIPTION
Fixes bug 30263; bugfix on 0.4.0.1-alpha.