### PR TITLE
#5304: Support for OutboundBindAddressPT

### DIFF
--- a/changes/bug5304
+++ b/changes/bug5304
@@ -1,0 +1,6 @@
+  o Minor features (pluggable transports):
+    - Added option OutboundBindAddressPT to torrc. This option allows users to
+      specify which IPv4 and IPv6 address they want pluggable transports to use
+      for outgoing IP packets. Tor does not have a way to enforce that the pluggable
+      transport honors this option so each pluggable transport will have to
+      implement support for this feature. Closes ticket 5304.

--- a/doc/tor.1.txt
+++ b/doc/tor.1.txt
@@ -735,6 +735,17 @@ GENERAL OPTIONS
     This setting will be ignored
     for connections to the loopback addresses (127.0.0.0/8 and ::1).
 
+[[OutboundBindAddressPT]] **OutboundBindAddressPT** __IP__::
+    Request that pluggable transports makes all outbound connections
+    originate from the IP address specified. Because outgoing connections
+    are handled by the pluggable transport itself, it is not possible for
+    Tor to enforce whether the pluggable transport honors this option. This
+    option overrides **OutboundBindAddress** for the same IP version. This
+    option may be used twice, once with an IPv4 address and once with an
+    IPv6 address. IPv6 addresses should be wrapped in square brackets. This
+    setting will be ignored for connections to the loopback addresses
+    (127.0.0.0/8 and ::1).
+
 [[PidFile]] **PidFile** __FILE__::
     On startup, write our PID to FILE. On clean shutdown, remove
     FILE. Can not be changed while tor is running.

--- a/scripts/maint/practracker/exceptions.txt
+++ b/scripts/maint/practracker/exceptions.txt
@@ -140,7 +140,7 @@ problem function-size /src/feature/client/entrynodes.c:entry_guards_upgrade_wait
 problem function-size /src/feature/client/entrynodes.c:entry_guard_parse_from_state() 246
 problem function-size /src/feature/client/transports.c:handle_proxy_line() 108
 problem function-size /src/feature/client/transports.c:parse_method_line_helper() 112
-problem function-size /src/feature/client/transports.c:create_managed_proxy_environment() 109
+problem function-size /src/feature/client/transports.c:create_managed_proxy_environment() 140
 problem function-size /src/feature/control/control.c:connection_control_process_inbuf() 136
 problem function-size /src/feature/control/control_auth.c:handle_control_authchallenge() 103
 problem function-size /src/feature/control/control_auth.c:handle_control_authenticate() 187

--- a/src/app/config/config.c
+++ b/src/app/config/config.c
@@ -549,6 +549,7 @@ static config_var_t option_vars_[] = {
   V(OutboundBindAddress,         LINELIST,   NULL),
   V(OutboundBindAddressOR,       LINELIST,   NULL),
   V(OutboundBindAddressExit,     LINELIST,   NULL),
+  V(OutboundBindAddressPT,       LINELIST,   NULL),
 
   OBSOLETE("PathBiasDisableRate"),
   V(PathBiasCircThreshold,       INT,      "-1"),
@@ -8323,7 +8324,8 @@ parse_outbound_address_lines(const config_line_t *lines, outbound_addr_t type,
                      "configured: %s",
                      family==AF_INET?" IPv4":(family==AF_INET6?" IPv6":""),
                      type==OUTBOUND_ADDR_OR?" OR":
-                     (type==OUTBOUND_ADDR_EXIT?" exit":""), lines->value);
+                     (type==OUTBOUND_ADDR_EXIT?" exit":
+                     (type==OUTBOUND_ADDR_PT?" PT":"")), lines->value);
       return -1;
     }
     lines = lines->next;
@@ -8360,6 +8362,12 @@ parse_outbound_addresses(or_options_t *options, int validate_only, char **msg)
   if (parse_outbound_address_lines(options->OutboundBindAddressExit,
                                    OUTBOUND_ADDR_EXIT, options, validate_only,
                                    msg)  < 0) {
+    goto err;
+  }
+
+  if (parse_outbound_address_lines(options->OutboundBindAddressPT,
+                                   OUTBOUND_ADDR_PT, options, validate_only,
+                                   msg) < 0) {
     goto err;
   }
 

