### PR TITLE
Remove want_cmddata from HSFETCH, which does not in fact want data

### DIFF
--- a/changes/bug30646
+++ b/changes/bug30646
@@ -1,0 +1,4 @@
+  o Minor bugfixes (controller):
+    - Repair the HSFETCH command so that it works again. Previously, it
+      expected a body when it shouldn't have. Fixes bug 30646; bugfix on
+      0.4.1.1-alpha.

--- a/src/feature/control/control_cmd.c
+++ b/src/feature/control/control_cmd.c
@@ -1385,7 +1385,6 @@ static const control_cmd_syntax_t hsfetch_syntax = {
   .min_args = 1, .max_args = 1,
   .accept_keywords = true,
   .allowed_keywords = hsfetch_keywords,
-  .want_cmddata = true,
 };
 
 /** Implementation for the HSFETCH command. */


### PR DESCRIPTION
This looks a copy-and-paste error to me.  Fixes bug 30646; bugfix on
0.4.1.1-alpha.