### PR TITLE
[Tor Trac #31207]: Space out first connection_edge_process_relay_cell() line in circuit_receive_relay_cell()

### DIFF
--- a/src/core/or/relay.c
+++ b/src/core/or/relay.c
@@ -265,7 +265,7 @@ circuit_receive_relay_cell(cell_t *cell, circuit_t *circ,
     if (cell_direction == CELL_DIRECTION_OUT) {
       ++stats_n_relay_cells_delivered;
       log_debug(LD_OR,"Sending away from origin.");
-      if ((reason=connection_edge_process_relay_cell(cell, circ, conn, NULL))
+      if ((reason = connection_edge_process_relay_cell(cell, circ, conn, NULL))
           < 0) {
         log_fn(LOG_PROTOCOL_WARN, LD_PROTOCOL,
                "connection_edge_process_relay_cell (away from origin) "


### PR DESCRIPTION
For the bug [here](https://trac.torproject.org/projects/tor/ticket/31207).