### PR TITLE
#12399: Change loglevel of message 'Hash of session info was not as expected'

### DIFF
--- a/changes/bug12399
+++ b/changes/bug12399
@@ -1,0 +1,3 @@
+  o Minor bugfixes (logging):
+    - Change log level of message "Hash of session info was not as expected"
+      to LOG_PROTOCOL_WARN. Fixes bug 12399; bugfix on 0.1.1.10-alpha.

--- a/src/feature/rend/rendmid.c
+++ b/src/feature/rend/rendmid.c
@@ -70,7 +70,8 @@ rend_mid_establish_intro_legacy(or_circuit_t *circ, const uint8_t *request,
     goto err;
   }
   if (tor_memneq(expected_digest, request+2+asn1len, DIGEST_LEN)) {
-    log_warn(LD_PROTOCOL, "Hash of session info was not as expected.");
+    log_fn(LOG_PROTOCOL_WARN, LD_PROTOCOL,
+           "Hash of session info was not as expected.");
     reason = END_CIRC_REASON_TORPROTOCOL;
     goto err;
   }
@@ -116,7 +117,6 @@ rend_mid_establish_intro_legacy(or_circuit_t *circ, const uint8_t *request,
   /* Now, set up this circuit. */
   circuit_change_purpose(TO_CIRCUIT(circ), CIRCUIT_PURPOSE_INTRO_POINT);
   hs_circuitmap_register_intro_circ_v2_relay_side(circ, (uint8_t *)pk_digest);
-
   log_info(LD_REND,
            "Established introduction point on circuit %u for service %s",
            (unsigned) circ->p_circ_id, safe_str(serviceid));


### PR DESCRIPTION
https://trac.torproject.org/projects/tor/ticket/12399