### PR TITLE
Ticket31589 042 01

### DIFF
--- a/changes/ticket31589
+++ b/changes/ticket31589
@@ -1,0 +1,2 @@
+  o Code simplification and refactoring (onion services):
+    - Interface for function `decrypt_desc_layer` cleaned up. Closes ticket 31589.

--- a/scripts/maint/practracker/exceptions.txt
+++ b/scripts/maint/practracker/exceptions.txt
@@ -244,7 +244,7 @@ problem function-size /src/feature/hs/hs_common.c:hs_get_responsible_hsdirs() 10
 problem function-size /src/feature/hs/hs_config.c:config_service_v3() 107
 problem function-size /src/feature/hs/hs_config.c:config_generic_service() 138
 problem function-size /src/feature/hs/hs_descriptor.c:desc_encode_v3() 101
-problem function-size /src/feature/hs/hs_descriptor.c:decrypt_desc_layer() 105
+problem function-size /src/feature/hs/hs_descriptor.c:decrypt_desc_layer() 111
 problem function-size /src/feature/hs/hs_descriptor.c:decode_introduction_point() 122
 problem function-size /src/feature/hs/hs_descriptor.c:desc_decode_superencrypted_v3() 107
 problem function-size /src/feature/hs/hs_descriptor.c:desc_decode_encrypted_v3() 107

--- a/src/feature/hs/hs_descriptor.h
+++ b/src/feature/hs/hs_descriptor.h
@@ -276,6 +276,7 @@ void hs_desc_authorized_client_free_(hs_desc_authorized_client_t *client);
                 hs_desc_authorized_client_free_, (client))
 
 hs_desc_authorized_client_t *hs_desc_build_fake_authorized_client(void);
+
 void hs_desc_build_authorized_client(const uint8_t *subcredential,
                                      const curve25519_public_key_t *
                                      client_auth_pk,
@@ -308,10 +309,8 @@ STATIC int desc_sig_is_valid(const char *b64_sig,
                              const char *encoded_desc, size_t encoded_len);
 
 MOCK_DECL(STATIC size_t, decrypt_desc_layer,(const hs_descriptor_t *desc,
-                                             const uint8_t *encrypted_blob,
-                                             size_t encrypted_blob_size,
                                              const uint8_t *descriptor_cookie,
-                                             int is_superencrypted_layer,
+                                             bool is_superencrypted_layer,
                                              char **decrypted_out));
 
 #endif /* defined(HS_DESCRIPTOR_PRIVATE) */

--- a/src/test/fuzz/fuzz_hsdescv3.c
+++ b/src/test/fuzz/fuzz_hsdescv3.c
@@ -35,16 +35,21 @@ mock_rsa_ed25519_crosscert_check(const uint8_t *crosscert,
 
 static size_t
 mock_decrypt_desc_layer(const hs_descriptor_t *desc,
-                        const uint8_t *encrypted_blob,
-                        size_t encrypted_blob_size,
                         const uint8_t *descriptor_cookie,
-                        int is_superencrypted_layer,
+                        bool is_superencrypted_layer,
                         char **decrypted_out)
 {
   (void)is_superencrypted_layer;
   (void)desc;
   (void)descriptor_cookie;
   const size_t overhead = HS_DESC_ENCRYPTED_SALT_LEN + DIGEST256_LEN;
+  const uint8_t *encrypted_blob = (is_superencrypted_layer)
+    ? desc->plaintext_data.superencrypted_blob
+    : desc->superencrypted_data.encrypted_blob;
+  size_t encrypted_blob_size = (is_superencrypted_layer)
+    ? desc->plaintext_data.superencrypted_blob_size
+    : desc->superencrypted_data.encrypted_blob_size;
+
   if (encrypted_blob_size < overhead)
     return 0;
   *decrypted_out = tor_memdup_nulterm(


### PR DESCRIPTION
[Ticket](https://trac.torproject.org/projects/tor/ticket/31589)
```
============================================================================
Testsuite summary for tor 0.4.2.0-alpha-dev
============================================================================
# TOTAL: 21
# PASS:  19
# SKIP:  2
# XFAIL: 0
# FAIL:  0
# XPASS: 0
# ERROR: 0
============================================================================
make[2]: Leaving directory '/hdd/programming/cpp/tor'
perl ./scripts/maint/checkSpace.pl -C \
	./src/lib/*/*.[ch] ./src/core/*/*.[ch] ./src/feature/*/*.[ch] ./src/app/*/*.[ch] ./src/test/*.[ch] ./src/test/*/*.[ch] ./src/tools/*.[ch]
python3 ./scripts/maint/practracker/includes.py
(warning) problem file-size /src/app/config/or_options_st.h 1121
(warning) problem function-size /src/feature/dirparse/microdesc_parse.c:microdescs_parse_from_string() 171
(warning) problem file-size /src/feature/hs/hs_service.c 4132
(warning) problem function-size /src/feature/rend/rendmid.c:rend_mid_establish_intro_legacy() 105
(warning) problem file-size /src/feature/rend/rendservice.c 4522
(warning) problem function-size /src/feature/rend/rendservice.c:rend_service_receive_introduction() 334
./scripts/maint/checkShellScripts.sh
./scripts/maint/checkShellScripts.sh: Install shellcheck to check shell scripts.
make[1]: Leaving directory '/hdd/programming/cpp/tor'
```