### PR TITLE
[Tor Trac #13194]: Track time between ESTABLISH_RENDEZVOUS and RENDEZVOUS1 cell

### DIFF
--- a/changes/ticket13194
+++ b/changes/ticket13194
@@ -1,0 +1,5 @@
+  o Minor features (onion services):
+    - Track the time in milliseconds between a ESTABLISH_RENDEZVOUS and
+      RENDEZVOUS1 control cell. This patch will allow us to measure the
+      performance and slowdowns of an onion service. Closes ticket 13194.
+      Patch by Neel Chauhan.

--- a/scripts/maint/practracker/exceptions.txt
+++ b/scripts/maint/practracker/exceptions.txt
@@ -239,7 +239,7 @@ problem function-size /src/feature/rend/rendmid.c:rend_mid_establish_intro_legac
 problem function-size /src/feature/rend/rendparse.c:rend_parse_v2_service_descriptor() 187
 problem function-size /src/feature/rend/rendparse.c:rend_decrypt_introduction_points() 104
 problem function-size /src/feature/rend/rendparse.c:rend_parse_introduction_points() 131
-problem file-size /src/feature/rend/rendservice.c 4511
+problem file-size /src/feature/rend/rendservice.c 4521
 problem function-size /src/feature/rend/rendservice.c:rend_service_prune_list_impl_() 107
 problem function-size /src/feature/rend/rendservice.c:rend_config_service() 164
 problem function-size /src/feature/rend/rendservice.c:rend_service_load_auth_keys() 178
@@ -247,7 +247,7 @@ problem function-size /src/feature/rend/rendservice.c:rend_service_receive_intro
 problem function-size /src/feature/rend/rendservice.c:rend_service_parse_intro_for_v3() 115
 problem function-size /src/feature/rend/rendservice.c:rend_service_decrypt_intro() 115
 problem function-size /src/feature/rend/rendservice.c:rend_service_intro_has_opened() 126
-problem function-size /src/feature/rend/rendservice.c:rend_service_rendezvous_has_opened() 117
+problem function-size /src/feature/rend/rendservice.c:rend_service_rendezvous_has_opened() 127
 problem function-size /src/feature/rend/rendservice.c:directory_post_to_hs_dir() 108
 problem function-size /src/feature/rend/rendservice.c:upload_service_descriptor() 111
 problem function-size /src/feature/rend/rendservice.c:rend_consider_services_intro_points() 170

--- a/src/core/or/origin_circuit_st.h
+++ b/src/core/or/origin_circuit_st.h
@@ -293,6 +293,9 @@ struct origin_circuit_t {
    * to 2*CircuitsAvailableTimoeut. */
   int circuit_idle_timeout;
 
+  /** When did we send a ESTABLISH_RENDEZVOUS cell? */
+  struct timeval establish_rend_time;
+
 };
 
 #endif /* !defined(ORIGIN_CIRCUIT_ST_H) */

--- a/src/feature/rend/rendclient.c
+++ b/src/feature/rend/rendclient.c
@@ -102,6 +102,8 @@ rend_client_send_establish_rendezvous(origin_circuit_t *circ)
     return -1;
   }
 
+  tor_gettimeofday(&circ->establish_rend_time);
+
   return 0;
 }
 

--- a/src/feature/rend/rendservice.c
+++ b/src/feature/rend/rendservice.c
@@ -3456,6 +3456,8 @@ rend_service_rendezvous_has_opened(origin_circuit_t *circuit)
   char hexcookie[9];
   int reason;
   const char *rend_cookie, *rend_pk_digest;
+  struct timeval rend1_time, rend_time_diff;
+  uint64_t msec_rend;
 
   tor_assert(circuit->base_.purpose == CIRCUIT_PURPOSE_S_CONNECT_REND);
   tor_assert(circuit->cpath);
@@ -3536,6 +3538,14 @@ rend_service_rendezvous_has_opened(origin_circuit_t *circuit)
     log_warn(LD_GENERAL, "Couldn't send RENDEZVOUS1 cell.");
     goto done;
   }
+
+  tor_gettimeofday(&rend1_time);
+  timersub(&rend1_time, &circuit->establish_rend_time, &rend_time_diff);
+  msec_rend = ((uint64_t)rend_time_diff.tv_sec)*1000 +
+              (rend_time_diff.tv_usec)/1000;
+  log_info(LD_REND, "Time between ESTABLISH_RENDEZVOUS and RENDEZVOUS1 cells "
+                    "for circuit %u is %lu ms",
+                    (unsigned) circuit->base_.n_circ_id, (long) msec_rend);
 
   crypto_dh_free(hop->rend_dh_handshake_state);
   hop->rend_dh_handshake_state = NULL;


### PR DESCRIPTION
For the bug [here](https://trac.torproject.org/projects/tor/ticket/13194).