### PR TITLE
[Tor Trac #25568]: Check if intro points are marked as failed in v2 INTRO cells

### DIFF
--- a/changes/bug25568
+++ b/changes/bug25568
@@ -1,0 +1,5 @@
+  o Minor bugfixes (onion services):
+    - When sending the INTRO cell for a v2 Onion Service, look at the failure
+      cache alongside timeout values to check if the intro point is marked
+      as failed. Previously, we only looked at if the relay timeout values.
+      Fixes bug 25568; bugfix on 0.1.0.1-rc. Patch by Neel Chauhan.

--- a/src/feature/rend/rendcache.c
+++ b/src/feature/rend/rendcache.c
@@ -242,7 +242,15 @@ rend_cache_failure_check(rend_service_descriptor_t *desc)
     return 0;
   }
 
-  return strmap_get_lc(rend_cache_failure, service_id) != NULL;
+  SMARTLIST_FOREACH_BEGIN(desc->intro_nodes, rend_intro_point_t *, intro) {
+    rend_cache_failure_intro_t *entry;
+    if (cache_failure_intro_lookup((const uint8_t *)
+                                   intro->extend_info->identity_digest,
+                                   service_id, &entry)) {
+      return 1;
+    }
+  }  SMARTLIST_FOREACH_END(intro);
+  return 0;
 }
 
 /** Free all storage held by the service descriptor cache. */

--- a/src/feature/rend/rendcache.c
+++ b/src/feature/rend/rendcache.c
@@ -228,6 +228,23 @@ rend_cache_entry_free_void(void *p)
   rend_cache_entry_free_(p);
 }
 
+/** Check if a failure cache entry exists for the service ID in the given
+ * descriptor <b>desc</b>. */
+int
+rend_cache_failure_check(rend_service_descriptor_t *desc)
+{
+  char service_id[REND_SERVICE_ID_LEN_BASE32 + 1];
+
+  if (desc == NULL) {
+    return 0;
+  }
+  if (rend_get_service_id(desc->pk, service_id) < 0) {
+    return 0;
+  }
+
+  return strmap_get_lc(rend_cache_failure, service_id) != NULL;
+}
+
 /** Free all storage held by the service descriptor cache. */
 void
 rend_cache_free_all(void)

--- a/src/feature/rend/rendcache.h
+++ b/src/feature/rend/rendcache.h
@@ -80,6 +80,7 @@ int rend_cache_store_v2_desc_as_client(const char *desc,
                                        rend_cache_entry_t **entry);
 size_t rend_cache_get_total_allocation(void);
 
+int rend_cache_failure_check(rend_service_descriptor_t *desc);
 void rend_cache_intro_failure_note(rend_intro_point_failure_t failure,
                                    const uint8_t *identity,
                                    const char *service_id);

--- a/src/feature/rend/rendclient.c
+++ b/src/feature/rend/rendclient.c
@@ -1112,7 +1112,7 @@ rend_client_any_intro_points_usable(const rend_cache_entry_t *entry)
   extend_info_t *extend_info =
     rend_client_get_random_intro_impl(entry, get_options()->StrictNodes, 0);
 
-  int rv = (extend_info != NULL);
+  int rv = (extend_info != NULL) && !(rend_cache_failure_check(entry->parsed));
 
   extend_info_free(extend_info);
   return rv;

--- a/src/feature/rend/rendclient.c
+++ b/src/feature/rend/rendclient.c
@@ -1109,13 +1109,12 @@ rend_client_get_random_intro_impl(const rend_cache_entry_t *entry,
 int
 rend_client_any_intro_points_usable(const rend_cache_entry_t *entry)
 {
-  extend_info_t *extend_info =
-    rend_client_get_random_intro_impl(entry, get_options()->StrictNodes, 0);
+  if (!rend_cache_failure_check(entry->parsed)) {
+    return 0;
+  }
 
-  int rv = (extend_info != NULL) && !(rend_cache_failure_check(entry->parsed));
-
-  extend_info_free(extend_info);
-  return rv;
+  return rend_client_get_random_intro_impl(entry,
+                                        get_options()->StrictNodes, 0) != NULL;
 }
 
 /** Client-side authorizations for hidden services; map of onion address to


### PR DESCRIPTION
For the bug [here](https://trac.torproject.org/projects/tor/ticket/25568).