### PR TITLE
make dist: only include files from practracker dir intentionally.

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -165,9 +165,12 @@ EXTRA_DIST+= \
 	README						\
 	ReleaseNotes					\
 	scripts/maint/checkIncludes.py                  \
-	scripts/maint/checkSpace.pl \
-	scripts/maint/practracker
-
+	scripts/maint/checkSpace.pl 			\
+	scripts/maint/practracker/exceptions.txt	\
+	scripts/maint/practracker/metrics.py		\
+	scripts/maint/practracker/practracker.py	\
+	scripts/maint/practracker/problem.py		\
+	scripts/maint/practracker/util.py
 
 ## This tells etags how to find mockable function definitions.
 AM_ETAGSFLAGS=--regex='{c}/MOCK_IMPL([^,]+,\W*\([a-zA-Z0-9_]+\)\W*,/\1/s'

--- a/changes/ticket31311
+++ b/changes/ticket31311
@@ -1,0 +1,3 @@
+  o Minor bugfixes (distribution):
+    - Do not ship any temporary files found in the scripts/maint/practracker
+      directory. Fixes bug 31311; bugfix on 0.4.1.1-alpha.


### PR DESCRIPTION
Previously, we included temporary files and whatnot, which is not
good.

Fixes bug 31311; bugfix on 0.4.1.1-alpha.