### PR TITLE
test: Change "make test-stem" so it only runs the stem tests that use…

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -275,7 +275,7 @@ need-stem-path:
 	fi
 
 test-stem: need-stem-path $(TESTING_TOR_BINARY)
-	@$(PYTHON) "$$STEM_SOURCE_DIR"/run_tests.py --tor "$(TESTING_TOR_BINARY)" --integ --log notice --target RUN_ALL;
+	@$(PYTHON) "$$STEM_SOURCE_DIR"/run_tests.py --tor "$(TESTING_TOR_BINARY)" --integ --test control.controller --test control.base_controller --test process --log notice;
 
 test-stem-full: need-stem-path $(TESTING_TOR_BINARY)
 	@$(PYTHON) "$$STEM_SOURCE_DIR"/run_tests.py --tor "$(TESTING_TOR_BINARY)" --all --log notice --target RUN_ALL,ONLINE -v;

--- a/changes/ticket31554
+++ b/changes/ticket31554
@@ -1,0 +1,4 @@
+  o Minor features (stem tests):
+    - Change "make test-stem" so it only runs the stem tests that use tor.
+      This change makes test-stem faster and more reliable.
+      Closes ticket 31554.


### PR DESCRIPTION
… tor

This change makes test-stem faster and more reliable.

Use "make test-stem-full" to run all of stem's tests.

Closes ticket 31554.