### PR TITLE
Use strtod, not atof, for parsing doubles in the configuration.

### DIFF
--- a/changes/ticket31475
+++ b/changes/ticket31475
@@ -1,0 +1,5 @@
+  o Minor bugfixes (configuration):
+    - Invalid floating-point values in the configuration file are now
+      detected treated as errors in the configuration. Previously, they
+      were ignored and treated as zero. Fixes bug 31475; bugfix on
+      0.0.1.

--- a/src/lib/confmgt/type_defs.c
+++ b/src/lib/confmgt/type_defs.c
@@ -283,9 +283,16 @@ double_parse(void *target, const char *value, char **errmsg,
   (void)params;
   (void)errmsg;
   double *v = (double*)target;
-  // XXXX This is the preexisting behavior, but we should detect errors here.
-  *v = atof(value);
-  return 0;
+  char *endptr=NULL;
+  *v = strtod(value, &endptr);
+  if (endptr == value || *endptr != '\0') {
+    // Either there are no converted characters, or there were some characters
+    // that didn't get converted.
+    tor_asprintf(errmsg, "Could not convert %s to a number.", escaped(value));
+    return -1;
+  } else {
+    return 0;
+  }
 }
 
 static char *

--- a/src/test/test_confparse.c
+++ b/src/test/test_confparse.c
@@ -488,6 +488,8 @@ test_confparse_assign_badval(void *arg)
 static const badval_test_t bv_notint = { "pos X\n", "malformed" };
 static const badval_test_t bv_negint = { "pos -10\n", "out of bounds" };
 static const badval_test_t bv_badu64 = { "u64 u64\n", "malformed" };
+static const badval_test_t bv_dbl1 = { "dbl xxx\n", "Could not convert" };
+static const badval_test_t bv_dbl2 = { "dbl 1.0 xx\n", "Could not convert" };
 static const badval_test_t bv_badcsvi1 =
   { "csv_interval 10 wl\n", "malformed" };
 static const badval_test_t bv_badcsvi2 =
@@ -1045,6 +1047,8 @@ struct testcase_t confparse_tests[] = {
   BADVAL_TEST(notint),
   BADVAL_TEST(negint),
   BADVAL_TEST(badu64),
+  BADVAL_TEST(dbl1),
+  BADVAL_TEST(dbl2),
   BADVAL_TEST(badcsvi1),
   BADVAL_TEST(badcsvi2),
   BADVAL_TEST(nonoption),

--- a/src/test/test_confparse.c
+++ b/src/test/test_confparse.c
@@ -490,6 +490,14 @@ static const badval_test_t bv_negint = { "pos -10\n", "out of bounds" };
 static const badval_test_t bv_badu64 = { "u64 u64\n", "malformed" };
 static const badval_test_t bv_dbl1 = { "dbl xxx\n", "Could not convert" };
 static const badval_test_t bv_dbl2 = { "dbl 1.0 xx\n", "Could not convert" };
+static const badval_test_t bv_dbl3 = {
+   "dbl 1e-10000\n", "too small to express" };
+static const badval_test_t bv_dbl4 = {
+   "dbl 1e1000\n", "too large to express" };
+static const badval_test_t bv_dbl5 = {
+   "dbl -1e-10000\n", "too small to express" };
+static const badval_test_t bv_dbl6 = {
+   "dbl -1e1000\n", "too large to express" };
 static const badval_test_t bv_badcsvi1 =
   { "csv_interval 10 wl\n", "malformed" };
 static const badval_test_t bv_badcsvi2 =
@@ -1049,6 +1057,10 @@ struct testcase_t confparse_tests[] = {
   BADVAL_TEST(badu64),
   BADVAL_TEST(dbl1),
   BADVAL_TEST(dbl2),
+  BADVAL_TEST(dbl3),
+  BADVAL_TEST(dbl4),
+  BADVAL_TEST(dbl5),
+  BADVAL_TEST(dbl6),
   BADVAL_TEST(badcsvi1),
   BADVAL_TEST(badcsvi2),
   BADVAL_TEST(nonoption),


### PR DESCRIPTION
This lets us detect erroneous doubles, which previously we could not
do.

Fixes bug 31475; bugfix on commit 00a9e3732e88, a.k.a svn:r136.