### PR TITLE
#30286: pre-push.git-hook: Don't reject fixup and squash commits when pushing to non-upstream remotes

### DIFF
--- a/changes/bug30286
+++ b/changes/bug30286
@@ -1,0 +1,4 @@
+  o Minor bugfixes (developer tooling):
+    - Fix pre-push hook to refrain from rejecting fixup and squash commits
+      when pushing to non-upstream git remote. Fixes bug 30286; bugfix on
+      0.4.0.1-alpha.

--- a/scripts/git/pre-push.git-hook
+++ b/scripts/git/pre-push.git-hook
@@ -8,6 +8,9 @@
 #
 # To install this script, copy it into .git/hooks/pre-push path in your
 # local copy of git repository. Make sure it has permission to execute.
+# Furthermore, make sure that TOR_UPSTREAM_REMOTE_NAME environment
+# variable is set to local name of git remote that corresponds to upstream
+# repository on e,g. git.torproject.org.
 #
 # The following sample script was used as starting point:
 # https://github.com/git/git/blob/master/templates/hooks--pre-push.sample

--- a/scripts/git/pre-push.git-hook
+++ b/scripts/git/pre-push.git-hook
@@ -16,16 +16,6 @@ echo "Running pre-push hook"
 
 z40=0000000000000000000000000000000000000000
 
-remote="$1"
-
-ref_is_upstream_branch() {
-        if [ "$1" == "refs/heads/master" ] ||
-                [[ "$1" == refs/heads/release-* ]] ||
-                [[ "$1" == refs/heads/maint-* ]]
-        then
-                return 1
-        fi
-}
 
 workdir=$(git rev-parse --show-toplevel)
 if [ -x "$workdir/.git/hooks/pre-commit" ]; then
@@ -39,6 +29,24 @@ if [ -e scripts/maint/practracker/practracker.py ]; then
     exit 1
   fi
 fi
+
+remote="$1"
+remote_loc="$2"
+
+if [[ "$remote_loc" != *github.com/torproject/tor.git ]] &&
+   [[ "$remote_loc" != *torproject.org/tor.git ]]; then
+  echo "Not pushing to upstream - refraining from further checks"
+  exit 0
+fi
+
+ref_is_upstream_branch() {
+        if [ "$1" == "refs/heads/master" ] ||
+                [[ "$1" == refs/heads/release-* ]] ||
+                [[ "$1" == refs/heads/maint-* ]]
+        then
+                return 1
+        fi
+}
 
 # shellcheck disable=SC2034
 while read -r local_ref local_sha remote_ref remote_sha

--- a/scripts/git/pre-push.git-hook
+++ b/scripts/git/pre-push.git-hook
@@ -10,7 +10,7 @@
 # local copy of git repository. Make sure it has permission to execute.
 # Furthermore, make sure that TOR_UPSTREAM_REMOTE_NAME environment
 # variable is set to local name of git remote that corresponds to upstream
-# repository on e,g. git.torproject.org.
+# repository on e.g. git.torproject.org.
 #
 # The following sample script was used as starting point:
 # https://github.com/git/git/blob/master/templates/hooks--pre-push.sample

--- a/scripts/git/pre-push.git-hook
+++ b/scripts/git/pre-push.git-hook
@@ -16,6 +16,7 @@ echo "Running pre-push hook"
 
 z40=0000000000000000000000000000000000000000
 
+upstream_name=${TOR_UPSTREAM_REMOTE_NAME:-"upstream"}
 
 workdir=$(git rev-parse --show-toplevel)
 if [ -x "$workdir/.git/hooks/pre-commit" ]; then
@@ -33,8 +34,9 @@ fi
 remote="$1"
 remote_loc="$2"
 
-if [[ "$remote_loc" != *github.com/torproject/tor.git ]] &&
-   [[ "$remote_loc" != *torproject.org/tor.git ]]; then
+remote_name=$(git remote --verbose | grep "$2" | awk '{print $1}' | head -n 1)
+
+if [[ "$remote_name" != "$upstream_name" ]]; then
   echo "Not pushing to upstream - refraining from further checks"
   exit 0
 fi


### PR DESCRIPTION
https://trac.torproject.org/projects/tor/ticket/30286