### PR TITLE
Make evloop into a subsystem.

### DIFF
--- a/changes/ticket30806
+++ b/changes/ticket30806
@@ -1,0 +1,3 @@
+  o Code simplification and refactoring:
+    - Use the subsystems mechanism to manage the main event loop code.
+      Closes ticket 30806.

--- a/src/app/main/main.c
+++ b/src/app/main/main.c
@@ -653,10 +653,6 @@ tor_init(int argc, char *argv[])
     return -1;
   }
 
-  if (tor_init_libevent_rng() < 0) {
-    log_warn(LD_NET, "Problem initializing libevent RNG.");
-  }
-
   /* Scan/clean unparseable descriptors; after reading config */
   routerparse_init();
 

--- a/src/app/main/shutdown.c
+++ b/src/app/main/shutdown.c
@@ -160,8 +160,6 @@ tor_free_all(int postfork)
 
   subsystems_shutdown();
 
-  tor_libevent_free_all();
-
   /* Stuff in util.c and address.c*/
   if (!postfork) {
     esc_router_info(NULL);

--- a/src/app/main/subsystem_list.c
+++ b/src/app/main/subsystem_list.c
@@ -25,6 +25,7 @@
 #include "lib/time/time_sys.h"
 #include "lib/tls/tortls_sys.h"
 #include "lib/wallclock/wallclock_sys.h"
+#include "lib/evloop/evloop_sys.h"
 
 #include "feature/dirauth/dirauth_sys.h"
 
@@ -49,6 +50,8 @@ const subsys_fns_t *tor_subsystems[] = {
   &sys_orconn_event, /* -33 */
   &sys_ocirc_event, /* -32 */
   &sys_btrack, /* -30 */
+
+  &sys_evloop, /* -20 */
 
   &sys_mainloop, /* 5 */
   &sys_or, /* 20 */

--- a/src/lib/evloop/.may_include
+++ b/src/lib/evloop/.may_include
@@ -8,6 +8,7 @@ lib/log/*.h
 lib/malloc/*.h
 lib/net/*.h
 lib/string/*.h
+lib/subsys/*.h
 lib/testsupport/*.h
 lib/thread/*.h
 lib/time/*.h

--- a/src/lib/evloop/evloop_sys.c
+++ b/src/lib/evloop/evloop_sys.c
@@ -1,0 +1,46 @@
+/* Copyright (c) 2001 Matej Pfajfar.
+ * Copyright (c) 2001-2004, Roger Dingledine.
+ * Copyright (c) 2004-2006, Roger Dingledine, Nick Mathewson.
+ * Copyright (c) 2007-2019, The Tor Project, Inc. */
+/* See LICENSE for licensing information */
+
+/**
+ * @file evloop_sys.c
+ * @brief Subsystem definition for the event loop module
+ **/
+
+#include "orconfig.h"
+#include "lib/subsys/subsys.h"
+#include "lib/evloop/compat_libevent.h"
+#include "lib/evloop/evloop_sys.h"
+
+static int
+subsys_evloop_initialize(void)
+{
+  if (tor_init_libevent_rng() < 0)
+    return -1;
+  return 0;
+}
+
+static void
+subsys_evloop_postfork(void)
+{
+#ifdef TOR_UNIT_TESTS
+  tor_libevent_postfork();
+#endif
+}
+
+static void
+subsys_evloop_shutdown(void)
+{
+  tor_libevent_free_all();
+}
+
+const struct subsys_fns_t sys_evloop = {
+  .name = "evloop",
+  .supported = true,
+  .level = -20,
+  .initialize = subsys_evloop_initialize,
+  .shutdown = subsys_evloop_shutdown,
+  .postfork = subsys_evloop_postfork,
+};

--- a/src/lib/evloop/evloop_sys.c
+++ b/src/lib/evloop/evloop_sys.c
@@ -13,12 +13,15 @@
 #include "lib/subsys/subsys.h"
 #include "lib/evloop/compat_libevent.h"
 #include "lib/evloop/evloop_sys.h"
+#include "lib/log/log.h"
 
 static int
 subsys_evloop_initialize(void)
 {
-  if (tor_init_libevent_rng() < 0)
+  if (tor_init_libevent_rng() < 0) {
+    log_warn(LD_NET, "Problem initializing libevent RNG.");
     return -1;
+  }
   return 0;
 }
 

--- a/src/lib/evloop/evloop_sys.h
+++ b/src/lib/evloop/evloop_sys.h
@@ -1,0 +1,17 @@
+/* Copyright (c) 2001 Matej Pfajfar.
+ * Copyright (c) 2001-2004, Roger Dingledine.
+ * Copyright (c) 2004-2006, Roger Dingledine, Nick Mathewson.
+ * Copyright (c) 2007-2019, The Tor Project, Inc. */
+/* See LICENSE for licensing information */
+
+/**
+ * @file evloop_sys.h
+ * @brief Declare subsystem object for the event loop module.
+ **/
+
+#ifndef TOR_LIB_EVLOOP_EVLOOP_SYS_H
+#define TOR_LIB_EVLOOP_EVLOOP_SYS_H
+
+extern const struct subsys_fns_t sys_evloop;
+
+#endif /* !defined(TOR_LIB_EVLOOP_EVLOOP_SYS_H) */

--- a/src/lib/evloop/include.am
+++ b/src/lib/evloop/include.am
@@ -8,6 +8,7 @@ endif
 # ADD_C_FILE: INSERT SOURCES HERE.
 src_lib_libtor_evloop_a_SOURCES =			\
 	src/lib/evloop/compat_libevent.c		\
+	src/lib/evloop/evloop_sys.c			\
 	src/lib/evloop/procmon.c			\
 	src/lib/evloop/timers.c				\
 	src/lib/evloop/token_bucket.c			\
@@ -21,6 +22,7 @@ src_lib_libtor_evloop_testing_a_CFLAGS = $(AM_CFLAGS) $(TEST_CFLAGS)
 # ADD_C_FILE: INSERT HEADERS HERE.
 noinst_HEADERS +=					\
 	src/lib/evloop/compat_libevent.h		\
+	src/lib/evloop/evloop_sys.h			\
 	src/lib/evloop/procmon.h			\
 	src/lib/evloop/timers.h				\
 	src/lib/evloop/token_bucket.h			\

--- a/src/test/test_channelpadding.c
+++ b/src/test/test_channelpadding.c
@@ -289,8 +289,6 @@ test_channelpadding_timers(void *arg)
   channel_t *chans[CHANNELS_TO_TEST];
   (void)arg;
 
-  tor_libevent_postfork();
-
   if (!connection_array)
     connection_array = smartlist_new();
 
@@ -393,7 +391,6 @@ test_channelpadding_killonehop(void *arg)
   channelpadding_decision_t decision;
   int64_t new_time;
   (void)arg;
-  tor_libevent_postfork();
 
   routerstatus_t *relay = tor_malloc_zero(sizeof(routerstatus_t));
   monotime_init();
@@ -501,8 +498,6 @@ test_channelpadding_consensus(void *arg)
   int64_t val;
   int64_t new_time;
   (void)arg;
-
-  tor_libevent_postfork();
 
   /*
    * Params tested:
@@ -897,8 +892,6 @@ test_channelpadding_decide_to_pad_channel(void *arg)
   if (!connection_array)
     connection_array = smartlist_new();
   (void)arg;
-
-  tor_libevent_postfork();
 
   monotime_init();
   monotime_enable_test_mocking();

--- a/src/test/test_compat_libevent.c
+++ b/src/test/test_compat_libevent.c
@@ -151,8 +151,6 @@ test_compat_libevent_postloop_events(void *arg)
   mainloop_event_t *a = NULL, *b = NULL;
   periodic_timer_t *timed = NULL;
 
-  tor_libevent_postfork();
-
   /* If postloop events don't work, then these events will activate one
    * another ad infinitum and, and the periodic event will never occur. */
   b = mainloop_event_postloop_new(activate_event_cb, &a);


### PR DESCRIPTION
Note that the event base object is _not_ created from the initialize
function, since it is configuration-dependent.  This will wait until
configuration is integrated into subsystems.

Closes ticket 30806.