### PR TITLE
Don't pass a NULL into a %s when logging client auth file load failure

### DIFF
--- a/changes/bug30475
+++ b/changes/bug30475
@@ -1,0 +1,4 @@
+  o Minor bugfixes ():
+    - Avoid a GCC 9.1.1 warning (and possible crash depending on libc
+      implemenation) when failing to load a hidden service client authorization
+      file.  Fixes bug 30475; bugfix on 0.3.5.1-alpha.

--- a/src/feature/hs/hs_service.c
+++ b/src/feature/hs/hs_service.c
@@ -1259,16 +1259,16 @@ load_client_keys(hs_service_t *service)
     client_key_file_path = hs_path_from_filename(client_keys_dir_path,
                                                  filename);
     client_key_str = read_file_to_str(client_key_file_path, 0, NULL);
-    /* Free immediately after using it. */
-    tor_free(client_key_file_path);
 
     /* If we cannot read the file, continue with the next file. */
     if (!client_key_str)  {
       log_warn(LD_REND, "Client authorization file %s can't be read. "
                         "Corrupted or verify permission? Ignoring.",
                client_key_file_path);
+      tor_free(client_key_file_path);
       continue;
     }
+    tor_free(client_key_file_path);
 
     client = parse_authorized_client(client_key_str);
     /* Wipe and free immediately after using it. */


### PR DESCRIPTION
Fortunately, in 0.3.5.1-alpha we improved logging for various
failure cases involved with onion service client auth.

Unfortunately, for this one, we freed the file right before logging
its name.

Fortunately, tor_free() sets its pointer to NULL, so we didn't have
a use-after-free bug.

Unfortunately, passing NULL to %s is not defined.

Fortunately, GCC 9.1.1 caught the issue!

Unfortunately, nobody has actually tried building Tor with GCC 9.1.1
before. Or if they had, they didn't report the warning.

Fixes bug 30475; bugfix on 0.3.5.1-alpha.