### PR TITLE
stats: Always publish pluggable transports in extra info documents

### DIFF
--- a/changes/bug30956
+++ b/changes/bug30956
@@ -1,0 +1,4 @@
+  o Minor bugfixes (pluggable transports):
+    - Always publish bridge pluggable transport information in the extra info
+      descriptor, even if ExtraInfoStatistics is 0. This information is
+      needed by BridgeDB. Fixes bug 30956; bugfix on 0.4.1.1-alpha.

--- a/doc/tor.1.txt
+++ b/doc/tor.1.txt
@@ -2451,8 +2451,10 @@ is non-zero):
 [[ExtraInfoStatistics]] **ExtraInfoStatistics** **0**|**1**::
     When this option is enabled, Tor includes previously gathered statistics in
     its extra-info documents that it uploads to the directory authorities.
-    Disabling this option also disables bandwidth usage statistics, GeoIPFile
-    hashes, and ServerTransportPlugin lists in the extra-info file.
+    Disabling this option also removes bandwidth usage statistics, and
+    GeoIPFile and GeoIPv6File hashes from the extra-info file. Bridge
+    ServerTransportPlugin lines are always includes in the extra-info file,
+    because they are required by BridgeDB.
     (Default: 1)
 
 [[ExtendAllowPrivateAddresses]] **ExtendAllowPrivateAddresses** **0**|**1**::


### PR DESCRIPTION
Always publish bridge pluggable transport information in the extra info
descriptor, even if ExtraInfoStatistics is 0. This information is
needed by BridgeDB.

Fixes bug 30956; bugfix on 0.4.1.1-alpha.