### PR TITLE
madvise: tolerate EINVAL and ENOSYS

### DIFF
--- a/changes/bug31570
+++ b/changes/bug31570
@@ -1,0 +1,5 @@
+  o Major bugfixes (crash, android):
+    - Tolerate systems (including some Android installations) where madvise
+      and MADV_DONTDUMP are available at build-time, but not at run time.
+      Previously, these systems would notice a failed syscall and abort.
+      Fixes bug 31570; bugfix on 0.4.1.1-alpha.


### PR DESCRIPTION
These errors can occur if we are built on a system with support for
madvise(MADV_NOFORK) but then we are run on a system whose kernel
does not support that flag.

If the error is something that we don't tolerate at all, we now log
it before crashing.

Fixes bug 31570.  I am calling this a bugfix on 0.4.1.1-alpha, where
we actually started using the map_anon code.