### PR TITLE
Bug 32058: mainloop: set periodic events as disabled while disconnecting them

### DIFF
--- a/src/core/mainloop/periodic.c
+++ b/src/core/mainloop/periodic.c
@@ -155,6 +155,7 @@ periodic_event_disconnect(periodic_event_item_t *event)
     return;
   mainloop_event_free(event->ev);
   event->last_action_time = 0;
+  event->enabled = 0;
 }
 
 /** Enable the given event by setting its "enabled" flag and scheduling it to


### PR DESCRIPTION
This PR fixes an issue we've been having in our project that embeds Tor using the `tor_api.h` interface: we realized that Tor would run fine the first time it's started, but then it would refuse to restart after a clean shutdown.

The issue can be reproduced with the following example:

<details>
  <summary>Source code</summary>
  
  ```c
#include <stdio.h>

#include <tor_api.h>

void run() {
    tor_main_configuration_t* tor_conf = tor_main_configuration_new();

    char* argv_conf[17];
    argv_conf[0] = "tor";
    argv_conf[1] = "__DisableSignalHandlers";
    argv_conf[2] = "1";
    argv_conf[3] = "SafeSocks";
    argv_conf[4] = "1";
    argv_conf[5] = "SocksPort";
    argv_conf[6] = "9050";
    argv_conf[7] = "NoExec";
    argv_conf[8] = "1";
    argv_conf[9] = "HashedControlPassword";
    argv_conf[10] = "16:51A310CE8FE1E06360CBB0B49DED70C261EA1EB103BFEBBFFC22BDA5F2";
    argv_conf[11] = "ControlPort";
    argv_conf[12] = "9051";
    argv_conf[13] = "DataDirectory";
    argv_conf[14] = "/tmp/tor-datadir";
    argv_conf[15] = "Log";
    argv_conf[16] = "notice stderr";

    int conf_res
        = tor_main_configuration_set_command_line(tor_conf, 17, argv_conf);
 
    tor_run_main(tor_conf);
    tor_main_configuration_free(tor_conf);
}

int main() {
    fprintf(stdout, "Starting first time...\n");
    run();
    fprintf(stdout, "Tor finished\n");

    fprintf(stdout, "Starting second time...\n");
    run();
    fprintf(stdout, "Tor finished\n");

    return 0;
}
  ```
  
</details>

The hashed hard-coded password is "password".

The first time it's started, Tor bootstraps without any issues. After a `SIGNAL SHUTDOWN` is sent on the control port, Tor will shutdown cleanly and then immediately restart. At this point Tor will sit there and do nothing. It's not frozen because it answers on the control port: for instance, while it's in that state, a `GETINFO status/bootstrap-phase` will immediately return the current bootstrap phase (0%).

After some debugging, we realized that some periodic events are `static`, and after the first run they would keep the `enabled` flag set to `1`. Thus, during the next mainloop initialization, they would not be connected since they looked like they already were.

This PR simply sets them back to `enabled = 0` when they are disconnected.

I'm not particularly familiar with Tor's codebase, so feel free to close this PR or suggest changes if you think there could be a better way to fix it.