### PR TITLE
subsys: Make the subsystem init order match the module dependencies

### DIFF
--- a/changes/bug31615
+++ b/changes/bug31615
@@ -1,0 +1,5 @@
+  o Minor bugfixes (subsystems):
+    - Make the subsystem init order match the subsystem module dependencies.
+      Call windows process security APIs as early as possible. Init log before
+      network and time, so that network and time can use logging.
+      Fixes bug 31615; bugfix on 0.4.0.1-alpha.

--- a/src/lib/err/torerr_sys.c
+++ b/src/lib/err/torerr_sys.c
@@ -33,7 +33,10 @@ subsys_torerr_shutdown(void)
 
 const subsys_fns_t sys_torerr = {
   .name = "err",
-  .level = -100,
+  /* Low-level error handling is a diagnostic feature, we want it to init
+   * right after windows process security, and shutdown last.
+   * (Security never shuts down.) */
+  .level = -99,
   .supported = true,
   .initialize = subsys_torerr_initialize,
   .shutdown = subsys_torerr_shutdown

--- a/src/lib/log/log_sys.c
+++ b/src/lib/log/log_sys.c
@@ -29,6 +29,8 @@ subsys_logging_shutdown(void)
 const subsys_fns_t sys_logging = {
   .name = "log",
   .supported = true,
+  /* Logging depends on threads, approx time, raw logging, and security.
+   * Most other lib modules depend on logging. */
   .level = -90,
   .initialize = subsys_logging_initialize,
   .shutdown = subsys_logging_shutdown,

--- a/src/lib/net/network_sys.c
+++ b/src/lib/net/network_sys.c
@@ -37,7 +37,9 @@ subsys_network_shutdown(void)
 
 const subsys_fns_t sys_network = {
   .name = "network",
-  .level = -90,
+  /* Network depends on logging, and a lot of other modules depend on network.
+   */
+  .level = -80,
   .supported = true,
   .initialize = subsys_network_initialize,
   .shutdown = subsys_network_shutdown,

--- a/src/lib/process/winprocess_sys.c
+++ b/src/lib/process/winprocess_sys.c
@@ -58,6 +58,8 @@ subsys_winprocess_initialize(void)
 
 const subsys_fns_t sys_winprocess = {
   .name = "winprocess",
+  /* HeapEnableTerminationOnCorruption and setdeppolicy() are security
+   * features, we want them to run first. */
   .level = -100,
   .supported = WINPROCESS_SYS_ENABLED,
   .initialize = subsys_winprocess_initialize,

--- a/src/lib/thread/compat_threads.c
+++ b/src/lib/thread/compat_threads.c
@@ -122,6 +122,8 @@ subsys_threads_initialize(void)
 const subsys_fns_t sys_threads = {
   .name = "threads",
   .supported = true,
+  /* Threads is used by logging, which is a diagnostic feature, we want it to
+   * init right after low-level error handling and approx time. */
   .level = -95,
   .initialize = subsys_threads_initialize,
 };

--- a/src/lib/time/time_sys.c
+++ b/src/lib/time/time_sys.c
@@ -20,7 +20,9 @@ subsys_time_initialize(void)
 
 const subsys_fns_t sys_time = {
   .name = "time",
-  .level = -90,
+  /* Monotonic time depends on logging, and a lot of other modules depend on
+   * monotonic time. */
+  .level = -80,
   .supported = true,
   .initialize = subsys_time_initialize,
 };

--- a/src/lib/wallclock/approx_time.c
+++ b/src/lib/wallclock/approx_time.c
@@ -54,6 +54,8 @@ subsys_wallclock_initialize(void)
 const subsys_fns_t sys_wallclock = {
   .name = "wallclock",
   .supported = true,
-  .level = -99,
+  /* Approximate time is a diagnostic feature, we want it to init right after
+   * low-level error handling. */
+  .level = -98,
   .initialize = subsys_wallclock_initialize,
 };


### PR DESCRIPTION
Fix levels for subsystems that depend on log/err
* winprocess (security) doesn't use err:
  * call windows process security APIs as early as possible
  * init err after winprocess
  * move wallclock so it's still after err
* network and time depend on log:
  * make sure that network and time can use logging.
  * init network and time after log

Add comments explaining the module init order.

Fixes bug 31615; bugfix on 0.4.0.1-alpha.