### PR TITLE
Fix a warning about casting the results of GetProcAddress.

### DIFF
--- a/changes/ticket31374
+++ b/changes/ticket31374
@@ -1,0 +1,4 @@
+  o Minor bugfixes (compilation warning):
+    - Fix a compilation warning on Windows about casting a function
+      pointer for GetTickCount64(). Fixes bug 31374; bugfix on
+      0.2.9.1-alpha.

--- a/src/common/compat_time.c
+++ b/src/common/compat_time.c
@@ -443,7 +443,7 @@ monotime_init_internal(void)
 
   HANDLE h = load_windows_system_library(TEXT("kernel32.dll"));
   if (h) {
-    GetTickCount64_fn = (GetTickCount64_fn_t)
+    GetTickCount64_fn = (GetTickCount64_fn_t) (void(*)(void))
       GetProcAddress(h, "GetTickCount64");
   }
   // FreeLibrary(h) ?
@@ -654,4 +654,3 @@ monotime_coarse_absolute_msec(void)
   return monotime_coarse_absolute_nsec() / ONE_MILLION;
 }
 #endif
-


### PR DESCRIPTION
Fixes bug 31374; bugfix on 0.2.9.1-alpha.