### PR TITLE
Add a rate-limit to our warning about the disabled .exit notation

### DIFF
--- a/changes/ticket31466
+++ b/changes/ticket31466
@@ -1,0 +1,5 @@
+  o Minor bugfixes (logging):
+    - Rate-limit our the logging message about the obsolete .exit notation.
+      Previously, there was no limit on this warning, which could potentially
+      be triggered many times by a hostile website. Fixes bug 31466;
+      bugfix on 0.2.2.1-alpha.

--- a/src/or/connection_edge.c
+++ b/src/or/connection_edge.c
@@ -1186,9 +1186,11 @@ connection_ap_handshake_rewrite(entry_connection_t *conn,
    * disallowed when they're coming straight from the client, but you're
    * allowed to have them in MapAddress commands and so forth. */
   if (!strcmpend(socks->address, ".exit") && !options->AllowDotExit) {
-    log_warn(LD_APP, "The  \".exit\" notation is disabled in Tor due to "
-             "security risks. Set AllowDotExit in your torrc to enable "
-             "it (at your own risk).");
+    static ratelim_t exit_warning_limit = RATELIM_INIT(60*15);
+    log_fn_ratelim(&exit_warning_limit, LOG_WARN, LD_APP,
+                   "The  \".exit\" notation is disabled in Tor due to "
+                   "security risks.  Set AllowDotExit in your torrc to enable "
+                   "it (at your own risk).");
     control_event_client_status(LOG_WARN, "SOCKS_BAD_HOSTNAME HOSTNAME=%s",
                                 escaped(socks->address));
     out->end_reason = END_STREAM_REASON_TORPROTOCOL;


### PR DESCRIPTION
This warning would previously be given every time we tried to open a
connection to a foo.exit address, which could potentially be used to
flood the logs.  Now, we don't allow this warning to appear more
than once every 15 minutes.

Fixes bug 31466; bugfix on 0.2.2.1-alpha, when .exit was first
deprecated.