### PR TITLE
Make get_proxy_type() connection-specific

### DIFF
--- a/changes/bug29670
+++ b/changes/bug29670
@@ -1,0 +1,4 @@
+  o Minor bugfixes (configuration, proxies):
+    - Fix a bug that prevented us from supporting SOCKS5 proxies that want
+      authentication along with configued (but unused!)
+      ClientTransportPlugins. Fixes bug 29670; bugfix on 0.2.6.1-alpha.


### PR DESCRIPTION
Previously, we were looking at our global settings to see what kind
of proxy we had.  But doing this would sometimes give us the wrong
results when we had ClientTransportPlugin configured but we weren't
using it for a particular connection.  In several places in the
code, we had added checks to see if we were _really_ using a PT or
whether we were using a socks proxy, but we had forgotten to do so
in at least once case.  Instead, since every time we call this
function we are asking about a single connection, it is probably
best just to make this function connection-specific.

Fixes bug 29670; bugfix on 0.2.6.2-alpha.