### PR TITLE
Travis: Skip test_rebind on macOS builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -204,6 +204,8 @@ install:
   - if [[ "$TEST_STEM" != "" ]]; then pushd stem; python -c "from stem import stem; print(stem.__version__);"; git log -1; popd; fi
 
 script:
+  # Skip test_rebind on macOS
+  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then export TOR_SKIP_TEST_REBIND=true; fi
   - ./autogen.sh
   - CONFIGURE_FLAGS="$ASCIIDOC_OPTIONS $COVERAGE_OPTIONS $HARDENING_OPTIONS $MODULES_OPTIONS $NSS_OPTIONS $OPENSSL_OPTIONS $RUST_OPTIONS --enable-fatal-warnings --disable-silent-rules"
   - echo "Configure flags are $CONFIGURE_FLAGS"

--- a/changes/bug30713
+++ b/changes/bug30713
@@ -1,0 +1,5 @@
+  o Minor bugfixes (testing):
+    - Skip test_rebind when the TOR_SKIP_TEST_REBIND environmental variable is
+      set. Fixes bug 30713; bugfix on 0.3.5.1-alpha.
+    - Skip test_rebind on macOS in Travis, because it is unreliable on
+      macOS on Travis. Fixes bug 30713; bugfix on 0.3.5.1-alpha.

--- a/src/test/test_rebind.py
+++ b/src/test/test_rebind.py
@@ -16,6 +16,10 @@ def fail(msg):
     logging.error('FAIL')
     sys.exit(msg)
 
+def skip(msg):
+    logging.warning('SKIP: {}'.format(msg))
+    sys.exit(77)
+
 def try_connecting_to_socksport():
     socks_socket = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
     if socks_socket.connect_ex(('127.0.0.1', socks_port)):
@@ -64,6 +68,9 @@ if sys.hexversion < 0x02070000:
 
 if sys.hexversion > 0x03000000 and sys.hexversion < 0x03010000:
     fail("ERROR: unsupported Python3 version (should be >= 3.1)")
+
+if 'TOR_SKIP_TEST_REBIND' in os.environ:
+    skip('$TOR_SKIP_TEST_REBIND is set')
 
 control_port = pick_random_port()
 socks_port = pick_random_port()

--- a/src/test/test_rebind.sh
+++ b/src/test/test_rebind.sh
@@ -27,6 +27,6 @@ elif [ ! -d "$tmpdir" ]; then
   exit 3
 fi
 
-"${PYTHON:-python}" "${abs_top_srcdir:-.}/src/test/test_rebind.py" "${TESTING_TOR_BINARY}" "$tmpdir" || exitcode=1
+"${PYTHON:-python}" "${abs_top_srcdir:-.}/src/test/test_rebind.py" "${TESTING_TOR_BINARY}" "$tmpdir"
 
-exit ${exitcode}
+exit $?


### PR DESCRIPTION
Skip test_rebind when the TOR_SKIP_TEST_REBIND environmental variable
is set.

Skip test_rebind on macOS in Travis builds, because it is unreliable
on macOS on Travis.

Fixes bug 30713; bugfix on 0.3.5.1-alpha.