### PR TITLE
Fix a memory-leak warning in test_circuitbuid.c

### DIFF
--- a/src/test/test_circuitbuild.c
+++ b/src/test/test_circuitbuild.c
@@ -167,6 +167,7 @@ test_upgrade_from_guard_wait(void *arg)
   tt_assert(!list);
 
  done:
+  smartlist_free(list);
   circuit_free(circ);
   entry_guard_free_(guard);
 }


### PR DESCRIPTION
Coverity wants us to free everything that we are potentially
allocating, even stuff where allocating it would be a bug.  Adding
a smartlist_free() here will fix the warning.

Fixes bug 31452; bugfix on 16a0b7ed6779bf72a8a471c, which is not in
any released Tor.  This is CID 1447292.