### PR TITLE
[Tor Trac #25568]: hs: Lookup failure cache when introducing to an intro point

### DIFF
--- a/changes/bug25568
+++ b/changes/bug25568
@@ -1,0 +1,4 @@
+  o Minor bugfixes (onion services):
+    - When connecting to an intro point that has been specified multiple times
+      in a descriptor, do not connect to ones which are marked as "failed".
+      Fixes bug 25568; bugfix on 0.1.0.1-rc. Patch by Neel Chauhan.

--- a/scripts/maint/practracker/exceptions.txt
+++ b/scripts/maint/practracker/exceptions.txt
@@ -233,7 +233,7 @@ problem function-size /src/feature/relay/router.c:router_build_fresh_unsigned_ro
 problem function-size /src/feature/relay/router.c:router_dump_router_to_string() 371
 problem function-size /src/feature/relay/routerkeys.c:load_ed_keys() 294
 problem function-size /src/feature/rend/rendcache.c:rend_cache_store_v2_desc_as_client() 193
-problem function-size /src/feature/rend/rendclient.c:rend_client_send_introduction() 220
+problem function-size /src/feature/rend/rendclient.c:rend_client_send_introduction() 230
 problem function-size /src/feature/rend/rendcommon.c:rend_encode_v2_descriptors() 225
 problem function-size /src/feature/rend/rendmid.c:rend_mid_establish_intro_legacy() 104
 problem function-size /src/feature/rend/rendparse.c:rend_parse_v2_service_descriptor() 187

--- a/scripts/maint/practracker/exceptions.txt
+++ b/scripts/maint/practracker/exceptions.txt
@@ -194,7 +194,7 @@ problem function-size /src/feature/dirparse/routerparse.c:extrainfo_parse_entry_
 problem function-size /src/feature/hibernate/hibernate.c:accounting_parse_options() 109
 problem function-size /src/feature/hs/hs_cell.c:hs_cell_build_establish_intro() 115
 problem function-size /src/feature/hs/hs_cell.c:hs_cell_parse_introduce2() 154
-problem function-size /src/feature/hs/hs_client.c:send_introduce1() 104
+problem function-size /src/feature/hs/hs_client.c:send_introduce1() 112
 problem function-size /src/feature/hs/hs_client.c:hs_config_client_authorization() 108
 problem function-size /src/feature/hs/hs_common.c:hs_get_responsible_hsdirs() 104
 problem function-size /src/feature/hs/hs_config.c:config_generic_service() 140

--- a/src/feature/rend/rendcache.c
+++ b/src/feature/rend/rendcache.c
@@ -361,6 +361,19 @@ cache_failure_intro_lookup(const uint8_t *identity, const char *service_id,
   return 0;
 }
 
+/** CHeck if we have a failure for a relay with the identity digest
+ * <b>identity</b> which has DIGEST_LEN bytes and service ID <b>service_id</b>
+ * which is a null-terminated string. If found, return 1, else return 0. */
+int
+rend_cache_v2_intro_has_failure(const uint8_t *identity,
+                                const char *service_id)
+{
+  rend_cache_failure_intro_t *intro_entry;
+  int ret = cache_failure_intro_lookup(identity, service_id, &intro_entry);
+
+  return ret;
+}
+
 /** Allocate a new cache failure intro object and copy the content from
  * <b>entry</b> to this newly allocated object. Return it. */
 static rend_cache_failure_intro_t *

--- a/src/feature/rend/rendcache.h
+++ b/src/feature/rend/rendcache.h
@@ -71,6 +71,8 @@ int rend_cache_lookup_entry(const char *query, int version,
 int rend_cache_lookup_v2_desc_as_service(const char *query,
                                          rend_cache_entry_t **entry_out);
 int rend_cache_lookup_v2_desc_as_dir(const char *query, const char **desc);
+int rend_cache_v2_intro_has_failure(const uint8_t *identity,
+                                    const char *service_id);
 
 int rend_cache_store_v2_desc_as_dir(const char *desc);
 int rend_cache_store_v2_desc_as_service(const char *desc);


### PR DESCRIPTION
For the ticket [here](https://trac.torproject.org/projects/tor/ticket/25568).