### PR TITLE
Disable -Wextra-semi when not using clang.

### DIFF
--- a/changes/bug31769
+++ b/changes/bug31769
@@ -1,0 +1,4 @@
+  o Minor bugfixes (compilation):
+    - Remove the "-Wextra-semi" flag from our builds when using GCC: only
+      clang supports it for C, and recent versions of GCC have started to warn
+      about it. Fixes bug 31769; bugfix on 0.2.9.1-alpha.

--- a/configure.ac
+++ b/configure.ac
@@ -1737,7 +1737,6 @@ if test "x$enable_gcc_warnings_advisory" != "xno"; then
      -Wexplicit-ownership-type
      -Wextern-initializer
      -Wextra
-     -Wextra-semi
      -Wextra-tokens
      -Wflexible-array-extensions
      -Wfloat-conversion
@@ -1883,6 +1882,12 @@ if test "x$enable_gcc_warnings_advisory" != "xno"; then
      -Wvla-extension
      -Wzero-length-array
   ], [ TOR_CHECK_CFLAGS([warning_flag]) ])
+
+  if test "$have_clang" = 1; then
+    # Only check this flag on Clang.  GCC has it now, but generates a
+    # warning if we use it in C.  Thanks, GCC!
+    TOR_CHECK_CFLAGS([-Wextra-semi])
+  fi
 
 dnl    We should re-enable this in some later version.  Clang doesn't
 dnl    mind, but it causes trouble with GCC.


### PR DESCRIPTION
GCC 9.2.1 is apparently planning to add a version of this flag, but
it produces a warning when you use it with C code.

Fixes bug 31769; bugfix on 0.2.9.1-alpha.