### PR TITLE
config: Make CLEAR with a nonempty value into a nonfatal assertion.

### DIFF
--- a/changes/ticket31529
+++ b/changes/ticket31529
@@ -1,0 +1,5 @@
+  o Minor features (debugging):
+    - Log a nonfatal assertion failure if we encounter a configuration
+      line whose command is "CLEAR" but which has a nonempty value.
+      This should be impossible, according to the rules of our
+      configuration line parsing. Closes ticket 31529.

--- a/src/app/config/confparse.c
+++ b/src/app/config/confparse.c
@@ -652,9 +652,14 @@ config_assign_line(const config_mgr_t *mgr, void *options,
     }
     return 0;
   } else if (c->command == CONFIG_LINE_CLEAR && !clear_first) {
-    // XXXX This is unreachable, since a CLEAR line always has an
-    // XXXX empty value.
-    config_reset(mgr, options, mvar, use_defaults); // LCOV_EXCL_LINE
+    // This block is unreachable, since a CLEAR line always has an
+    // empty value, and so will trigger be handled by the previous
+    // "if (!strlen(c->value))" block.
+
+    // LCOV_EXCL_START
+    tor_assert_nonfatal_unreached();
+    config_reset(mgr, options, mvar, use_defaults);
+    // LCOV_EXCL_STOP
   }
 
   if (options_seen && ! config_var_is_cumulative(cvar)) {


### PR DESCRIPTION
When we parse a CLEAR line (e.g., "/OrPort" or /OrPort blah blah"),
we always suppress the value, even if one exists.  That means that
the block of code was meant to handle CLEAR lines didn't actually do
anything, since we previously handled them the same way as with
other empty values.

Closes ticket 31529.