### PR TITLE
test-network-all: Test IPv6-only v3 single onion services

### DIFF
--- a/changes/ticket27251
+++ b/changes/ticket27251
@@ -1,0 +1,4 @@
+  o Testing (chutney):
+    - In "make test-network-all", test IPv6-only v3 single onion services,
+      using the chutney network single-onion-v23-ipv6-md. This test will
+      not pass until 23588 has been merged. Closes ticket 27251.

--- a/src/test/include.am
+++ b/src/test/include.am
@@ -46,10 +46,8 @@ TESTS += src/test/test src/test/test-slow src/test/test-memwipe \
 TEST_CHUTNEY_FLAVORS = basic-min bridges-min hs-v2-min hs-v3-min \
 	single-onion-v23
 # only run if we can ping6 ::1 (localhost)
-# IPv6-only v3 single onion services don't work yet, so we don't test the
-# single-onion-v23-ipv6-md flavor
 TEST_CHUTNEY_FLAVORS_IPV6 = bridges+ipv6-min ipv6-exit-min hs-v23-ipv6-md \
-	single-onion-ipv6-md
+	single-onion-v23-ipv6-md
 # only run if we can find a stable (or simply another) version of tor
 TEST_CHUTNEY_FLAVORS_MIXED = mixed+hs-v2
 


### PR DESCRIPTION
In "make test-network-all", test IPv6-only v3 single onion services,
using the chutney network single-onion-v23-ipv6-md. This test will
not pass until 23588 has been merged.

Closes ticket 27251.