### PR TITLE
Treat an unexpected constant-sized VERSIONS cell as a PROTOCOL_WARN.

### DIFF
--- a/changes/bug31107
+++ b/changes/bug31107
@@ -1,0 +1,4 @@
+  o Minor bugfixes (logging, protocol violations):
+    - Do not log a nonfatal assertion failure when receiving a VERSIONS
+      cell on a connection using the obsolete v1 link protocol. Log a
+      protocol_warn instead. Fixes bug 31107; bugfix on 0.2.4.4-alpha.

--- a/src/or/channeltls.c
+++ b/src/or/channeltls.c
@@ -1098,7 +1098,15 @@ channel_tls_handle_cell(cell_t *cell, or_connection_t *conn)
       /* do nothing */
       break;
     case CELL_VERSIONS:
-      tor_fragile_assert();
+      /* A VERSIONS cell should always be a variable-length cell, and
+       * so should never reach this function (which handles constant-sized
+       * cells). But if the connection is using the (obsolete) v1 link
+       * protocol, all cells will be treated as constant-sized, and so
+       * it's possible we'll reach this code.
+       */
+      log_fn(LOG_PROTOCOL_WARN, LD_CHANNEL,
+             "Received unexpected VERSIONS cell on a channel using link "
+             "protocol %d; ignoring.", conn->link_proto);
       break;
     case CELL_NETINFO:
       ++stats_n_netinfo_cells_processed;


### PR DESCRIPTION
We previously used tor_fragile_assert() to declare that this case
could not happen: VERSIONS cells are always supposed to be
variable-sized, right?

This is incorrect, though.  On a v1 link protocol connection, all
cells are fixed-sized.  There aren't supposed to be any VERSIONS
cells with this version of the protocol, but apparently, somebody
was messing up.  (The v1 link protocol is obsolete, so probably the
implementer responsible didn't mean to be using it.)

Fixes bug 31107.  Bugfix on 0.2.4.4-alpha, when we introduced a
tor_fragile_assert() for this case.