### PR TITLE
[Tor Trac #25568]: Disallow duplicate v2 and v3 onion service intro point descriptors

### DIFF
--- a/changes/bug25568
+++ b/changes/bug25568
@@ -1,0 +1,7 @@
+  o Minor bugfixes (onion services):
+    - When a client receives an intro point descriptor, reject duplicate
+      entries when we are processing the descriptor. This prevents clients
+      from re-trying intro points which have failed, and affects both
+      version 2 and version 3 onion services. Previously, we re-try
+      duplicate entries even if they have failed Fixes bug 25568;
+      bugfix on 0.1.0.1-rc. Patch by Neel Chauhan.

--- a/changes/bug25568
+++ b/changes/bug25568
@@ -3,5 +3,5 @@
       entries when we are processing the descriptor. This prevents clients
       from re-trying intro points which have failed, and affects both
       version 2 and version 3 onion services. Previously, we re-try
-      duplicate entries even if they have failed Fixes bug 25568;
+      duplicate entries even if they have failed. Fixes bug 25568;
       bugfix on 0.1.0.1-rc. Patch by Neel Chauhan.

--- a/scripts/maint/practracker/exceptions.txt
+++ b/scripts/maint/practracker/exceptions.txt
@@ -202,7 +202,7 @@ problem function-size /src/feature/hs/hs_descriptor.c:desc_encode_v3() 104
 problem function-size /src/feature/hs/hs_descriptor.c:decrypt_desc_layer() 110
 problem function-size /src/feature/hs/hs_descriptor.c:decode_introduction_point() 122
 problem function-size /src/feature/hs/hs_descriptor.c:desc_decode_superencrypted_v3() 109
-problem function-size /src/feature/hs/hs_descriptor.c:desc_decode_encrypted_v3() 109
+problem function-size /src/feature/hs/hs_descriptor.c:desc_decode_encrypted_v3() 114
 problem file-size /src/feature/hs/hs_service.c 4109
 problem function-size /src/feature/keymgt/loadkey.c:ed_key_init_from_file() 333
 problem function-size /src/feature/nodelist/authcert.c:trusted_dirs_load_certs_from_string() 124

--- a/scripts/maint/practracker/exceptions.txt
+++ b/scripts/maint/practracker/exceptions.txt
@@ -238,7 +238,7 @@ problem function-size /src/feature/rend/rendcommon.c:rend_encode_v2_descriptors(
 problem function-size /src/feature/rend/rendmid.c:rend_mid_establish_intro_legacy() 104
 problem function-size /src/feature/rend/rendparse.c:rend_parse_v2_service_descriptor() 187
 problem function-size /src/feature/rend/rendparse.c:rend_decrypt_introduction_points() 104
-problem function-size /src/feature/rend/rendparse.c:rend_parse_introduction_points() 131
+problem function-size /src/feature/rend/rendparse.c:rend_parse_introduction_points() 145
 problem file-size /src/feature/rend/rendservice.c 4511
 problem function-size /src/feature/rend/rendservice.c:rend_service_prune_list_impl_() 107
 problem function-size /src/feature/rend/rendservice.c:rend_config_service() 164

--- a/src/feature/hs/hs_descriptor.c
+++ b/src/feature/hs/hs_descriptor.c
@@ -1949,6 +1949,11 @@ decode_intro_points(const hs_descriptor_t *desc,
         continue;
       }
 
+      /* Strip last newline */
+      if (chunk[strlen(chunk) - 1] == '\n') {
+        chunk[strlen(chunk) - 1] = '\0';
+      }
+
       smartlist_add_asprintf(intro_points, "%s %s", str_intro_point, chunk);
     } SMARTLIST_FOREACH_END(chunk);
   }
@@ -2688,6 +2693,7 @@ hs_desc_encode_descriptor,(const hs_descriptor_t *desc,
     ret = hs_desc_decode_descriptor(*encoded_out, desc->subcredential,
                                     NULL, NULL);
     if (BUG(ret < 0)) {
+      tor_free(*encoded_out);
       goto err;
     }
   }

--- a/src/test/hs_test_helpers.h
+++ b/src/test/hs_test_helpers.h
@@ -15,6 +15,8 @@ hs_descriptor_t *hs_helper_build_hs_desc_no_ip(
                                  const ed25519_keypair_t *signing_kp);
 hs_descriptor_t *hs_helper_build_hs_desc_with_ip(
                                  const ed25519_keypair_t *signing_kp);
+hs_descriptor_t *hs_helper_build_hs_desc_with_dup_ip(
+                                 const ed25519_keypair_t *signing_kp);
 void hs_helper_desc_equal(const hs_descriptor_t *desc1,
                           const hs_descriptor_t *desc2);
 void

--- a/src/test/test.c
+++ b/src/test/test.c
@@ -639,6 +639,90 @@ test_rend_fns(void *arg)
   tor_free(intro_points_encrypted);
 }
 