--- a/src/app/config/config.c
+++ b/src/app/config/config.c
@@ -8348,7 +8348,7 @@ parse_outbound_addresses(or_options_t *options, int validate_only, char **msg)
   }
 
   if (parse_outbound_address_lines(options->OutboundBindAddress,
-                                   OUTBOUND_ADDR_EXIT_AND_OR, options,
+                                   OUTBOUND_ADDR_ANY, options,
                                    validate_only, msg) < 0) {
     goto err;
   }

--- a/src/app/config/config.c
+++ b/src/app/config/config.c
@@ -1899,6 +1899,15 @@ options_act(const or_options_t *old_options)
              "in a non-anonymous mode. It will provide NO ANONYMITY.");
   }
 
+  if (parse_outbound_addresses(options, 0, &msg) < 0) {
+    // LCOV_EXCL_START
+    log_warn(LD_BUG, "Failed parsing previously validated outbound "
+             "bind addresses: %s", msg);
+    tor_free(msg);
+    return -1;
+    // LCOV_EXCL_STOP
+  }
+
   /* If we are a bridge with a pluggable transport proxy but no
      Extended ORPort, inform the user that they are missing out. */
   if (server_mode(options) && options->ServerTransportPlugin &&
@@ -2109,15 +2118,6 @@ options_act(const or_options_t *old_options)
                      http_authenticator, strlen(http_authenticator),
                      DIGEST_SHA256);
     tor_free(http_authenticator);
-  }
-
-  if (parse_outbound_addresses(options, 0, &msg) < 0) {
-    // LCOV_EXCL_START
-    log_warn(LD_BUG, "Failed parsing previously validated outbound "
-             "bind addresses: %s", msg);
-    tor_free(msg);
-    return -1;
-    // LCOV_EXCL_STOP
   }
 
   config_maybe_load_geoip_files_(options, old_options);

