### PR TITLE
#30950: Fix shellcheck warning SC2034 in test_rebind.sh.

### DIFF
--- a/src/test/test_rebind.sh
+++ b/src/test/test_rebind.sh
@@ -12,8 +12,6 @@ if test "$UNAME_OS" = 'CYGWIN' || \
   fi
 fi
 
-exitcode=0
-
 tmpdir=
 clean () {
   if [ -n "$tmpdir" ] && [ -d "$tmpdir" ]; then


### PR DESCRIPTION
Bugfix on be0a4be276c945e4e90b43ce8f784b5b75bef122 (not in any Tor release).

https://trac.torproject.org/projects/tor/ticket/30950