### PR TITLE
test_token_bucket: negate after casting to signed type.

### DIFF
--- a/src/test/test_token_bucket.c
+++ b/src/test/test_token_bucket.c
@@ -93,7 +93,7 @@ test_token_bucket_ctr_dec(void *arg)
 
   /* Keep underflowing shouldn't flag the bucket as empty. */
   tt_uint_op(false, OP_EQ, token_bucket_ctr_dec(&tb, BURST));
-  tt_int_op(tb.counter.bucket, OP_EQ, (int32_t) ((BURST + 1) * -1));
+  tt_int_op(tb.counter.bucket, OP_EQ, - (int32_t) (BURST + 1));
 
  done:
   ;


### PR DESCRIPTION
Previously we tried multiplying by -1 before casting to int32_t,
which would cause us to cast the -1 to an unsigned before we
multiplied.  This gave us compiler warnings on windows.

Fixes bug 31353; bug not in any released Tor.