### PR TITLE
[#31810] Handle errors from execve() in the Unix process backend more gracefully.

### DIFF
--- a/changes/bug31810
+++ b/changes/bug31810
@@ -1,0 +1,4 @@
+  o Minor bugfixes (process management):
+    - Remove assertion in the Unix process backend. This assertion would trigger
+      when a new process is spawned where the executable is not found leading to
+      a stack trace from the child process. Fixes bug 31810; bugfix on 0.4.0.1-alpha.

--- a/src/lib/process/process_unix.c
+++ b/src/lib/process/process_unix.c
@@ -255,18 +255,13 @@ process_unix_exec(process_t *process)
     /* Call the requested program. */
     retval = execve(argv[0], argv, env->unixoid_environment_block);
 
-    /* If we made it here it is because execve failed :-( */
-    if (-1 == retval)
-      fprintf(stderr, "Call to execve() failed: %s", strerror(errno));
-
+    /* LCOV_EXCL_START */
     tor_free(argv);
     process_environment_free(env);
 
-    tor_assert_unreached();
-
  error:
-    /* LCOV_EXCL_START */
-    fprintf(stderr, "Error from child process: %s", strerror(errno));
+    fprintf(stderr, "Error from child process: %s\n", strerror(errno));
+
     _exit(1);
     /* LCOV_EXCL_STOP */
   }

--- a/src/lib/process/process_win32.c
+++ b/src/lib/process/process_win32.c
@@ -234,6 +234,9 @@ process_win32_exec(process_t *process)
     CloseHandle(stdin_pipe_read);
     CloseHandle(stdin_pipe_write);
 
+    /* Notify our process to ensure the exit handler is called. */
+    process_notify_event_exit(process, 0);
+
     return PROCESS_STATUS_ERROR;
   }
 

--- a/src/test/test_process_slow.c
+++ b/src/test/test_process_slow.c
@@ -328,8 +328,36 @@ test_callbacks_terminate(void *arg)
   process_free(process);
 }
 
+static void
+test_bogus_path_callbacks(void *arg)
+{
+  (void)arg;
+
+  /* Process callback data. */
+  process_data_t *process_data = process_data_new();
+
+  /* Setup our process. */
+  process_t *process = process_new("does-not-exist");
+  process_set_data(process, process_data);
+  process_set_exit_callback(process, process_exit_callback);
+
+  /* Run our process. */
+  process_exec(process);
+
+  /* Start our main loop. */
+  run_main_loop(process_data);
+
+  /* Check if we did exit. */
+  tt_assert(process_data->did_exit);
+
+ done:
+  process_data_free(process_data);
+  process_free(process);
+}
+
 struct testcase_t slow_process_tests[] = {
   { "callbacks", test_callbacks, 0, NULL, NULL },
   { "callbacks_terminate", test_callbacks_terminate, 0, NULL, NULL },
+  { "bogus_path_exit_callbacks", test_bogus_path_callbacks, 0, NULL, NULL},
   END_OF_TESTCASES
 };


### PR DESCRIPTION
This patch removes a call to tor_assert_unreached() after execve()
failed. This assertion leads to the child process emitting a stack trace
on its output, which makes the error harder for the user to demystify,
since they think it is an internal error in Tor instead of "just" being
a "no such file or directory" error.

See: https://bugs.torproject.org/31810