### PR TITLE
#31012: Make tor-print-ed-signing-cert output RFC1123 and unix timestamps as well

### DIFF
--- a/changes/ticket31012
+++ b/changes/ticket31012
@@ -1,0 +1,4 @@
+  o Minor bugfixes (operator tools):
+    - Make tor-print-ed-signing-cert(1) print certificate expiration date in
+      RFC 1123 and UNIX timestamp formats, to make output machine readable.
+      Fixes bug 31012; bugfix on 0.3.5.1-alpha.

--- a/doc/tor-print-ed-signing-cert.1.txt
+++ b/doc/tor-print-ed-signing-cert.1.txt
@@ -21,6 +21,12 @@ DESCRIPTION
 **tor-print-ed-signing-cert** is utility program for Tor relay operators to
 check expiration date of ed25519 signing certificate.
 
+Expiration date is printed in three formats:
+
+* Human-readable timestamp, localized to current timezone.
+* RFC 1123 timestamp (at GMT timezone).
+* Unix time value.
+
 SEE ALSO
 --------
 **tor**(1) +

--- a/src/tools/tor-print-ed-signing-cert.c
+++ b/src/tools/tor-print-ed-signing-cert.c
@@ -10,11 +10,13 @@
 #include "lib/cc/torint.h"  /* TOR_PRIdSZ */
 #include "lib/crypt_ops/crypto_format.h"
 #include "lib/malloc/malloc.h"
+#include "lib/encoding/time_fmt.h"
 
 int
 main(int argc, char **argv)
 {
   ed25519_cert_t *cert = NULL;
+  char rfc1123_buf[RFC1123_TIME_LEN+1] = "";
 
   if (argc != 2) {
     fprintf(stderr, "Usage:\n");
@@ -58,6 +60,11 @@ main(int argc, char **argv)
   time_t expires_at = (time_t)cert->exp_field * 60 * 60;
 
   printf("Expires at: %s", ctime(&expires_at));
+
+  format_rfc1123_time(rfc1123_buf, expires_at);
+  printf("RFC 1123 timestamp: %s\n", rfc1123_buf);
+
+  printf("UNIX timestamp: %ld\n", (long int)expires_at);
 
   ed25519_cert_free(cert);
 


### PR DESCRIPTION
https://trac.torproject.org/projects/tor/ticket/31012