### PR TITLE
build: The <sys/sysctl.h> is now deprecated on Linux

### DIFF
--- a/changes/ticket31673
+++ b/changes/ticket31673
@@ -1,0 +1,3 @@
+  o New system requirements (build system):
+    - Do not include the deprecated <sys/sysctl.h> on Linux or Windows system.
+      Closes 31673;

--- a/src/lib/meminfo/meminfo.c
+++ b/src/lib/meminfo/meminfo.c
@@ -18,9 +18,6 @@
 #include "lib/log/log.h"
 #include "lib/malloc/malloc.h"
 
-#ifdef HAVE_SYS_SYSCTL_H
-#include <sys/sysctl.h>
-#endif
 #ifdef HAVE_FCNTL_H
 #include <fcntl.h>
 #endif
@@ -35,6 +32,10 @@
 #include <windows.h>
 #endif
 #include <string.h>
+
+#if defined(HAVE_SYS_SYSCTL_H) && !defined(_WIN32) && !defined(__linux__)
+#include <sys/sysctl.h>
+#endif
 
 DISABLE_GCC_WARNING(aggregate-return)
 /** Call the platform malloc info function, and dump the results to the log at


### PR DESCRIPTION
Closes #31673