### PR TITLE
Correct the syntax description for the MAPADDRESS command.

### DIFF
--- a/changes/ticket31772
+++ b/changes/ticket31772
@@ -1,0 +1,4 @@
+  o Minor bugfixes (controller protocol):
+    - Fix the MAPADDRESS controller command to accept one or more
+      arguments. Previously, it required two or more arguments, and ignored
+      the first. Fixes bug 31772; bugfix on 0.4.1.1-alpha.

--- a/src/feature/control/control_cmd.c
+++ b/src/feature/control/control_cmd.c
@@ -639,7 +639,9 @@ address_is_invalid_mapaddress_target(const char *addr)
 }
 
 static const control_cmd_syntax_t mapaddress_syntax = {
-  .max_args=1,
+  // no positional arguments are expected
+  .max_args=0,
+  // an arbitrary number of K=V entries are supported.
   .accept_keywords=true,
 };
 


### PR DESCRIPTION
In 0.4.1.1-alpha I introduced a bug where we would require and
ignore a single positional argument.

Fixes bug 31772.