### PR TITLE
Move bandwidth-file-headers line to appear in the correct vote section

### DIFF
--- a/changes/bug30316
+++ b/changes/bug30316
@@ -1,0 +1,4 @@
+  o Minor bugfixes (directory authority):
+    - Move the "bandwidth-file-headers" line in directory authority votes
+      so that it conforms to dir-spec.txt. Fixes bug 30316; bugfix on
+      0.3.5.1-alpha.

--- a/src/feature/dirauth/dirvote.c
+++ b/src/feature/dirauth/dirvote.c
@@ -322,10 +322,10 @@ format_networkstatus_vote(crypto_pk_t *private_signing_key,
                  "known-flags %s\n"
                  "flag-thresholds %s\n"
                  "params %s\n"
+                 "%s" /* bandwidth file headers */
                  "dir-source %s %s %s %s %d %d\n"
                  "contact %s\n"
                  "%s" /* shared randomness information */
-                 "%s" /* bandwidth file headers */
                  ,
                  v3_ns->type == NS_TYPE_VOTE ? "vote" : "opinion",
                  methods,
@@ -338,13 +338,12 @@ format_networkstatus_vote(crypto_pk_t *private_signing_key,
                  flags,
                  flag_thresholds,
                  params,
+                 bw_headers_line ? bw_headers_line : "",
                  voter->nickname, fingerprint, voter->address,
                  fmt_addr32(addr), voter->dir_port, voter->or_port,
                  voter->contact,
                  shared_random_vote_str ?
-                           shared_random_vote_str : "",
-                 bw_headers_line ?
-                           bw_headers_line : "");
+                           shared_random_vote_str : "");
 
     tor_free(params);
     tor_free(flags);


### PR DESCRIPTION
Fixes bug 30316; bugfix on 0.3.5.1-alpha.