### PR TITLE
Coverity: different implementation for csiphash

### DIFF
--- a/changes/ticket31025
+++ b/changes/ticket31025
@@ -1,0 +1,5 @@
+  o Minor bugfixes (coverity):
+    - In our siphash implementation, when building for coverity, use memcpy
+      in place of a switch statement, so that coverity can tell we are not
+      accessing out-of-bounds memory. Fixes bug 31025; bugfix on
+      0.2.8.1-alpha.  This is tracked as CID 1447293 and 1447295.

--- a/src/ext/csiphash.c
+++ b/src/ext/csiphash.c
@@ -87,6 +87,13 @@ uint64_t siphash24(const void *src, unsigned long src_sz, const struct sipkey *k
 		v0 ^= mi;
 	}
 
+#ifdef __COVERITY__
+	{
+		uint64_t mi = 0;
+		memcpy(&mi, m+i, (src_sz-blocks));
+		last7 = _le64toh(mi) | (uint64_t)(src_sz & 0xff) << 56;
+	}
+#else
 	switch (src_sz - blocks) {
 		case 7: last7 |= (uint64_t)m[i + 6] << 48; /* Falls through. */
 		case 6: last7 |= (uint64_t)m[i + 5] << 40; /* Falls through. */
@@ -98,6 +105,7 @@ uint64_t siphash24(const void *src, unsigned long src_sz, const struct sipkey *k
 		case 0:
 		default:;
 	}
+#endif
 	v3 ^= last7;
 	DOUBLE_ROUND(v0,v1,v2,v3);
 	v0 ^= last7;


### PR DESCRIPTION
Coverity has had trouble figuring out our csiphash implementation,
and has given spurious warnings about its behavior.

This patch changes the csiphash implementation when coverity is in
use, so that coverity can figure out that we are not about to read
beyond the provided input.

Closes ticket 31025.