### PR TITLE
begin_cell_parse(): Add an assertion to please coverity.

### DIFF
--- a/changes/ticket31026
+++ b/changes/ticket31026
@@ -1,0 +1,5 @@
+  o Minor bugfixes (coverity compliance):
+    - Add an assertion when parsing a BEGIN cell so that coverity can be sure
+      that we are not about to dereference a NULL address.
+      Fixes bug 31026; bugfix on 0.2.4.7-alpha.  This is CID
+      1447296.

--- a/scripts/maint/practracker/exceptions.txt
+++ b/scripts/maint/practracker/exceptions.txt
@@ -101,7 +101,7 @@ problem function-size /src/core/or/circuituse.c:circuit_get_open_circ_or_launch(
 problem function-size /src/core/or/circuituse.c:connection_ap_handshake_attach_circuit() 244
 problem function-size /src/core/or/command.c:command_process_create_cell() 156
 problem function-size /src/core/or/command.c:command_process_relay_cell() 132
-problem file-size /src/core/or/connection_edge.c 4595
+problem file-size /src/core/or/connection_edge.c 4596
 problem include-count /src/core/or/connection_edge.c 65
 problem function-size /src/core/or/connection_edge.c:connection_ap_expire_beginning() 117
 problem function-size /src/core/or/connection_edge.c:connection_ap_handshake_rewrite() 192
@@ -109,7 +109,7 @@ problem function-size /src/core/or/connection_edge.c:connection_ap_handle_onion(
 problem function-size /src/core/or/connection_edge.c:connection_ap_handshake_rewrite_and_attach() 423
 problem function-size /src/core/or/connection_edge.c:connection_ap_handshake_send_begin() 111
 problem function-size /src/core/or/connection_edge.c:connection_ap_handshake_socks_resolved() 106
-problem function-size /src/core/or/connection_edge.c:connection_exit_begin_conn() 184
+problem function-size /src/core/or/connection_edge.c:connection_exit_begin_conn() 185
 problem function-size /src/core/or/connection_edge.c:connection_exit_connect() 102
 problem file-size /src/core/or/connection_or.c 3124
 problem include-count /src/core/or/connection_or.c 51

--- a/src/core/or/connection_edge.c
+++ b/src/core/or/connection_edge.c
@@ -3833,6 +3833,7 @@ connection_exit_begin_conn(cell_t *cell, circuit_t *circ)
 
   if (! bcell.is_begindir) {
     /* Steal reference */
+    tor_assert(bcell.address);
     address = bcell.address;
     port = bcell.port;
 


### PR DESCRIPTION
Coverity doesn't understand that if begin_cell_parse() returns 0 and
sets is_begindir to 0, its address field will always be set.

Fixes bug 30126; bugfix on 0.2.4.7-alpha; Fixes CID 1447296.