### PR TITLE
Tolerate net-unreachable failures in util/socketpair_ersatz

### DIFF
--- a/changes/bug30804
+++ b/changes/bug30804
@@ -1,0 +1,4 @@
+  o Minor bugfixes (testing):
+    - Teach the util/socketpair_ersatz test to work correctly when we
+      have no network stack configured. Fixes bug 30804; bugfix on
+      0.2.5.1-alpha.

--- a/src/test/test_util.c
+++ b/src/test/test_util.c
@@ -5399,6 +5399,11 @@ test_util_socketpair(void *arg)
     tt_skip();
   }
 #endif /* defined(__FreeBSD__) */
+  if (ersatz && socketpair_result == -ENETUNREACH) {
+    /* We can also fail with -ENETUNREACH if we have no network stack at
+     * all. */
+    tt_skip();
+  }
   tt_int_op(0, OP_EQ, socketpair_result);
 
   tt_assert(SOCKET_OK(fds[0]));


### PR DESCRIPTION
This can happen when we have no network stack configured. Fixes bug
30804; bugfix on 0.2.5.1-alpha.