### PR TITLE
sendme: Do not decrement window in a log_debug()

### DIFF
--- a/changes/ticket30628
+++ b/changes/ticket30628
@@ -1,0 +1,5 @@
+  o Major bugfixes (Flow Control, SENDME):
+    - The decrement of the stream-level package window was done in a log_debug()
+      statement meaning that if the debug logs were not enabled, the decrement
+      would never happen and thus the window would be out of sync with the other
+      end point. Fixes bug 30628; bugfix on 0.4.1.1-alpha.

--- a/src/core/or/sendme.c
+++ b/src/core/or/sendme.c
@@ -619,7 +619,9 @@ int
 sendme_note_stream_data_packaged(edge_connection_t *conn)
 {
   tor_assert(conn);
-  log_debug(LD_APP, "Stream package_window now %d.", --conn->package_window);
+
+  --conn->package_window;
+  log_debug(LD_APP, "Stream package_window now %d.", conn->package_window);
   return conn->package_window;
 }
 


### PR DESCRIPTION
If "Log debug ..." is not set, the decrement never happens. This lead to the
package/deliver window to be out of sync at the stream level and thus breaking
the connection after 50+ cells.

Fixes #30628

Signed-off-by: David Goulet <dgoulet@torproject.org>