### PR TITLE
[0.4.0] Remove overly strict assertions in transports.c.

### DIFF
--- a/changes/ticket31091
+++ b/changes/ticket31091
@@ -1,0 +1,3 @@
+  o Minor bugfixes (pluggable transports):
+    - Remove overly strict assertions that triggers when a pluggable transport
+      is spawned in an unsuccessful manner. Fixes bug 31091; bugfix on 0.4.0.1-alpha.

--- a/src/feature/client/transports.c
+++ b/src/feature/client/transports.c
@@ -1826,15 +1826,13 @@ managed_proxy_stdout_callback(process_t *process,
 
   managed_proxy_t *mp = process_get_data(process);
 
-  if (BUG(mp == NULL))
+  if (mp == NULL)
     return;
 
   handle_proxy_line(line, mp);
 
-  if (proxy_configuration_finished(mp)) {
+  if (proxy_configuration_finished(mp))
     handle_finished_proxy(mp);
-    tor_assert(mp->conf_state == PT_PROTO_COMPLETED);
-  }
 }
 
 /** Callback function that is called when our PT process have data on its


### PR DESCRIPTION
This patch removes an overly strict tor_assert() and an ignorable BUG()
expression. Both of these would trigger if a PT was unable to configure
itself during startup. The easy way to trigger this is to configure an
obfs4 bridge where you make the obfs4 process try to bind on a port
number under 1024.

See: https://bugs.torproject.org/31091