### PR TITLE
Fix gcc build exclude on travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -91,7 +91,7 @@ matrix:
     - compiler: gcc
       os: linux
       ## TOR_RUST_DEPENDENCIES is spelt RUST_DEPENDENCIES in 0.3.2
-      env: RUST_OPTIONS="--enable-rust" TOR_RUST_DEPENDENCIES=true HARDENING_OPTIONS=""
+      env: RUST_OPTIONS="--enable-rust" TOR_RUST_DEPENDENCIES=true
 
 ## (Linux only) Use the latest Linux image (Ubuntu Trusty)
 dist: trusty

--- a/changes/bug31463
+++ b/changes/bug31463
@@ -1,0 +1,3 @@
+  o Minor bugfixes (rust):
+    - Correctly exclude a redundant rust build job in Travis. Fixes bug 31463;
+      bugfix on 0.3.5.4-alpha.


### PR DESCRIPTION
The main build doesn't use HARDENING_OPTIONS, so the exclude shouldn't,
either. Reduces the number of builders by one.