### PR TITLE
#31040: Early exit from post-merge git hook script when not merging to master

### DIFF
--- a/changes/bug31040
+++ b/changes/bug31040
@@ -1,0 +1,3 @@
+  o Minor bugfixes (developer tooling):
+    - Only log git script changes in post-merge script when merge was to the
+      master branch. Fixes bug 31040; bugfix on 0.4.1.1-alpha.

--- a/scripts/git/post-merge.git-hook
+++ b/scripts/git/post-merge.git-hook
@@ -35,6 +35,12 @@ check_for_script_update() {
         fi
 }
 
+cur_branch=$(git rev-parse --abbrev-ref HEAD)
+if [ "$cur_branch" != "master" ]; then
+  echo "post-merge: Not a master branch. Skipping."
+  exit 0
+fi
+
 check_for_diffs "pre-push"
 check_for_diffs "pre-commit"
 check_for_diffs "post-merge"


### PR DESCRIPTION
https://trac.torproject.org/projects/tor/ticket/31040