### PR TITLE
fix for circpad_add_matching_machines to be able to negotiate more machines

### DIFF
--- a/src/core/or/circuitpadding.c
+++ b/src/core/or/circuitpadding.c
@@ -2084,8 +2084,8 @@ circpad_add_matching_machines(origin_circuit_t *on_circ,
           circ->padding_machine[i] = NULL;
           on_circ->padding_negotiation_failed = 1;
         } else {
-          /* Success. Don't try any more machines */
-          return;
+          /* Success. Don't try any more machines on this index */
+          break;
         }
       }
     } SMARTLIST_FOREACH_END(machine);


### PR DESCRIPTION
As part of `circuitpadding.c`, in `circpad_add_matching_machines()`, the macros `FOR_EACH_CIRCUIT_MACHINE_BEGIN` and `SMARTLIST_FOREACH_REVERSE_BEGIN` currently expand to a for loop each. The outer loop goes over each machine index (currently 2, set by `CIRCPAD_MAX_MACHINES`), while the inner loop looks for a suitable machine for that index to negotiate. As soon as one is found and negotiated, currently, the function returns without looking for a machine for later indices in the outer loop. The fix replaces the return with a break of the inner loop, enabling the function to negotiate machines for later indices by continuing the outer loop.  