### PR TITLE
dirparse: Stop crashing when parsing unknown descriptor purpose annot…

### DIFF
--- a/changes/bug30781
+++ b/changes/bug30781
@@ -1,0 +1,4 @@
+  o Minor bugfixes (directory authorities):
+    - Stop crashing after parsing an unknown descriptor purpose annotation.
+      We think this bug can only be triggered by modifying a local file.
+      Fixes bug 30781; bugfix on 0.2.0.8-alpha.

--- a/src/or/routerparse.c
+++ b/src/or/routerparse.c
@@ -1921,6 +1921,9 @@ router_parse_entry_from_string(const char *s, const char *end,
   if ((tok = find_opt_by_keyword(tokens, A_PURPOSE))) {
     tor_assert(tok->n_args);
     router->purpose = router_purpose_from_string(tok->args[0]);
+    if (router->purpose == ROUTER_PURPOSE_UNKNOWN) {
+      goto err;
+    }
   } else {
     router->purpose = ROUTER_PURPOSE_GENERAL;
   }


### PR DESCRIPTION
…ations

We think this bug can only be triggered by modifying a local file.

Fixes bug 30781; bugfix on 0.2.0.8-alpha.