### PR TITLE
circpad RP machine transition fix

### DIFF
--- a/src/core/or/circuitpadding_machines.c
+++ b/src/core/or/circuitpadding_machines.c
@@ -408,7 +408,7 @@ circpad_machine_relay_hide_rend_circuits(smartlist_t *machines_sl)
   /* OBFUSCATE_CIRC_SETUP -> END transition when we send our first
    * padding packet and/or hit the state length (the state length is 1). */
   relay_machine->states[CIRCPAD_STATE_OBFUSCATE_CIRC_SETUP].
-      next_state[CIRCPAD_EVENT_PADDING_RECV] = CIRCPAD_STATE_END;
+      next_state[CIRCPAD_EVENT_PADDING_SENT] = CIRCPAD_STATE_END;
   relay_machine->states[CIRCPAD_STATE_OBFUSCATE_CIRC_SETUP].
       next_state[CIRCPAD_EVENT_LENGTH_COUNT] = CIRCPAD_STATE_END;
 


### PR DESCRIPTION
The RP circpad machine, on the relay side, should transition as soon as a padding cell is sent to the client according to the code comment. The code currently transitions on receiving a padding cell, not sending. Fix below. 