### PR TITLE
30784: Windows put its timeval definitions in winsock2.h.

### DIFF
--- a/src/lib/thread/compat_winthreads.c
+++ b/src/lib/thread/compat_winthreads.c
@@ -12,6 +12,7 @@
 
 #ifdef _WIN32
 
+#include <winsock2.h>
 #include <windows.h>
 #include <process.h>
 #include "lib/thread/threads.h"


### PR DESCRIPTION
In compat_winthreads.c, tor_cond_wait takes and uses an argument of type struct timeval without including winsock2.h (which is where timeval comes from, per the below documentation URL). This might work by accident with the particular toolchain normally used by the Tor project, but with MinGW this currently is causing the below compiler error.

https://docs.microsoft.com/en-us/windows/desktop/api/winsock/ns-winsock-timeval

```
tor/src/lib/thread/compat_winthreads.c:160:22: error: incomplete definition of type 'struct timeval'
    ms_orig = ms = tv->tv_sec*1000 + (tv->tv_usec+999)/1000;
                   ~~^
tor/src/lib/thread/threads.h:27:8: note: forward declaration of 'struct timeval'
struct timeval;
       ^
tor/src/lib/thread/compat_winthreads.c:160:41: error: incomplete definition of type 'struct timeval'
    ms_orig = ms = tv->tv_sec*1000 + (tv->tv_usec+999)/1000;
                                      ~~^
../.././vpn/tor/src/lib/thread/threads.h:27:8: note: forward declaration of 'struct timeval'
struct timeval;
       ^
2 errors generated.
```