### PR TITLE
Remove the unused "exitcode" variable from test_rebind.sh

### DIFF
--- a/src/test/test_rebind.sh
+++ b/src/test/test_rebind.sh
@@ -12,8 +12,6 @@ if test "$UNAME_OS" = 'CYGWIN' || \
   fi
 fi
 
-exitcode=0
-
 tmpdir=
 clean () {
   if [ -n "$tmpdir" ] && [ -d "$tmpdir" ]; then


### PR DESCRIPTION
Fixes a shellcheck issue; closes ticket 30964.  No user-visible
change.