### PR TITLE
hs-v3: Remove intro point on circuit build time out

### DIFF
--- a/changes/ticket31561
+++ b/changes/ticket31561
@@ -1,0 +1,3 @@
+  o Minor bugfix (hidden service v3):
+    - Remove intro points from service descriptor list after building circuit
+      times out. Fixes bug 31561; bugfix on 0.3.2.1-alpha.

--- a/src/core/or/circuituse.c
+++ b/src/core/or/circuituse.c
@@ -840,10 +840,15 @@ circuit_expire_building(void)
                  -1);
 
     circuit_log_path(LOG_INFO,LD_CIRC,TO_ORIGIN_CIRCUIT(victim));
-    if (victim->purpose == CIRCUIT_PURPOSE_C_MEASURE_TIMEOUT)
+    if (victim->purpose == CIRCUIT_PURPOSE_C_MEASURE_TIMEOUT) {
       circuit_mark_for_close(victim, END_CIRC_REASON_MEASUREMENT_EXPIRED);
-    else
+    } else {
       circuit_mark_for_close(victim, END_CIRC_REASON_TIMEOUT);
+      if (victim->purpose >= CIRCUIT_PURPOSE_S_HS_MIN_ &&
+          victim->purpose <= CIRCUIT_PURPOSE_S_HS_MAX_) {
+        hs_service_circuit_timed_out(TO_ORIGIN_CIRCUIT(victim));
+      }
+    }
 
     pathbias_count_timeout(TO_ORIGIN_CIRCUIT(victim));
   } SMARTLIST_FOREACH_END(victim);

--- a/src/core/or/circuituse.c
+++ b/src/core/or/circuituse.c
@@ -96,6 +96,10 @@ circuit_purpose_is_hs_service(uint8_t purpose)
 static int
 circuit_purpose_is_hs_client(uint8_t purpose)
 {
+  if (purpose == CIRCUIT_PURPOSE_HS_VANGUARDS) {
+    return 1;
+  }
+
   /* Client-side purpose */
   return (purpose >= CIRCUIT_PURPOSE_C_HS_MIN_ &&
           purpose <= CIRCUIT_PURPOSE_C_HS_MAX_);

--- a/src/core/or/circuituse.c
+++ b/src/core/or/circuituse.c
@@ -73,6 +73,34 @@
 STATIC void circuit_expire_old_circuits_clientside(void);
 static void circuit_increment_failure_count(void);
 
+/* Return true iff the circuit purpose is for an onion service excluding
+ * client, only service side. */
+static int
+circuit_purpose_is_hs_service(uint8_t purpose)
+{
+  if (purpose == CIRCUIT_PURPOSE_HS_VANGUARDS) {
+    return 1;
+  }
+
+  /* Service-side purpose */
+  if (purpose >= CIRCUIT_PURPOSE_S_HS_MIN_ &&
+      purpose <= CIRCUIT_PURPOSE_S_HS_MAX_) {
+    return 1;
+  }
+
+  return 0;
+}
+
+/* Return true iff the circuit purpose is for an onion service client
+ * excluding service side. */
+static int
+circuit_purpose_is_hs_client(uint8_t purpose)
+{
+  /* Client-side purpose */
+  return (purpose >= CIRCUIT_PURPOSE_C_HS_MIN_ &&
+          purpose <= CIRCUIT_PURPOSE_C_HS_MAX_);
+}
+
 /** Check whether the hidden service destination of the stream at
  *  <b>edge_conn</b> is the same as the destination of the circuit at
  *  <b>origin_circ</b>. */
@@ -844,8 +872,7 @@ circuit_expire_building(void)
       circuit_mark_for_close(victim, END_CIRC_REASON_MEASUREMENT_EXPIRED);
     } else {
       circuit_mark_for_close(victim, END_CIRC_REASON_TIMEOUT);
-      if (victim->purpose >= CIRCUIT_PURPOSE_S_HS_MIN_ &&
-          victim->purpose <= CIRCUIT_PURPOSE_S_HS_MAX_) {
+      if (circuit_purpose_is_hs_service(victim->purpose)) {
         hs_service_circuit_timed_out(TO_ORIGIN_CIRCUIT(victim));
       }
     }
@@ -1969,23 +1996,8 @@ have_enough_path_info(int need_exit)
 int
 circuit_purpose_is_hidden_service(uint8_t purpose)
 {
-   if (purpose == CIRCUIT_PURPOSE_HS_VANGUARDS) {
-     return 1;
-   }
-
-   /* Client-side purpose */
-   if (purpose >= CIRCUIT_PURPOSE_C_HS_MIN_ &&
-       purpose <= CIRCUIT_PURPOSE_C_HS_MAX_) {
-     return 1;
-   }
-
-   /* Service-side purpose */
-   if (purpose >= CIRCUIT_PURPOSE_S_HS_MIN_ &&
-       purpose <= CIRCUIT_PURPOSE_S_HS_MAX_) {
-     return 1;
-   }
-
-   return 0;
+  return circuit_purpose_is_hs_client(purpose) ||
+         circuit_purpose_is_hs_service(purpose);
 }
 
 /**

--- a/src/feature/hs/hs_service.c
+++ b/src/feature/hs/hs_service.c
@@ -3428,8 +3428,9 @@ service_intro_circuit_timed_out(const origin_circuit_t *circ)
   /* This IP can not have an established circuit. Scream loudly if so but
    * proceed to remove it to recover. */
   tor_assert_nonfatal(!ip->circuit_established);
-  /* Remove intro from service's descriptor(s). */
+  /* Remove and free intro from service's descriptor(s). */
   service_intro_point_remove(service, ip);
+  service_intro_point_free(ip);
 }
 
 /* ========== */

