### PR TITLE
Stub out some more functions in dirvote/*.h, fix compilation.

### DIFF
--- a/changes/bug31552
+++ b/changes/bug31552
@@ -1,0 +1,5 @@
+  o Minor bugfixes (compilation):
+    - Add more stub functions to fix compilation on Android with LTO, when
+      --disable-module-dirauth is used. Previously, these compilation
+      settings would make the compiler look for functions that didn't exist.
+      Fixes bug 31552; bugfix on 0.4.1.1-alpha.

--- a/src/feature/dirauth/keypin.h
+++ b/src/feature/dirauth/keypin.h
@@ -11,10 +11,25 @@ int keypin_check_and_add(const uint8_t *rsa_id_digest,
                          const int replace_existing_entry);
 int keypin_check(const uint8_t *rsa_id_digest,
                  const uint8_t *ed25519_id_key);
-
-int keypin_open_journal(const char *fname);
 int keypin_close_journal(void);
+
+#ifdef HAVE_MODULE_DIRAUTH
+int keypin_open_journal(const char *fname);
 int keypin_load_journal(const char *fname);
+#else
+static inline int
+keypin_open_journal(const char *fname)
+{
+  (void)fname;
+  return 0;
+}
+static inline int
+keypin_load_journal(const char *fname)
+{
+  (void)fname;
+  return 0;
+}
+#endif
 void keypin_clear(void);
 int keypin_check_lone_rsa(const uint8_t *rsa_id_digest);
 
@@ -44,4 +59,3 @@ MOCK_DECL(STATIC void, keypin_add_entry_to_map, (keypin_ent_t *ent));
 #endif /* defined(KEYPIN_PRIVATE) */
 
 #endif /* !defined(TOR_KEYPIN_H) */
-

--- a/src/feature/dirauth/process_descs.h
+++ b/src/feature/dirauth/process_descs.h
@@ -25,15 +25,35 @@ enum was_router_added_t dirserv_add_descriptor(routerinfo_t *ri,
                                                const char **msg,
                                                const char *source);
 
-int authdir_wants_to_reject_router(routerinfo_t *ri, const char **msg,
-                                   int complain,
-                                   int *valid_out);
 uint32_t dirserv_router_get_status(const routerinfo_t *router,
                                    const char **msg,
                                    int severity);
 void dirserv_set_node_flags_from_authoritative_status(node_t *node,
                                                       uint32_t authstatus);
 
+#ifdef HAVE_MODULE_DIRAUTH
 int dirserv_would_reject_router(const routerstatus_t *rs);
+int authdir_wants_to_reject_router(routerinfo_t *ri, const char **msg,
+                                   int complain,
+                                   int *valid_out);
+#else
+static inline int
+dirserv_would_reject_router(const routerstatus_t *rs)
+{
+  (void)rs;
+  return 0;
+}
+static inline int
+authdir_wants_to_reject_router(routerinfo_t *ri, const char **msg,
+                               int complain,
+                               int *valid_out)
+{
+  (void)ri;
+  (void)msg;
+  (void)complain;
+  (void)valid_out;
+  return 0;
+}
+#endif
 
 #endif /* !defined(TOR_RECV_UPLOADS_H) */

--- a/src/feature/dirauth/process_descs.h
+++ b/src/feature/dirauth/process_descs.h
@@ -12,10 +12,13 @@
 #ifndef TOR_RECV_UPLOADS_H
 #define TOR_RECV_UPLOADS_H
 
-int dirserv_load_fingerprint_file(void);
-void dirserv_free_fingerprint_list(void);
-int dirserv_add_own_fingerprint(crypto_pk_t *pk);
+// for was_router_added_t.
+#include "feature/nodelist/routerlist.h"
 
