### PR TITLE
[Tor Trac #31652]: hs-v3: Service circuit retry limit should not close a valid circuit

### DIFF
--- a/changes/bug31652
+++ b/changes/bug31652
@@ -1,0 +1,7 @@
+  o Minor bugfixes (onion services):
+    - When we launch an intro circuit for a v3 onion service, reject intro
+      points circuits that retried more than the maximum of three times.
+      Previously, we allowed intro points that tried more than thrice to
+      launch and they got killed in cleanup_intro_points() even if they
+      succeeded. Fixes bug 31652; bugfix on 0.3.2.1-alpha. Patch by Neel
+      Chauhan.

--- a/src/feature/hs/hs_service.c
+++ b/src/feature/hs/hs_service.c
@@ -2612,10 +2612,14 @@ launch_intro_point_circuits(hs_service_t *service)
         ei = get_extend_info_from_intro_point(ip, 0);
       }
 
-      if (ei == NULL) {
-        /* This is possible if we can get a node_t but not the extend info out
-         * of it. In this case, we remove the intro point and a new one will
-         * be picked at the next main loop callback. */
+      /* We remove the intro point if:
+       * - We can get a node_t but not the extend info out of it.
+       * - The intro point has retried the circuit more than
+       *   MAX_INTRO_POINT_CIRCUIT_RETRIES times
+       * In this case, we remove the intro point and a new one will be picked
+       * at the next main loop callback. */
+      if (ei == NULL ||
+          ip->circuit_retries > MAX_INTRO_POINT_CIRCUIT_RETRIES) {
         MAP_DEL_CURRENT(key);
         service_intro_point_free(ip);
         continue;


### PR DESCRIPTION
For the bug [here](https://trac.torproject.org/projects/tor/ticket/31652).