### PR TITLE
Ignore regular cells in padding circuits.

### DIFF
--- a/changes/bug30942
+++ b/changes/bug30942
@@ -1,0 +1,4 @@
+  o Minor bugfixes (circuit padding):
+    - Ignore non-padding cells on padding circuits. This addresses various
+      warning messages from subsystems that were not expecting padding
+      circuits. Fixes bug 30942; bugfix on 0.4.1.1-alpha.

--- a/src/core/or/relay.c
+++ b/src/core/or/relay.c
@@ -1663,6 +1663,17 @@ connection_edge_process_relay_cell(cell_t *cell, circuit_t *circ,
       if (circpad_handle_padding_negotiated(circ, cell, layer_hint) == 0)
         circuit_read_valid_data(TO_ORIGIN_CIRCUIT(circ), rh.length);
       return 0;
+  }
+
+  /* If this is a padding circuit we don't need to parse any other commands
+   * than the padding ones. Just drop them to the floor. */
+  if (circ->purpose == CIRCUIT_PURPOSE_C_CIRCUIT_PADDING) {
+    log_info(domain, "Ignored cell (%d) that arrived in padding circuit.",
+             rh.command);
+    return 0;
+  }
+
+  switch (rh.command) {
     case RELAY_COMMAND_BEGIN:
     case RELAY_COMMAND_BEGIN_DIR:
       if (layer_hint &&


### PR DESCRIPTION
Padding circuits were regular cells that got closed before their padding
machine could finish. This means that they can still receive regular cells from
their past life, but they have no way or reason to answer them anymore. Hence
let's ignore them before they even get to the proper subsystems.