### PR TITLE
sendme: Add FlowCtrl protover value

### DIFF
--- a/src/core/or/protover.c
+++ b/src/core/or/protover.c
@@ -53,7 +53,8 @@ static const struct {
   { PRT_DESC, "Desc" },
   { PRT_MICRODESC, "Microdesc"},
   { PRT_PADDING, "Padding"},
-  { PRT_CONS, "Cons" }
+  { PRT_CONS, "Cons" },
+  { PRT_FLOWCTRL, "FlowCtrl"},
 };
 
 #define N_PROTOCOL_NAMES ARRAY_LENGTH(PROTOCOL_NAMES)
@@ -401,7 +402,8 @@ protover_get_supported_protocols(void)
 #endif
     "Microdesc=1-2 "
     "Relay=1-2 "
-    "Padding=1";
+    "Padding=1 "
+    "FlowCtrl=1";
 }
 
 /** The protocols from protover_get_supported_protocols(), as parsed into a

--- a/src/core/or/protover.h
+++ b/src/core/or/protover.h
@@ -44,6 +44,7 @@ typedef enum protocol_type_t {
   PRT_MICRODESC = 8,
   PRT_CONS      = 9,
   PRT_PADDING   = 10,
+  PRT_FLOWCTRL  = 11,
 } protocol_type_t;
 
 bool protover_contains_long_protocol_names(const char *s);

--- a/src/rust/protover/ffi.rs
+++ b/src/rust/protover/ffi.rs
@@ -31,6 +31,7 @@ fn translate_to_rust(c_proto: uint32_t) -> Result<Protocol, ProtoverError> {
         8 => Ok(Protocol::Microdesc),
         9 => Ok(Protocol::Cons),
         10 => Ok(Protocol::Padding),
+        11 => Ok(Protocol::FlowCtrl),
         _ => Err(ProtoverError::UnknownProtocol),
     }
 }

--- a/src/rust/protover/protover.rs
+++ b/src/rust/protover/protover.rs
@@ -47,6 +47,7 @@ pub enum Protocol {
     Microdesc,
     Relay,
     Padding,
+    FlowCtrl,
 }
 
 impl fmt::Display for Protocol {
@@ -75,6 +76,7 @@ impl FromStr for Protocol {
             "Microdesc" => Ok(Protocol::Microdesc),
             "Relay" => Ok(Protocol::Relay),
             "Padding" => Ok(Protocol::Padding),
+            "FlowCtrl" => Ok(Protocol::FlowCtrl),
             _ => Err(ProtoverError::UnknownProtocol),
         }
     }
@@ -166,7 +168,8 @@ pub(crate) fn get_supported_protocols_cstr() -> &'static CStr {
              LinkAuth=3 \
              Microdesc=1-2 \
              Relay=1-2 \
-             Padding=1"
+             Padding=1 \
+             FlowCtrl=1"
         )
     } else {
         cstr!(
@@ -180,7 +183,8 @@ pub(crate) fn get_supported_protocols_cstr() -> &'static CStr {
              LinkAuth=1,3 \
              Microdesc=1-2 \
              Relay=1-2 \
-             Padding=1"
+             Padding=1 \
+             FlowCtrl=1"
         )
     }
 }


### PR DESCRIPTION
See proposal 289 section 4.3 for more details.

It describes the flow control protocol at the circuit and stream level. If
there is no FlowCtrl protocol version, tor supports the unauthenticated flow
control features from its supported Relay protocols.

At this commit, relay will start advertising FlowCtrl=1 meaning they support
authenticated SENDMEs v1.

Closes #30363

Signed-off-by: David Goulet <dgoulet@torproject.org>