+/** Test parsing of duplicate rendezvous service descriptors. */
+static void
+test_rend_dup(void *arg)
+{
+  rend_service_descriptor_t *generated = NULL, *parsed = NULL;
+  char service_id[DIGEST_LEN];
+  char service_id_base32[REND_SERVICE_ID_LEN_BASE32+1];
+  const char *next_desc;
+  smartlist_t *descs = smartlist_new();
+  char computed_desc_id[DIGEST_LEN];
+  char parsed_desc_id[DIGEST_LEN];
+  crypto_pk_t *pk1 = NULL, *pk2 = NULL;
+  time_t now;
+  char *intro_points_encrypted = NULL;
+  size_t intro_points_size;
+  size_t encoded_size;
+  int i;
+
+  (void)arg;
+
+  /* Initialize the service cache. */
+  rend_cache_init();
+
+  pk1 = pk_generate(0);
+  pk2 = pk_generate(1);
+  generated = tor_malloc_zero(sizeof(rend_service_descriptor_t));
+  generated->pk = crypto_pk_dup_key(pk1);
+  crypto_pk_get_digest(generated->pk, service_id);
+  base32_encode(service_id_base32, REND_SERVICE_ID_LEN_BASE32+1,
+                service_id, REND_SERVICE_ID_LEN);
+  now = time(NULL);
+  generated->timestamp = now;
+  generated->version = 2;
+  generated->protocols = 42;
+  generated->intro_nodes = smartlist_new();
+
+  crypto_pk_t *okey = pk_generate(2);
+
+  for (i = 0; i < 3; i++) {
+    rend_intro_point_t *intro = tor_malloc_zero(sizeof(rend_intro_point_t));
+    intro->extend_info = tor_malloc_zero(sizeof(extend_info_t));
+    intro->extend_info->onion_key = crypto_pk_dup_key(okey);
+    crypto_pk_get_digest(intro->extend_info->onion_key,
+                         intro->extend_info->identity_digest);
+    intro->extend_info->nickname[0] = '$';
+    base16_encode(intro->extend_info->nickname + 1,
+                  sizeof(intro->extend_info->nickname) - 1,
+                  intro->extend_info->identity_digest, DIGEST_LEN);
+
+    /* Use a fixed IP and port */
+    tor_addr_from_ipv4h(&intro->extend_info->addr, 0x60F6C5F7);
+    intro->extend_info->port = 9001;
+    intro->intro_key = crypto_pk_dup_key(pk2);
+
+    smartlist_add(generated->intro_nodes, intro);
+  }
+
+  crypto_pk_free(okey);
+
+  rend_encode_v2_descriptors(descs, generated, now, 0,
+                             REND_NO_AUTH, NULL, NULL);
+  rend_compute_v2_desc_id(computed_desc_id, service_id_base32, NULL, now, 0);
+  rend_parse_v2_service_descriptor(&parsed, parsed_desc_id,
+               &intro_points_encrypted, &intro_points_size, &encoded_size,
+               &next_desc,
+          ((rend_encoded_v2_service_descriptor_t *)smartlist_get(descs, 0))
+                                        ->desc_str, 1);
+  tt_int_op(rend_parse_introduction_points(parsed, intro_points_encrypted,
+                                         intro_points_size),OP_EQ, -1);
+
+  rend_service_descriptor_free(parsed);
+
+ done:
+  for (i = 0; i < smartlist_len(descs); i++)
+    rend_encoded_v2_service_descriptor_free_(smartlist_get(descs, i));
+  smartlist_free(descs);
+
+  rend_service_descriptor_free(parsed);
+  rend_service_descriptor_free(generated);
+  crypto_pk_free(pk1);
+  crypto_pk_free(pk2);
+  tor_free(intro_points_encrypted);
+}
+
 /** Run unit tests for stats code. */
 static void
 test_stats(void *arg)
@@ -812,6 +896,7 @@ static struct testcase_t test_array[] = {
   { "fast_handshake", test_fast_handshake, 0, NULL, NULL },
   FORK(circuit_timeout),
   FORK(rend_fns),
+  FORK(rend_dup),
   FORK(stats),
 
   END_OF_TESTCASES

--- a/src/test/test_hs_descriptor.c
+++ b/src/test/test_hs_descriptor.c
@@ -576,6 +576,34 @@ test_decode_bad_signature(void *arg)
 }
 
 static void
+test_decode_duplicate_intro(void *arg)
+{
+  int ret;
+  char *encoded = NULL;
+  ed25519_keypair_t signing_kp;
+  hs_descriptor_t *desc = NULL;
+  uint8_t subcredential[DIGEST256_LEN];
+
+  (void) arg;
+
+  ret = ed25519_keypair_generate(&signing_kp, 0);
+  tt_int_op(ret, OP_EQ, 0);
+  desc = hs_helper_build_hs_desc_with_dup_ip(&signing_kp);
+
+  hs_helper_get_subcred_from_identity_keypair(&signing_kp,
+                                              subcredential);
+
+  /* We just need this as it attempts hs_desc_decode_descriptor() */
+  tor_capture_bugs_(1);
+  ret = hs_desc_encode_descriptor(desc, &signing_kp, NULL, &encoded);
+  tt_int_op(ret, OP_EQ, -1);
+
+ done:
+  hs_descriptor_free(desc);
+  tor_free(encoded);
+}
+
+static void
 test_decode_plaintext(void *arg)
 {
   int ret;
@@ -831,6 +859,8 @@ struct testcase_t hs_descriptor[] = {
   { "decode_plaintext", test_decode_plaintext, TT_FORK,
     NULL, NULL },
   { "decode_bad_signature", test_decode_bad_signature, TT_FORK,
+    NULL, NULL },
+  { "decode_duplicate_intro", test_decode_duplicate_intro, TT_FORK,
     NULL, NULL },
 
   /* Misc. */


### PR DESCRIPTION
For the bug [here](https://trac.torproject.org/projects/tor/ticket/25568).