### PR TITLE
Fix bug when %including folder with comment only files. #31408

### DIFF
--- a/changes/bug31408
+++ b/changes/bug31408
@@ -1,4 +1,5 @@
   o Major bugfixes (torrc):
-    - Fix configuration files in a %included folder containing a 
-      configuration file with only comments or whitespace being
-      ignored. Fixes bug 31408; bugfix on 0.4.0.5.
+    - Stop ignoring torrc options after an %include directive, when the
+      included directory ends with a file that does not contain any config
+      options. (But does contain comments or whitespace.)
+      Fixes bug 31408; bugfix on 0.3.1.1-alpha.

--- a/changes/bug31408
+++ b/changes/bug31408
@@ -1,0 +1,4 @@
+  o Major bugfixes (torrc):
+    - Fix configuration files in a %included folder containing a 
+      configuration file with only comments or whitespace being
+      ignored. Fixes bug 31408; bugfix on 0.4.0.5.

--- a/src/lib/fs/conffile.c
+++ b/src/lib/fs/conffile.c
@@ -153,16 +153,18 @@ config_process_include(const char *path, int recursion_level, int extended,
   int rv = -1;
   SMARTLIST_FOREACH_BEGIN(config_files, const char *, config_file) {
     config_line_t *included_config = NULL;
+    config_line_t *included_config_last = NULL;
     if (config_get_included_config(config_file, recursion_level, extended,
-                                   &included_config, list_last,
+                                   &included_config, &included_config_last,
                                    opened_lst) < 0) {
       goto done;
     }
 
     *next = included_config;
-    if (*list_last)
-      next = &(*list_last)->next;
-
+    if (included_config_last) {
+      next = &included_config_last->next;
+      *list_last = included_config_last;
+    }
   } SMARTLIST_FOREACH_END(config_file);
   *list = ret_list;
   rv = 0;


### PR DESCRIPTION
When processing a %included folder, a bug caused the pointer to
the last element of the options list to be set to NULL when
processing a file with only comments or whitepace. This could
cause options from other files on the same folder to be
discarded depending on the lines after the affected %include.