### PR TITLE
sendme: Fix coverity CID 1444999

### DIFF
--- a/src/core/or/sendme.c
+++ b/src/core/or/sendme.c
@@ -412,6 +412,11 @@ sendme_process_circuit_level(crypt_path_t *layer_hint,
   /* If we are the origin of the circuit, we are the Client so we use the
    * layer hint (the Exit hop) for the package window tracking. */
   if (CIRCUIT_IS_ORIGIN(circ)) {
+    /* If we are the origin of the circuit, it is impossible to not have a
+     * cpath. Just in case, bug on it and close the circuit. */
+    if (BUG(layer_hint == NULL)) {
+      return -END_CIRC_REASON_TORPROTOCOL;
+    }
     if ((layer_hint->package_window + CIRCWINDOW_INCREMENT) >
         CIRCWINDOW_START_MAX) {
       static struct ratelim_t exit_warn_ratelim = RATELIM_INIT(600);


### PR DESCRIPTION
The code flow in theory can end up with a layer_hint to be NULL but in
practice it should never happen because with an origin circuit, we must have
the layer_hint.

Just in case, BUG() on it if we ever end up in this situation and recover by
closing the circuit.

Fixes #30467.

Signed-off-by: David Goulet <dgoulet@torproject.org>