### PR TITLE
Shutdown libevent _after_ the subsystems.

### DIFF
--- a/changes/bug30629
+++ b/changes/bug30629
@@ -1,0 +1,6 @@
+  o Minor bugfixes (shutdown, libevent, memory safety):
+    - Avoid use-after-free bugs when shutting down, by making sure that we
+      shut down libevent only after shutting down all of its users. We
+      believe these are harmless in practice, since they only occur on the
+      shutdown path, and do not involve any attacker-controlled data. Fixes
+      bug 30629; bugfix on 0.4.1.1-alpha.

--- a/src/app/main/shutdown.c
+++ b/src/app/main/shutdown.c
@@ -157,9 +157,10 @@ tor_free_all(int postfork)
   if (!postfork) {
     release_lockfile();
   }
-  tor_libevent_free_all();
 
   subsystems_shutdown();
+
+  tor_libevent_free_all();
 
   /* Stuff in util.c and address.c*/
   if (!postfork) {


### PR DESCRIPTION
This is necessary since shutting down libevent frees some pointer
that the subsystems want to free themselves. A longer term solution
will be to turn the evloop module into a subsystem itself, but for
now it is best to do the minimal fix.

Fixes bug 30629; bugfix on 0.4.1.1-alpha.