### PR TITLE
Bug 29034: Cleanup hs circuitmap when purpose changes.

### DIFF
--- a/changes/bug29034
+++ b/changes/bug29034
@@ -1,0 +1,5 @@
+  o Major bugfixes (Onion service reachability):
+    - Properly clean up the introduction point map when circuits change purpose
+      from onion service circuits to pathbias, measurement, or other circuit types.
+      This should fix some service-side instances of introduction point failure.
+      Fixes bug 29034; bugfix on 0.3.2.1-alpha.

--- a/src/core/or/circuituse.c
+++ b/src/core/or/circuituse.c
@@ -3066,6 +3066,12 @@ circuit_change_purpose(circuit_t *circ, uint8_t new_purpose)
               circ->purpose,
               circuit_purpose_to_string(new_purpose),
               new_purpose);
+
+    /* Take specific actions if we are repurposing a hidden service circuit. */
+    if (circuit_purpose_is_hidden_service(circ->purpose) &&
+        !circuit_purpose_is_hidden_service(new_purpose)) {
+      hs_circ_cleanup(circ);
+    }
   }
 
   old_purpose = circ->purpose;


### PR DESCRIPTION
Leave the other rend and hs_ident data around until circuit free, since code
may still try to inspect it after marking the circuit for close. The
circuitmap is the important thing to clean up, since repurposed
intropoints must be removed from this map to ensure validity.