### PR TITLE
test/logging: Use SEVERITY_MASK_IDX() to find the LOG_ERR mask index

### DIFF
--- a/changes/bug31334
+++ b/changes/bug31334
@@ -1,0 +1,4 @@
+  o Code simplification and refactoring:
+    - Use SEVERITY_MASK_IDX() to find the LOG_* mask indexes in the unit
+      tests and fuzzers, rather than using hard-coded values.
+      Closes ticket 31334.

--- a/src/lib/log/log.c
+++ b/src/lib/log/log.c
@@ -55,10 +55,6 @@
 #include <android/log.h>
 #endif // HAVE_ANDROID_LOG_H.
 
-/** Given a severity, yields an index into log_severity_list_t.masks to use
- * for that severity. */
-#define SEVERITY_MASK_IDX(sev) ((sev) - LOG_ERR)
-
 /** @{ */
 /** The string we stick at the end of a log message when it is too long,
  * and its length. */

--- a/src/lib/log/log.h
+++ b/src/lib/log/log.h
@@ -297,4 +297,10 @@ MOCK_DECL(STATIC void, logv, (int severity, log_domain_mask_t domain,
     va_list ap) CHECK_PRINTF(5,0));
 #endif
 
+#if defined(LOG_PRIVATE) || defined(TOR_UNIT_TESTS)
+/** Given a severity, yields an index into log_severity_list_t.masks to use
+ * for that severity. */
+#define SEVERITY_MASK_IDX(sev) ((sev) - LOG_ERR)
+#endif
+
 #endif /* !defined(TOR_TORLOG_H) */

--- a/src/test/fuzz/fuzzing_common.c
+++ b/src/test/fuzz/fuzzing_common.c
@@ -167,7 +167,7 @@ main(int argc, char **argv)
     memset(&s, 0, sizeof(s));
     set_log_severity_config(loglevel, LOG_ERR, &s);
     /* ALWAYS log bug warnings. */
-    s.masks[LOG_WARN-LOG_ERR] |= LD_BUG;
+    s.masks[SEVERITY_MASK_IDX(LOG_WARN)] |= LD_BUG;
     add_stream_log(&s, "", fileno(stdout));
   }
 

--- a/src/test/test_logging.c
+++ b/src/test/test_logging.c
@@ -35,7 +35,7 @@ test_get_sigsafe_err_fds(void *arg)
 
   set_log_severity_config(LOG_WARN, LOG_ERR, &include_bug);
   set_log_severity_config(LOG_WARN, LOG_ERR, &no_bug);
-  no_bug.masks[0] &= ~(LD_BUG|LD_GENERAL);
+  no_bug.masks[SEVERITY_MASK_IDX(LOG_ERR)] &= ~(LD_BUG|LD_GENERAL);
   set_log_severity_config(LOG_INFO, LOG_NOTICE, &no_bug2);
 
   /* Add some logs; make sure the output is as expected. */

--- a/src/test/test_options.c
+++ b/src/test/test_options.c
@@ -54,9 +54,9 @@ setup_log_callback(void)
 {
   log_severity_list_t lst;
   memset(&lst, 0, sizeof(lst));
-  lst.masks[LOG_ERR - LOG_ERR] = ~0;
-  lst.masks[LOG_WARN - LOG_ERR] = ~0;
-  lst.masks[LOG_NOTICE - LOG_ERR] = ~0;
+  lst.masks[SEVERITY_MASK_IDX(LOG_ERR)] = ~0;
+  lst.masks[SEVERITY_MASK_IDX(LOG_WARN)] = ~0;
+  lst.masks[SEVERITY_MASK_IDX(LOG_NOTICE)] = ~0;
   add_callback_log(&lst, log_cback);
   mark_logs_temp();
 }

--- a/src/test/testing_common.c
+++ b/src/test/testing_common.c
@@ -295,7 +295,7 @@ main(int c, const char **v)
     memset(&s, 0, sizeof(s));
     set_log_severity_config(loglevel, LOG_ERR, &s);
     /* ALWAYS log bug warnings. */
-    s.masks[LOG_WARN-LOG_ERR] |= LD_BUG;
+    s.masks[SEVERITY_MASK_IDX(LOG_WARN)] |= LD_BUG;
     add_stream_log(&s, "", fileno(stdout));
   }
   {
@@ -303,7 +303,7 @@ main(int c, const char **v)
     log_severity_list_t s;
     memset(&s, 0, sizeof(s));
     set_log_severity_config(LOG_ERR, LOG_ERR, &s);
-    s.masks[LOG_WARN-LOG_ERR] |= LD_BUG;
+    s.masks[SEVERITY_MASK_IDX(LOG_WARN)] |= LD_BUG;
     add_callback_log(&s, log_callback_failure);
   }
   flush_log_messages_from_startup();


### PR DESCRIPTION
Move SEVERITY_MASK_IDX() to log.h private/unit tests section, so that
we can use it in log.c and the unit tests.

Fixes bug 31334; bugfix on 0.2.5.2-alpha.