### PR TITLE
hs: ADD_ONION NEW:BEST now defaults to ED25519-V3

### DIFF
--- a/changes/ticket29669
+++ b/changes/ticket29669
@@ -1,0 +1,3 @@
+  o Minor feature (hidden service, control port):
+    - The ADD_ONION key blob keyword "BEST" now defaults from RSA1024 (v2) to
+      ED25519-V3 (v3). Closes ticket 29669.

--- a/src/feature/control/control_cmd.c
+++ b/src/feature/control/control_cmd.c
@@ -1982,8 +1982,7 @@ add_onion_helper_keyarg(const char *arg, int discard_pk,
     *hs_version = HS_VERSION_THREE;
   } else if (!strcasecmp(key_type_new, key_type)) {
     /* "NEW:<Algorithm>" - Generating a new key, blob as algorithm. */
-    if (!strcasecmp(key_type_rsa1024, key_blob) ||
-        !strcasecmp(key_type_best, key_blob)) {
+    if (!strcasecmp(key_type_rsa1024, key_blob)) {
       /* "RSA1024", RSA 1024 bit, also currently "BEST" by default. */
       pk = crypto_pk_new();
       if (crypto_pk_generate_key(pk)) {
@@ -2002,7 +2001,9 @@ add_onion_helper_keyarg(const char *arg, int discard_pk,
       }
       decoded_key->v2 = pk;
       *hs_version = HS_VERSION_TWO;
-    } else if (!strcasecmp(key_type_ed25519_v3, key_blob)) {
+    } else if (!strcasecmp(key_type_ed25519_v3, key_blob) ||
+               !strcasecmp(key_type_best, key_blob)) {
+      /* "ED25519-V3", ed25519 key, also currently "BEST" by default. */
       ed25519_secret_key_t *sk = tor_malloc_zero(sizeof(*sk));
       if (ed25519_secret_key_generate(sk, 1) < 0) {
         tor_free(sk);

--- a/src/test/test_controller.c
+++ b/src/test/test_controller.c
@@ -243,8 +243,22 @@ test_add_onion_helper_keyarg_v3(void *arg)
   tor_free(pk.v3); pk.v3 = NULL;
   tor_free(key_new_blob);
 
+  /* Test "BEST" key generation (Assumes BEST = ED25519-V3). */
+  tor_free(pk.v3); pk.v3 = NULL;
+  tor_free(key_new_blob);
+  ret = add_onion_helper_keyarg("NEW:BEST", 0, &key_new_alg, &key_new_blob,
+                                &pk, &hs_version, NULL);
+  tt_int_op(ret, OP_EQ, 0);
+  tt_int_op(hs_version, OP_EQ, HS_VERSION_THREE);
+  tt_assert(pk.v3);
+  tt_str_op(key_new_alg, OP_EQ, "ED25519-V3");
+  tt_assert(key_new_blob);
+  tt_ptr_op(reply_str, OP_EQ, NULL);
+
   /* Test discarding the private key. */
   tor_free(reply_str);
+  tor_free(pk.v3); pk.v3 = NULL;
+  tor_free(key_new_blob);
   ret = add_onion_helper_keyarg("NEW:ED25519-V3", 1, &key_new_alg,
                                 &key_new_blob, &pk, &hs_version,
                                 NULL);
@@ -323,22 +337,10 @@ test_add_onion_helper_keyarg_v2(void *arg)
   tt_assert(key_new_blob);
   tt_ptr_op(reply_str, OP_EQ, NULL);
 
-  /* Test "BEST" key generation (Assumes BEST = RSA1024). */
-  crypto_pk_free(pk.v2); pk.v2 = NULL;
-  tor_free(key_new_blob);
-  ret = add_onion_helper_keyarg("NEW:BEST", 0, &key_new_alg, &key_new_blob,
-                                &pk, &hs_version, NULL);
-  tt_int_op(ret, OP_EQ, 0);
-  tt_int_op(hs_version, OP_EQ, HS_VERSION_TWO);
-  tt_assert(pk.v2);
-  tt_str_op(key_new_alg, OP_EQ, "RSA1024");
-  tt_assert(key_new_blob);
-  tt_ptr_op(reply_str, OP_EQ, NULL);
-
   /* Test discarding the private key. */
   crypto_pk_free(pk.v2); pk.v2 = NULL;
   tor_free(key_new_blob);
-  ret = add_onion_helper_keyarg("NEW:BEST", 1, &key_new_alg, &key_new_blob,
+  ret = add_onion_helper_keyarg("NEW:RSA1024", 1, &key_new_alg, &key_new_blob,
                                &pk, &hs_version, NULL);
   tt_int_op(ret, OP_EQ, 0);
   tt_int_op(hs_version, OP_EQ, HS_VERSION_TWO);


### PR DESCRIPTION
From RSA1024 (v2) to v3 now.

Closes #29669

Signed-off-by: David Goulet <dgoulet@torproject.org>