### PR TITLE
sendme: Introduce consensus param sendme_dir_min_version

### DIFF
--- a/src/core/or/or_circuit_st.h
+++ b/src/core/or/or_circuit_st.h
@@ -61,6 +61,13 @@ struct or_circuit_t {
    *  statistics. */
   unsigned int circuit_carries_hs_traffic_stats : 1;
 
+  /** If set, this circuit got a BEGIN_DIR, meaning a directory request, and
+   * not for any hidden service documents. We use this flag for SENDME
+   * mechanism in order to know if this circuit will serve a consensus for
+   * which we need to obey a specific consensus parameter about the minimal
+   * SENDME version we accept. */
+  unsigned int begin_dir_seen : 1;
+
   /** Number of cells that were removed from circuit queue; reset every
    * time when writing buffer stats to disk. */
   uint32_t processed_cells;

--- a/src/core/or/relay.c
+++ b/src/core/or/relay.c
@@ -1670,6 +1670,11 @@ connection_edge_process_relay_cell(cell_t *cell, circuit_t *circ,
                "from intermediary node. Dropping.");
         return 0;
       }
+      if (circ->purpose == CIRCUIT_PURPOSE_OR) {
+        /* Flag that this circuit just got a BEGIN_DIR and it is not an hidden
+         * service document request. */
+        TO_OR_CIRCUIT(circ)->begin_dir_seen = 1;
+      }
       if (conn) {
         log_fn(LOG_PROTOCOL_WARN, domain,
                "Begin cell for known stream. Dropping.");

--- a/src/core/or/sendme.h
+++ b/src/core/or/sendme.h
@@ -51,8 +51,10 @@ bool sendme_circuit_cell_is_next(int window);
 
 STATIC int get_emit_min_version(void);
 STATIC int get_accept_min_version(void);
+STATIC int get_dir_min_version(void);
 
-STATIC bool cell_version_is_valid(uint8_t cell_version);
+STATIC bool cell_version_is_valid(uint8_t cell_version,
+                                  const circuit_t *circ);
 
 STATIC ssize_t build_cell_payload_v1(const uint8_t *cell_digest,
                                      uint8_t *payload);


### PR DESCRIPTION
See section 4.5 of proposal 289 which describes why we need this parameter. To
summarize, this is to accomodate old clients not supporting authenticated
SENDMEs and booting up for the first time.

They need to be able to fetch a consensus to actually learn that the required
protocols is FlowCtrl=1 and thus not start up. And for that, we need to allow
a SENDME minimum version on a directory request circuit. That new consensus
parameter handles that.

Closes #30364

Signed-off-by: David Goulet <dgoulet@torproject.org>