### PR TITLE
configure: Explain --disable-module-dirauth better

### DIFF
--- a/changes/bug31825
+++ b/changes/bug31825
@@ -1,0 +1,3 @@
+  o Minor bugfixes (modules):
+    - Explain what the optional Directory Authority module is, and what
+      happens when it is disabled. Fixes bug 31825; bugfix on 0.3.4.1-alpha.

--- a/configure.ac
+++ b/configure.ac
@@ -251,7 +251,7 @@ m4_define(MODULES, dirauth)
 dnl Directory Authority module.
 AC_ARG_ENABLE([module-dirauth],
               AS_HELP_STRING([--disable-module-dirauth],
-                             [Do not build tor with the dirauth module]),
+                             [Build tor without the Directory Authority module: tor can not run as an authority]),
               [], dnl Action if-given
               AC_DEFINE([HAVE_MODULE_DIRAUTH], [1],
                         [Compile with Directory Authority feature support]))


### PR DESCRIPTION
Explain what the optional Directory Authority module is, and what
happens when it is disabled.

Fixes bug 31825; bugfix on 0.3.4.1-alpha.