--- a/src/app/config/or_options_st.h
+++ b/src/app/config/or_options_st.h
@@ -30,6 +30,10 @@ typedef enum {
    * `OutboundBindAddressOR` configuration entry in torrc. */
   OUTBOUND_ADDR_OR,
 
+  /** Outbound IP address for PT connections. Controlled by the
+   * `OutboundBindAddressPT` configuration entry in torrc. */
+  OUTBOUND_ADDR_PT,
+
   /** Outbound IP address for both Exit and OR connections. Controlled by the
    * OutboundBindAddress configuration entry in torrc. This value is used as
    * fallback if the more specific OUTBOUND_ADDR_EXIT and OUTBOUND_ADDR_OR is
@@ -127,6 +131,8 @@ struct or_options_t {
   struct config_line_t *OutboundBindAddressOR;
   /** Local address to bind outbound exit sockets */
   struct config_line_t *OutboundBindAddressExit;
+  /** Local address to bind outbound PT sockets */
+  struct config_line_t *OutboundBindAddressPT;
   /** Addresses derived from the various OutboundBindAddress lines.
    * [][0] is IPv4, [][1] is IPv6
    */

--- a/src/app/config/or_options_st.h
+++ b/src/app/config/or_options_st.h
@@ -21,9 +21,24 @@ struct config_line_t;
 
 /** Enumeration of outbound address configuration types:
  * Exit-only, OR-only, or both */
-typedef enum {OUTBOUND_ADDR_EXIT, OUTBOUND_ADDR_OR,
-              OUTBOUND_ADDR_EXIT_AND_OR,
-              OUTBOUND_ADDR_MAX} outbound_addr_t;
+typedef enum {
+  /** Outbound IP address for Exit connections. Controlled by the
+   * `OutboundBindAddressExit` configuration entry in torrc. */
+  OUTBOUND_ADDR_EXIT,
+
+  /** Outbound IP address for OR connections. Controlled by the
+   * `OutboundBindAddressOR` configuration entry in torrc. */
+  OUTBOUND_ADDR_OR,
+
+  /** Outbound IP address for both Exit and OR connections. Controlled by the
+   * OutboundBindAddress configuration entry in torrc. This value is used as
+   * fallback if the more specific OUTBOUND_ADDR_EXIT and OUTBOUND_ADDR_OR is
+   * unset. */
+  OUTBOUND_ADDR_EXIT_AND_OR,
+
+  /** Max value for this enum. Must be the last element in this enum. */
+  OUTBOUND_ADDR_MAX
+} outbound_addr_t;
 
 /** Configuration options for a Tor process. */
 struct or_options_t {

--- a/src/app/config/or_options_st.h
+++ b/src/app/config/or_options_st.h
@@ -20,7 +20,7 @@ struct smartlist_t;
 struct config_line_t;
 
 /** Enumeration of outbound address configuration types:
- * Exit-only, OR-only, or both */
+ * Exit-only, OR-only, PT-only, or any of them */
 typedef enum {
   /** Outbound IP address for Exit connections. Controlled by the
    * `OutboundBindAddressExit` configuration entry in torrc. */
@@ -34,11 +34,11 @@ typedef enum {
    * `OutboundBindAddressPT` configuration entry in torrc. */
   OUTBOUND_ADDR_PT,
 
-  /** Outbound IP address for both Exit and OR connections. Controlled by the
+  /** Outbound IP address for any outgoing connections. Controlled by the
    * OutboundBindAddress configuration entry in torrc. This value is used as
-   * fallback if the more specific OUTBOUND_ADDR_EXIT and OUTBOUND_ADDR_OR is
-   * unset. */
-  OUTBOUND_ADDR_EXIT_AND_OR,
+   * fallback if the more specific OUTBOUND_ADDR_EXIT, OUTBOUND_ADDR_OR, and
+   * OUTBOUND_ADDR_PT are unset. */
+  OUTBOUND_ADDR_ANY,
 
   /** Max value for this enum. Must be the last element in this enum. */
   OUTBOUND_ADDR_MAX

--- a/src/core/mainloop/connection.c
+++ b/src/core/mainloop/connection.c
@@ -2143,9 +2143,9 @@ conn_get_outbound_address(sa_family_t family,
       ext_addr = &options->OutboundBindAddresses[OUTBOUND_ADDR_EXIT]
                  [fam_index];
     } else if (!tor_addr_is_null(
-                 &options->OutboundBindAddresses[OUTBOUND_ADDR_EXIT_AND_OR]
+                 &options->OutboundBindAddresses[OUTBOUND_ADDR_ANY]
                  [fam_index])) {
-      ext_addr = &options->OutboundBindAddresses[OUTBOUND_ADDR_EXIT_AND_OR]
+      ext_addr = &options->OutboundBindAddresses[OUTBOUND_ADDR_ANY]
                  [fam_index];
     }
   } else { // All non-exit connections
@@ -2154,9 +2154,9 @@ conn_get_outbound_address(sa_family_t family,
       ext_addr = &options->OutboundBindAddresses[OUTBOUND_ADDR_OR]
                  [fam_index];
     } else if (!tor_addr_is_null(
-                 &options->OutboundBindAddresses[OUTBOUND_ADDR_EXIT_AND_OR]
+                 &options->OutboundBindAddresses[OUTBOUND_ADDR_ANY]
                  [fam_index])) {
-      ext_addr = &options->OutboundBindAddresses[OUTBOUND_ADDR_EXIT_AND_OR]
+      ext_addr = &options->OutboundBindAddresses[OUTBOUND_ADDR_ANY]
                  [fam_index];
     }
   }

--- a/src/feature/client/transports.h
+++ b/src/feature/client/transports.h
@@ -149,6 +149,8 @@ STATIC void managed_proxy_stderr_callback(process_t *, const char *, size_t);
 STATIC bool managed_proxy_exit_callback(process_t *, process_exit_code_t);
 
 STATIC int managed_proxy_severity_parse(const char *);
+STATIC const tor_addr_t *managed_proxy_outbound_address(const or_options_t *,
+                                                        sa_family_t);
 
 #endif /* defined(PT_PRIVATE) */
 


### PR DESCRIPTION
Add support for OutboundBindAddressPT in torrc and expose the value(s) to pluggable transports.