### PR TITLE
hs-v3: Make service pick the exact amount of intro points

### DIFF
--- a/changes/ticket31548
+++ b/changes/ticket31548
@@ -1,0 +1,7 @@
+  o Major bugfixes (hidden service v3):
+    - Make onion service always use the exact amount of configured intro points
+      (or less due to node exlusion). Before, a service could sometimes pick
+      more intro points than configured with the
+      HiddenServiceNumIntroductionPoints option. Fixes bug 31548; bugfix on
+      0.3.2.1-alpha.
+

--- a/src/feature/hs/hs_service.c
+++ b/src/feature/hs/hs_service.c
@@ -1686,6 +1686,15 @@ build_desc_intro_points(const hs_service_t *service,
 
   DIGEST256MAP_FOREACH(desc->intro_points.map, key,
                        const hs_service_intro_point_t *, ip) {
+    if (!ip->circuit_established) {
+      /* Ignore un-established intro points. They can linger in that list
+       * because their circuit has not opened and they haven't been removed
+       * yet even though we have enough intro circuits.
+       *
+       * XXX: Due to #31561, it can stay in that list until rotation so this
+       * check prevents to publish an intro point without a circuit. */
+      continue;
+    }
     hs_desc_intro_point_t *desc_ip = hs_desc_intro_point_new();
     if (setup_desc_intro_point(&desc->signing_kp, ip, now, desc_ip) < 0) {
       hs_desc_intro_point_free(desc_ip);


### PR DESCRIPTION
When encoding introduction points, we were not checking if that intro points
had an established circuit.

When botting up, the service will pick, by default, 3 + 2 intro points and the
first 3 that establish, we use them and upload the descriptor.

However, the intro point is removed from the service descriptor list only when
the circuit has opened and we see that we have already enough intro points, it
is then removed.

But it is possible that the service establishes 3 intro points successfully
before the other(s) have even opened yet.

This lead to the service encoding extra intro points in the descriptor even
though the circuit is not opened or might never establish (#31561).

Fixes #31548

Signed-off-by: David Goulet <dgoulet@torproject.org>