### PR TITLE
test: Avoid a map_anon_nofork test failure on SunOS

### DIFF
--- a/changes/bug31897
+++ b/changes/bug31897
@@ -1,0 +1,3 @@
+  o Minor bugfixes (tests, SunOS):
+    - Avoid a map_anon_nofork test failure due to a signed/unsigned integer
+      comparison. Fixes bug 31897; bugfix on 0.4.1.1-alpha.

--- a/src/test/test_util.c
+++ b/src/test/test_util.c
@@ -6190,7 +6190,7 @@ test_util_map_anon_nofork(void *arg)
   tor_munmap_anonymous(ptr, sz);
   ptr = tor_mmap_anonymous(sz, ANONMAP_NOINHERIT, &inherit);
   tt_ptr_op(ptr, OP_NE, 0);
-  memset(ptr, TEST_VALUE, sz);
+  memset(ptr, (uint8_t)TEST_VALUE, sz);
 
   tt_int_op(0, OP_EQ, pipe(pipefd));
   pid_t child = fork();

--- a/src/test/test_util.c
+++ b/src/test/test_util.c
@@ -6182,6 +6182,7 @@ test_util_map_anon_nofork(void *arg)
    * crash, or send zero. */
 
   char *ptr = NULL;
+  const char TEST_VALUE = 0xd0;
   size_t sz = 16384;
   int pipefd[2] = {-1, -1};
   unsigned inherit=0;
@@ -6189,7 +6190,7 @@ test_util_map_anon_nofork(void *arg)
   tor_munmap_anonymous(ptr, sz);
   ptr = tor_mmap_anonymous(sz, ANONMAP_NOINHERIT, &inherit);
   tt_ptr_op(ptr, OP_NE, 0);
-  memset(ptr, 0xd0, sz);
+  memset(ptr, TEST_VALUE, sz);
 
   tt_int_op(0, OP_EQ, pipe(pipefd));
   pid_t child = fork();
@@ -6220,7 +6221,7 @@ test_util_map_anon_nofork(void *arg)
     // noinherit isn't implemented.
     tt_int_op(inherit, OP_EQ, INHERIT_RES_KEEP);
     tt_int_op((int)r, OP_EQ, 1); // child should send us a byte.
-    tt_int_op(buf[0], OP_EQ, 0xd0); // that byte should what we set it to.
+    tt_int_op(buf[0], OP_EQ, TEST_VALUE); // that byte should be TEST_VALUE.
   }
 
   int ws;


### PR DESCRIPTION
This test failure happened due to a signed/unsigned integer
comparison.

This bug occurred on SunOS, it may also occur on other systems that
use signed char as the default. (And cast 1-byte integer constants
to an unsigned integer.)

Fixes bug 31897; bugfix on 0.4.1.1-alpha.