### PR TITLE
#31081: Respond with error message to GETCONF without arguments

### DIFF
--- a/changes/ticket31081
+++ b/changes/ticket31081
@@ -1,0 +1,3 @@
+  o Major features (controller protocol):
+    - Tor now responds with error message to GETCONF command without any
+      arguments. Resolves issue 31081.

--- a/src/feature/control/control_cmd.c
+++ b/src/feature/control/control_cmd.c
@@ -293,6 +293,12 @@ handle_control_getconf(control_connection_t *conn,
   const or_options_t *options = get_options();
   int i, len;
 
+  if (smartlist_len(questions) == 0) {
+    control_printf_endreply(conn, 552,
+                            "No configuration keys provided");
+    return 0;
+  }
+
   SMARTLIST_FOREACH_BEGIN(questions, const char *, q) {
     if (!option_is_recognized(q)) {
       smartlist_add(unrecognized, (char*) q);


### PR DESCRIPTION
https://trac.torproject.org/projects/tor/ticket/31081