### PR TITLE
Try using make -k in Travis configuration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,8 +15,10 @@ os:
 ## OS and compiler.
 env:
   global:
-    ## The Travis CI environment allows us two cores, so let's use both.
-    - MAKEFLAGS="-j 2"
+    ## The Travis CI environment allows us two cores, so let's use both.  Also,
+    ## let's use the "-k" flag so that we get all of the compilation failures,
+    ## not just the first one.
+    - MAKEFLAGS="-k -j 2"
     ## We turn on hardening by default
     ## Also known as --enable-fragile-hardening in 0.3.0.3-alpha and later
     - HARDENING_OPTIONS="--enable-expensive-hardening"

--- a/changes/ticket31372_travis
+++ b/changes/ticket31372_travis
@@ -1,0 +1,4 @@
+  o Minor features (continuous integration):
+    - When building on Travis, pass the "-k" flag to make, so that
+      we are informed of all compilation failures, not just the first
+      one or two. Closes part of ticket 31372.


### PR DESCRIPTION
Frequently, when a patch fails, it has failures in several files.
Using the "-k" flag will let us learn all the compilation errors,
not just the first one that the compiler hits.

Based on a patch by rl1987.