### PR TITLE
hs: Implement a helper to repurpose a circuit

### DIFF
--- a/changes/bug29034
+++ b/changes/bug29034
@@ -1,0 +1,5 @@
+  o Major bugfixes (Onion service reachability):
+    - Properly clean up the introduction point map and associated state when
+      circuits change purpose from onion service circuits to pathbias,
+      measurement, or other circuit types. This should fix some instances of
+      introduction point failure. Fixes bug 29034; bugfix on 0.3.2.1-alpha.

--- a/src/core/or/circuituse.c
+++ b/src/core/or/circuituse.c
@@ -3052,6 +3052,12 @@ circuit_change_purpose(circuit_t *circ, uint8_t new_purpose)
 
   if (circ->purpose == new_purpose) return;
 
+  /* Take specific actions if we are repurposing a hidden service circuit. */
+  if (circuit_purpose_is_hidden_service(circ->purpose) &&
+      !circuit_purpose_is_hidden_service(new_purpose)) {
+    hs_circ_repurpose(circ);
+  }
+
   if (CIRCUIT_IS_ORIGIN(circ)) {
     char old_purpose_desc[80] = "";
 

--- a/src/feature/hs/hs_circuit.h
+++ b/src/feature/hs/hs_circuit.h
@@ -16,6 +16,7 @@
 
 /* Cleanup function when the circuit is closed or/and freed. */
 void hs_circ_cleanup(circuit_t *circ);
+void hs_circ_repurpose(circuit_t *circ);
 
 /* Circuit API. */
 int hs_circ_service_intro_has_opened(hs_service_t *service,

--- a/src/feature/rend/rendcommon.c
+++ b/src/feature/rend/rendcommon.c
@@ -1045,3 +1045,14 @@ rend_circuit_pk_digest_eq(const origin_circuit_t *ocirc,
  match:
   return 1;
 }
+
+/* Cleanup the given circuit of all HS v2 data structure. */
+void
+rend_circ_cleanup(origin_circuit_t *circ)
+{
+  tor_assert(circ);
+
+  /* Both fields are set to NULL with these. */
+  crypto_pk_free(circ->intro_key);
+  rend_data_free(circ->rend_data);
+}

--- a/src/feature/rend/rendcommon.h
+++ b/src/feature/rend/rendcommon.h
@@ -71,6 +71,8 @@ int rend_non_anonymous_mode_enabled(const or_options_t *options);
 void assert_circ_anonymity_ok(const origin_circuit_t *circ,
                               const or_options_t *options);
 
+void rend_circ_cleanup(origin_circuit_t *circ);
+
 #ifdef RENDCOMMON_PRIVATE
 
 STATIC int


### PR DESCRIPTION
When we repurpose a hidden service circuit, we need to clean up from the HS
circuit map and any HS related data structured contained in the circuit.

This commit adds an helper function that does it when repurposing a hidden
service circuit.

Fixes #29034

Signed-off-by: David Goulet <dgoulet@torproject.org>