### PR TITLE
Fix 64-bit return issue in parse_log_domain()

### DIFF
--- a/changes/ticket31451
+++ b/changes/ticket31451
@@ -1,0 +1,4 @@
+  o Minor bugfixes (logging):
+    - Fix a code issue that would have broken our parsing of log
+      domains as soon as we had 33 of them.  Fortunately, we still
+      only have 29.  Fixes bug 31451; bugfix on 0.4.1.4-rc.

--- a/src/lib/log/log.c
+++ b/src/lib/log/log.c
@@ -1285,7 +1285,7 @@ parse_log_domain(const char *domain)
   int i;
   for (i=0; domain_list[i]; ++i) {
     if (!strcasecmp(domain, domain_list[i]))
-      return (1u<<i);
+      return (UINT64_C(1)<<i);
   }
   return 0;
 }


### PR DESCRIPTION
If unsigned int is 32-bits long, then our old code would give a
wrong result with any log domain whose mask was >= (1<<32).
Fortunately, there are no such log domains right now: the domain
mask is only 64 bits long to accommodate some flags.

Found by coverity as CID 1452041.

Fixes bug 31451; bugfix on 0.4.1.4-rc.