### PR TITLE
Travis: allow the test-stem job to fail

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -70,6 +70,10 @@ matrix:
   ## Careful! We use global envs, which makes it hard to exclude or
   ## allow failures by env:
   ## https://docs.travis-ci.com/user/customizing-the-build#matching-jobs-with-allow_failures
+  allow_failures:
+    ## test-stem sometimes hangs on Travis
+    - env: TEST_STEM="yes"
+
   exclude:
     ## Clang doesn't work in containerized builds, see below.
     - compiler: clang

--- a/changes/bug30744
+++ b/changes/bug30744
@@ -1,0 +1,3 @@
+  o Minor bugfixes (continuous integration):
+    - Allow the test-stem job to fail in Travis, because it sometimes hangs.
+      Fixes bug 30744; bugfix on 0.3.5.4-alpha.


### PR DESCRIPTION
Allow the test-stem job to fail in Travis, because it sometimes hangs.

Fixes bug 30744; bugfix on 0.3.5.4-alpha.