### PR TITLE
OOM-purge the DNS cache one part at a time

### DIFF
--- a/changes/ticket29617
+++ b/changes/ticket29617
@@ -1,0 +1,4 @@
+  o Minor bugfixes (out-of-memory handler):
+    - When purging the DNS cache because of an out-of-memory condition,
+      try purging just the older entries at first.  Previously, we would
+      purge the whole thing. Fixes bug 29617; bugfix on 0.3.5.1-alpha.

--- a/src/feature/relay/dns.c
+++ b/src/feature/relay/dns.c
@@ -2130,7 +2130,8 @@ dns_cache_handle_oom(time_t now, size_t min_remove_bytes)
     current_size -= bytes_removed;
     total_bytes_removed += bytes_removed;
 
-    time_inc += 3600; /* Increase time_inc by 1 hour. */
+    /* Increase time_inc by a reasonable fraction. */
+    time_inc += (MAX_DNS_TTL_AT_EXIT / 4);
   } while (total_bytes_removed < min_remove_bytes);
 
   return total_bytes_removed;


### PR DESCRIPTION
Previously we purged it in 1-hour increments -- but one-hour is the
maximum TTL for the cache!  Now we do it in 25%-TTL increments.

Fixes bug 29617; bugfix on 0.3.5.1-alpha.