### PR TITLE
test_util: Do not check for ENETUNREACH unless it exists.

### DIFF
--- a/src/test/test_util.c
+++ b/src/test/test_util.c
@@ -5399,11 +5399,13 @@ test_util_socketpair(void *arg)
     tt_skip();
   }
 #endif /* defined(__FreeBSD__) */
+#ifdef ENETUNREACH
   if (ersatz && socketpair_result == -ENETUNREACH) {
     /* We can also fail with -ENETUNREACH if we have no network stack at
      * all. */
     tt_skip();
   }
+#endif
   tt_int_op(0, OP_EQ, socketpair_result);
 
   tt_assert(SOCKET_OK(fds[0]));


### PR DESCRIPTION
Fixes bug 31352; bug not in any released Tor.