### PR TITLE
Appveyor: Avoid spurious errors in Appveyor CI builds

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -100,6 +100,18 @@ test_script:
 
 on_finish:
 - ps: >-
+    <# if we failed before install:, these functions won't be defined #>
+    Function Execute-Command ($commandPath)
+    {
+        & $commandPath $args 2>&1
+        if ( $LastExitCode -ne 0 ) {
+            $host.SetShouldExit( $LastExitCode )
+        }
+    }
+    Function Execute-Bash ()
+    {
+        Execute-Command 'c:\msys64\usr\bin\bash' '-e' '-c' $args
+    }
     if ($env:compiler -eq "mingw") {
             <# use the MSYS2 user binaries to archive failures #>
             $oldpath = ${env:Path} -split ';'

--- a/changes/bug31884
+++ b/changes/bug31884
@@ -1,0 +1,3 @@
+  o Minor bugfixes (Appveyor CI):
+    - Avoid spurious errors when Appveyor CI fails before the install step.
+      Fixes bug 31884; bugfix on 0.3.4.2-alpha.


### PR DESCRIPTION
When Appveyor fails before the install step, some of the finish step's
functions were not defined.

Fixes bug 31884; bugfix on 0.3.4.2-alpha.