### PR TITLE
kist: Set scheduler interval to 2msec for clients

### DIFF
--- a/changes/ticket29427
+++ b/changes/ticket29427
@@ -1,0 +1,7 @@
+  o Major bugfixes (cell scheduler, KIST):
+    - Only for clients (which includes onion services), set the KIST cell
+      scheduler interval to 2msec instead of 10msece which is the default
+      value for relays. Client are often single socket so this change will
+      make them not sleep even though data could be sent on the wire. This is
+      a partial fix to a bigger architectural problem. Fixes bug 29427; bugfix
+      on 0.3.2.2-alpha.

--- a/src/core/or/scheduler.h
+++ b/src/core/or/scheduler.h
@@ -101,8 +101,14 @@ typedef struct scheduler_s {
  * These are variables/constants that all of Tor should be able to see.
  *****************************************************************************/
 
-/* Default interval that KIST runs (in ms). */
-#define KIST_SCHED_RUN_INTERVAL_DEFAULT 10
+/* Default interval that KIST runs (in ms). Client and relays have different
+ * values due to bug detailled in #29427. We still kep an initialization value
+ * but it gets overwritten as soon as options are parsed or a consensus is
+ * loaded/received. */
+#define KIST_SCHED_RUN_INTERVAL_CLIENT_DEFAULT 2
+#define KIST_SCHED_RUN_INTERVAL_RELAY_DEFAULT  10
+#define KIST_SCHED_RUN_INTERVAL_DEFAULT_INIT   10
+
 /* Minimum interval that KIST runs. This value disables KIST. */
 #define KIST_SCHED_RUN_INTERVAL_MIN 0
 /* Maximum interval that KIST runs (in ms). */


### PR DESCRIPTION
KIST cell scheduler is called if at least one cell is put on a circuit queue.
A fullscheduler run might not handle all cells because it depends on the
available space in the TCP buffer for the socket. What KIST does at the moment
is reschedule itself in 10ms (static value), the KISTSchedRunInterval
parameter. This is done so we can properly handle priority between circuits
with this grace period (mostly loud vs quiet circuits).

The problem is that if tor has very few sockets to handle, like most Tor
clients they have a single connection to their Guard, then it process that
what it can (usually in couple msec) and then sleep for the remaining time.

That remaining time would be between 8 and 9 msec doing nothing even though
bytes might be ready to be sent.

This caps a tor client to a maximum of ~3MB/sec (experimental results) instead
of being able to push much more if needed, let say a bulk download.

With this, we are bringing down the cell scheduler interval _only_ for clients
to 2msec. Relays stay on 10msec because they handle a large amount of sockets
and thus there is no starvation on that side.

This is really a bandaid to #29427 but there is a wider architectural problem
with that ticket so we are not closing it with this commit.

Part of #29427.

Signed-off-by: David Goulet <dgoulet@torproject.org>