### PR TITLE
hs: Implement a helper to repurpose a circuit

### DIFF
--- a/changes/bug29034
+++ b/changes/bug29034
@@ -1,0 +1,5 @@
+  o Major bugfixes (Onion service reachability):
+    - Properly clean up the introduction point map and associated state when
+      circuits change purpose from onion service circuits to pathbias,
+      measurement, or other circuit types. This should fix some instances of
+      introduction point failure. Fixes bug 29034; bugfix on 0.3.2.1-alpha.

--- a/scripts/maint/practracker/exceptions.txt
+++ b/scripts/maint/practracker/exceptions.txt
@@ -92,7 +92,7 @@ problem function-size /src/core/or/circuitlist.c:circuits_handle_oom() 117
 problem function-size /src/core/or/circuitmux.c:circuitmux_set_policy() 110
 problem function-size /src/core/or/circuitmux.c:circuitmux_attach_circuit() 114
 problem function-size /src/core/or/circuitstats.c:circuit_build_times_parse_state() 124
-problem file-size /src/core/or/circuituse.c 3156
+problem file-size /src/core/or/circuituse.c 3162
 problem function-size /src/core/or/circuituse.c:circuit_is_acceptable() 133
 problem function-size /src/core/or/circuituse.c:circuit_expire_building() 394
 problem function-size /src/core/or/circuituse.c:circuit_log_ancient_one_hop_circuits() 126

--- a/src/core/or/circuituse.c
+++ b/src/core/or/circuituse.c
@@ -3068,6 +3068,12 @@ circuit_change_purpose(circuit_t *circ, uint8_t new_purpose)
 
   if (circ->purpose == new_purpose) return;
 
+  /* Take specific actions if we are repurposing a hidden service circuit. */
+  if (circuit_purpose_is_hidden_service(circ->purpose) &&
+      !circuit_purpose_is_hidden_service(new_purpose)) {
+    hs_circ_repurpose(circ);
+  }
+
   if (CIRCUIT_IS_ORIGIN(circ)) {
     char old_purpose_desc[80] = "";
 

--- a/src/feature/hs/hs_circuit.c
+++ b/src/feature/hs/hs_circuit.c
@@ -25,6 +25,7 @@
 #include "feature/nodelist/describe.h"
 #include "feature/nodelist/nodelist.h"
 #include "feature/rend/rendservice.h"
+#include "feature/rend/rendcommon.h"
 #include "feature/stats/rephist.h"
 #include "lib/crypt_ops/crypto_dh.h"
 #include "lib/crypt_ops/crypto_rand.h"
@@ -1190,5 +1191,35 @@ hs_circ_cleanup(circuit_t *circ)
    * where we can't register a new circuit for the same intro point. */
   if (circ->hs_token) {
     hs_circuitmap_remove_circuit(circ);
+  }
+}
+
+/* The given circuit will be repurposed so take the appropriate actions. A
+ * cleanup from the HS maps and of all HS related structures is done.
+ *
+ * Once this function returns, the circuit can be safely repurposed. */
+void
+hs_circ_repurpose(circuit_t *circ)
+{
+  origin_circuit_t *origin_circ;
+
+  tor_assert(circ);
+
+  /* Only repurposing an origin circuit is possible for HS. */
+  if (!CIRCUIT_IS_ORIGIN(circ)) {
+    return;
+  }
+  origin_circ = TO_ORIGIN_CIRCUIT(circ);
+
+  /* First, cleanup the circuit from the HS maps. */
+  hs_circ_cleanup(circ);
+
+  /* Depending on the version, different cleanup is done. */
+  if (origin_circ->rend_data) {
+    /* v2. */
+    rend_circ_cleanup(origin_circ);
+  } else if (origin_circ->hs_ident) {
+    /* v3. */
+    hs_ident_circuit_free(origin_circ->hs_ident);
   }
 }

--- a/src/feature/hs/hs_circuit.h
+++ b/src/feature/hs/hs_circuit.h
@@ -16,6 +16,7 @@
 
 /* Cleanup function when the circuit is closed or/and freed. */
 void hs_circ_cleanup(circuit_t *circ);
+void hs_circ_repurpose(circuit_t *circ);
 
 /* Circuit API. */
 int hs_circ_service_intro_has_opened(hs_service_t *service,

--- a/src/feature/rend/rendcommon.c
+++ b/src/feature/rend/rendcommon.c
@@ -1046,3 +1046,14 @@ rend_circuit_pk_digest_eq(const origin_circuit_t *ocirc,
  match:
   return 1;
 }
+
+/* Cleanup the given circuit of all HS v2 data structure. */
+void
+rend_circ_cleanup(origin_circuit_t *circ)
+{
+  tor_assert(circ);
+
+  /* Both fields are set to NULL with these. */
+  crypto_pk_free(circ->intro_key);
+  rend_data_free(circ->rend_data);
+}

--- a/src/feature/rend/rendcommon.h
+++ b/src/feature/rend/rendcommon.h
@@ -71,6 +71,8 @@ int rend_non_anonymous_mode_enabled(const or_options_t *options);
 void assert_circ_anonymity_ok(const origin_circuit_t *circ,
                               const or_options_t *options);
 
+void rend_circ_cleanup(origin_circuit_t *circ);
+
 #ifdef RENDCOMMON_PRIVATE
 
 STATIC int


### PR DESCRIPTION
When we repurpose a hidden service circuit, we need to clean up from the HS
circuit map and any HS related data structured contained in the circuit.

This commit adds an helper function that does it when repurposing a hidden
service circuit.

Fixes #29034

Signed-off-by: David Goulet <dgoulet@torproject.org>