+void dirserv_free_fingerprint_list(void);
+
+#ifdef HAVE_MODULE_DIRAUTH
+int dirserv_load_fingerprint_file(void);
 enum was_router_added_t dirserv_add_multiple_descriptors(
                                      const char *desc, size_t desclen,
                                      uint8_t purpose,
@@ -25,18 +28,45 @@ enum was_router_added_t dirserv_add_descriptor(routerinfo_t *ri,
                                                const char **msg,
                                                const char *source);
 
+int dirserv_would_reject_router(const routerstatus_t *rs);
+int authdir_wants_to_reject_router(routerinfo_t *ri, const char **msg,
+                                   int complain,
+                                   int *valid_out);
+int dirserv_add_own_fingerprint(crypto_pk_t *pk);
 uint32_t dirserv_router_get_status(const routerinfo_t *router,
                                    const char **msg,
                                    int severity);
 void dirserv_set_node_flags_from_authoritative_status(node_t *node,
                                                       uint32_t authstatus);
-
-#ifdef HAVE_MODULE_DIRAUTH
-int dirserv_would_reject_router(const routerstatus_t *rs);
-int authdir_wants_to_reject_router(routerinfo_t *ri, const char **msg,
-                                   int complain,
-                                   int *valid_out);
 #else
+static inline int
+dirserv_load_fingerprint_file(void)
+{
+  return 0;
+}
+static inline enum was_router_added_t
+dirserv_add_multiple_descriptors(const char *desc, size_t desclen,
+                                 uint8_t purpose,
+                                 const char *source,
+                                 const char **msg)
+{
+  (void)desc;
+  (void)desclen;
+  (void)purpose;
+  (void)source;
+  (void)msg;
+  return (enum was_router_added_t)0;
+}
+static inline enum was_router_added_t
+dirserv_add_descriptor(routerinfo_t *ri,
+                       const char **msg,
+                       const char *source)
+{
+  (void)ri;
+  (void)msg;
+  (void)source;
+  return (enum was_router_added_t)0;
+}
 static inline int
 dirserv_would_reject_router(const routerstatus_t *rs)
 {
@@ -53,6 +83,29 @@ authdir_wants_to_reject_router(routerinfo_t *ri, const char **msg,
   (void)complain;
   (void)valid_out;
   return 0;
+}
+static inline int
+dirserv_add_own_fingerprint(crypto_pk_t *pk)
+{
+  (void)pk;
+  return 0;
+}
+static inline uint32_t
+dirserv_router_get_status(const routerinfo_t *router,
+                          const char **msg,
+                          int severity)
+{
+  (void)router;
+  (void)msg;
+  (void)severity;
+  return 0;
+}
+static inline void
+dirserv_set_node_flags_from_authoritative_status(node_t *node,
+                                                 uint32_t authstatus)
+{
+  (void)node;
+  (void)authstatus;
 }
 #endif
 

--- a/src/feature/dirauth/reachability.h
+++ b/src/feature/dirauth/reachability.h
@@ -24,16 +24,16 @@
 #define REACHABILITY_TEST_CYCLE_PERIOD \
   (REACHABILITY_TEST_INTERVAL*REACHABILITY_MODULO_PER_TEST)
 
-void dirserv_orconn_tls_done(const tor_addr_t *addr,
-                             uint16_t or_port,
-                             const char *digest_rcvd,
-                             const struct ed25519_public_key_t *ed_id_rcvd);
 void dirserv_single_reachability_test(time_t now, routerinfo_t *router);
 void dirserv_test_reachability(time_t now);
 
 #ifdef HAVE_MODULE_DIRAUTH
 int dirserv_should_launch_reachability_test(const routerinfo_t *ri,
                                             const routerinfo_t *ri_old);
+void dirserv_orconn_tls_done(const tor_addr_t *addr,
+                             uint16_t or_port,
+                             const char *digest_rcvd,
+                             const struct ed25519_public_key_t *ed_id_rcvd);
 #else
 static inline int
 dirserv_should_launch_reachability_test(const routerinfo_t *ri,
@@ -42,6 +42,17 @@ dirserv_should_launch_reachability_test(const routerinfo_t *ri,
   (void)ri;
   (void)ri_old;
   return 0;
+}
+static inline void
+dirserv_orconn_tls_done(const tor_addr_t *addr,
+                        uint16_t or_port,
+                        const char *digest_rcvd,
+                        const struct ed25519_public_key_t *ed_id_rcvd)
+{
+  (void)addr;
+  (void)or_port;
+  (void)digest_rcvd;
+  (void)ed_id_rcvd;
 }
 #endif
 

--- a/src/feature/dirauth/reachability.h
+++ b/src/feature/dirauth/reachability.h
@@ -28,9 +28,21 @@ void dirserv_orconn_tls_done(const tor_addr_t *addr,
                              uint16_t or_port,
                              const char *digest_rcvd,
                              const struct ed25519_public_key_t *ed_id_rcvd);
-int dirserv_should_launch_reachability_test(const routerinfo_t *ri,
-                                            const routerinfo_t *ri_old);
 void dirserv_single_reachability_test(time_t now, routerinfo_t *router);
 void dirserv_test_reachability(time_t now);
+
+#ifdef HAVE_MODULE_DIRAUTH
+int dirserv_should_launch_reachability_test(const routerinfo_t *ri,
+                                            const routerinfo_t *ri_old);
+#else
+static inline int
+dirserv_should_launch_reachability_test(const routerinfo_t *ri,
+                                            const routerinfo_t *ri_old)
+{
+  (void)ri;
+  (void)ri_old;
+  return 0;
+}
+#endif
 
 #endif /* !defined(TOR_REACHABILITY_H) */


### PR DESCRIPTION
This fixes LTO compilation for Android and -O0 compilation in
general, when --disable-module-dirauth is provided.

Fixes bug 31552; bugfix on 0.4.1.1-alpha.