### PR TITLE
Fix memleak when failing to parse a CSV_INTERVAL.

### DIFF
--- a/changes/bug30894
+++ b/changes/bug30894
@@ -1,0 +1,4 @@
+  o Minor bugfixes (memory leaks):
+    - Fix a trivial memory leak when parsing an invalid value
+      from a download schedule in the configuration. Fixes bug
+      30894; bugfix on 0.3.4.1-alpha.

--- a/src/app/config/confparse.c
+++ b/src/app/config/confparse.c
@@ -225,6 +225,7 @@ config_assign_value(const config_format_t *fmt, void *options,
       tor_asprintf(msg,
           "Interval '%s %s' is malformed or out of bounds.",
           c->key, c->value);
+      tor_free(tmp);
       return -1;
     }
     *(int *)lvalue = i;


### PR DESCRIPTION
Fixes bug 30894; bugfix on 0.3.4.1-alpha