### PR TITLE
tls: Log TLS read buffer length bugs once

### DIFF
--- a/changes/bug31939
+++ b/changes/bug31939
@@ -1,0 +1,3 @@
+  o Minor bugfixes (tls, logging):
+    - Log TLS read buffer length bugs once, rather than filling the logs
+      with similar warnings. Fixes bug 31939; bugfix on 0.3.0.4-rc.

--- a/src/lib/tls/buffers_tls.c
+++ b/src/lib/tls/buffers_tls.c
@@ -68,9 +68,9 @@ buf_read_from_tls(buf_t *buf, tor_tls_t *tls, size_t at_most)
 
   check_no_tls_errors();
 
-  if (BUG(buf->datalen >= INT_MAX))
+  IF_BUG_ONCE(buf->datalen >= INT_MAX)
     return -1;
-  if (BUG(buf->datalen >= INT_MAX - at_most))
+  IF_BUG_ONCE(buf->datalen >= INT_MAX - at_most)
     return -1;
 
   while (at_most > total_read) {


### PR DESCRIPTION
Rather than filling the logs with similar warnings.

Fixes bug 31939; bugfix on 0.3.0.4-rc.