### PR TITLE
entrynodes: Make routine descriptor expiry notice logs less alarming

### DIFF
--- a/changes/bug31657
+++ b/changes/bug31657
@@ -1,0 +1,5 @@
+  o Minor bugfixes (guards):
+    - When tor is missing descriptors for some primary entry guards, make the
+      log message less alarming. It's normal for descriptors to expire, as long
+      as tor fetches new ones soon after. Fixes bug 31657;
+      bugfix on 0.3.3.1-alpha.

--- a/src/feature/client/entrynodes.c
+++ b/src/feature/client/entrynodes.c
@@ -3765,7 +3765,8 @@ guard_selection_get_err_str_if_dir_info_missing(guard_selection_t *gs,
 
   /* otherwise return a helpful error string */
   tor_asprintf(&ret_str, "We're missing descriptors for %d/%d of our "
-               "primary entry guards (total %sdescriptors: %d/%d).",
+               "primary entry guards (total %sdescriptors: %d/%d). "
+               "That's ok. We will try to fetch missing descriptors soon.",
                n_missing_descriptors, num_primary_to_check,
                using_mds?"micro":"", num_present, num_usable);
 

--- a/src/test/test_entrynodes.c
+++ b/src/test/test_entrynodes.c
@@ -1723,7 +1723,8 @@ test_entry_guard_manage_primary(void *arg)
     dir_info_str =guard_selection_get_err_str_if_dir_info_missing(gs, 1, 2, 3);
     tt_str_op(dir_info_str, OP_EQ,
               "We're missing descriptors for 1/2 of our primary entry guards "
-              "(total microdescriptors: 2/3).");
+              "(total microdescriptors: 2/3). That's ok. We will try to fetch "
+              "missing descriptors soon.");
     tor_free(dir_info_str);
   }
 


### PR DESCRIPTION
When tor is missing descriptors for some primary entry guards, make the
log message less alarming. It's normal for descriptors to expire, as long
as tor fetches new ones soon after.

Fixes bug 31657; bugfix on 0.3.3.1-alpha.