### PR TITLE
scripts/git: add TOR_PUSH_DELAY to git-push-all.sh

### DIFF
--- a/changes/ticket29879
+++ b/changes/ticket29879
@@ -1,0 +1,7 @@
+  o Minor features (git scripts):
+    - Add a TOR_PUSH_DELAY variable to git-push-all.sh, which makes the script
+      push master and maint branches with a delay between each branch. These
+      delays trigger the CI jobs in a set order, which should show the most
+      likely failures first. Also make pushes atomic by default, and make
+      the script pass any command-line arguments to git push.
+      Closes ticket 29879.

--- a/scripts/git/git-push-all.sh
+++ b/scripts/git/git-push-all.sh
@@ -1,11 +1,44 @@
 #!/usr/bin/env bash
 
-# The remote upstream branch on which git.torproject.org/tor.git points to.
-UPSTREAM_BRANCH=${TOR_UPSTREAM_REMOTE_NAME:-"upstream"}
+# Usage: git-push-all.sh
+#        env vars: TOR_UPSTREAM_REMOTE_NAME=upstream TOR_PUSH_DELAY=0
+#        options: --no-atomic --dry-run (any other git push option)
+#
+# TOR_PUSH_DELAY pushes the master and maint branches separately, so that CI
+# runs in a sensible order.
+# push --atomic is the default when TOR_PUSH_DELAY=0, and for release branches.
 
-git push "$UPSTREAM_BRANCH" \
-   master \
-   {release,maint}-0.4.1 \
-   {release,maint}-0.4.0 \
-   {release,maint}-0.3.5 \
-   {release,maint}-0.2.9
+set -e
+
+# The upstream remote which git.torproject.org/tor.git points to.
+UPSTREAM_REMOTE=${TOR_UPSTREAM_REMOTE_NAME:-"upstream"}
+# Add a delay between pushes, so CI runs on the most important branches first
+PUSH_DELAY=${TOR_PUSH_DELAY:-0}
+
+PUSH_BRANCHES=`echo \
+  master \
+  {release,maint}-0.4.1 \
+  {release,maint}-0.4.0 \
+  {release,maint}-0.3.5 \
+  {release,maint}-0.2.9 \
+  `
+
+if [ "$PUSH_DELAY" -le 0 ]; then
+  echo "Pushing $PUSH_BRANCHES"
+  git push --atomic "$@" "$UPSTREAM_REMOTE" $PUSH_BRANCHES
+else
+  PUSH_BRANCHES=`echo "$PUSH_BRANCHES" | tr " " "\n" | sort -V`
+  MASTER_BRANCH=`echo "$PUSH_BRANCHES" | tr " " "\n" | grep master`
+  MAINT_BRANCHES=`echo "$PUSH_BRANCHES" | tr " " "\n" | grep maint`
+  RELEASE_BRANCHES=`echo "$PUSH_BRANCHES" | tr " " "\n" | grep release | \
+    tr "\n" " "`
+  printf "Pushing with %ss delays, so CI runs in this order:\n%s\n%s\n%s\n" \
+    "$PUSH_DELAY" "$MASTER_BRANCH" "$MAINT_BRANCHES" "$RELEASE_BRANCHES"
+  git push "$@" "$UPSTREAM_REMOTE" $MASTER_BRANCH
+  sleep "$PUSH_DELAY"
+  for b in $MAINT_BRANCHES; do
+    git push "$@" "$UPSTREAM_REMOTE" $b
+    sleep "$PUSH_DELAY"
+  done
+  git push --atomic "$@" "$UPSTREAM_REMOTE" $RELEASE_BRANCHES
+fi


### PR DESCRIPTION
Add a TOR_PUSH_DELAY variable to git-push-all.sh, which makes the script
push master and maint branches with a delay between each branch. These
delays trigger the CI jobs in a set order, which should show the most
likely failures first.

Also:
* make pushes atomic by default, and
* make the script pass any command-line arguments to git push.

Closes ticket 29879.