--- a/src/feature/hs/hs_service.c
+++ b/src/feature/hs/hs_service.c
@@ -3405,7 +3405,10 @@ service_encode_descriptor(const hs_service_t *service,
 }
 
 /* An introduction circuit has timed out while building or waiting for an
- * established introduction cell. */
+ * established introduction cell.
+ *
+ * Remove the corresponding introduction point from the service map so it
+ * doesn't get put in the descriptor or considered usable by the service. */
 static void
 service_intro_circuit_timed_out(const origin_circuit_t *circ)
 {
@@ -3423,6 +3426,9 @@ service_intro_circuit_timed_out(const origin_circuit_t *circ)
   if (BUG(service == NULL) || BUG(ip == NULL)) {
     return;
   }
+  /* This IP can not have an established circuit. Scream loudly if so but
+   * proceed to remove it to recover. */
+  tor_assert_nonfatal(!ip->circuit_established);
   /* Remove intro from service's descriptor(s). */
   service_intro_point_remove(service, ip);
 }

--- a/src/feature/hs/hs_service.c
+++ b/src/feature/hs/hs_service.c
@@ -3416,8 +3416,7 @@ service_intro_circuit_timed_out(const origin_circuit_t *circ)
   hs_service_intro_point_t *ip = NULL;
 
   tor_assert(circ);
-  tor_assert(TO_CIRCUIT(circ)->purpose == CIRCUIT_PURPOSE_S_ESTABLISH_INTRO ||
-             TO_CIRCUIT(circ)->purpose == CIRCUIT_PURPOSE_S_INTRO);
+  tor_assert(TO_CIRCUIT(circ)->purpose == CIRCUIT_PURPOSE_S_ESTABLISH_INTRO);
   tor_assert(circ->hs_ident);
 
   /* Get the corresponding service and intro point. */

--- a/src/feature/hs/hs_service.h
+++ b/src/feature/hs/hs_service.h
@@ -323,6 +323,7 @@ void hs_service_map_has_changed(void);
 void hs_service_dir_info_changed(void);
 void hs_service_run_scheduled_events(time_t now);
 void hs_service_circuit_has_opened(origin_circuit_t *circ);
+void hs_service_circuit_timed_out(const origin_circuit_t *circ);
 int hs_service_receive_intro_established(origin_circuit_t *circ,
                                          const uint8_t *payload,
                                          size_t payload_len);


### PR DESCRIPTION
When establishing service intro points, if a circuit ever times out due to
CBT, callback into the HS subsystem in order to remove the intro point from
the service descriptor list.

Fixese #31561

Signed-off-by: David Goulet <dgoulet@torproject.org>