### PR TITLE
practracker: add envvar TOR_PRACTRACKER_OPTIONS

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -371,7 +371,7 @@ endif
 
 check-best-practices:
 if USEPYTHON
-	@$(PYTHON) $(top_srcdir)/scripts/maint/practracker/practracker.py $(top_srcdir)
+	@$(PYTHON) $(top_srcdir)/scripts/maint/practracker/practracker.py $(top_srcdir) $(TOR_PRACTRACKER_OPTIONS)
 endif
 
 practracker-regen:

--- a/changes/ticket31309
+++ b/changes/ticket31309
@@ -1,0 +1,4 @@
+  o Minor features (best practices tracker):
+    - Add a TOR_PRACTRACKER_OPTIONS variable for passing arguments
+      to practracker from the environment. We may want this for
+      continuous integration. Closes ticket 31309.


### PR DESCRIPTION
We have Makefile.am use this to decide how to invoke practracker on
the Tor source.