### PR TITLE
Ticket31882  move Android build config into core tor 

### DIFF
--- a/changes/ticket31882
+++ b/changes/ticket31882
@@ -1,2 +1,7 @@
   o Minor feature (configure, build system):
     - The standard __ANDROID__ macro is now used for platform detection.
+    - --enable-android provides the standard, minimal build configuration
+      for creating Tor binaries to run either as a shared library or a daemon.
+      It enables PIC, disables system torrc, systemd, and all doc generation.
+      This flag is not required to build for Android.
+      Closes ticket 31882.

--- a/changes/ticket31882
+++ b/changes/ticket31882
@@ -1,0 +1,2 @@
+  o Minor feature (configure, build system):
+    - The standard __ANDROID__ macro is now used for platform detection.

--- a/configure.ac
+++ b/configure.ac
@@ -97,6 +97,20 @@ else
             [Defined if we're building with OpenSSL or LibreSSL])
 fi
 
+dnl Enable minimal, standard Android build
+AC_ARG_ENABLE(android,
+     AS_HELP_STRING(--enable-android, [setup build for Android exeutable/shared library]))
+
+if test "x$enable_android" = "xyes"; then
+  asciidoc=false
+  enable_html_manual=no
+  enable_manpage=no
+  enable_pic=yes
+  enable_system_torrc=no
+  enable_tool_name_check=no
+  have_systemd=no
+fi
+
 if test "$enable_static_tor" = "yes"; then
   enable_static_libevent="yes";
   enable_static_openssl="yes";
@@ -126,7 +140,7 @@ AC_ARG_ENABLE(asciidoc,
         "yes") asciidoc=true ;;
         "no")  asciidoc=false ;;
         *) AC_MSG_ERROR(bad value for --disable-asciidoc) ;;
-      esac], [asciidoc=true])
+      esac], [test "x$asciidoc" = "xtrue" && asciidoc=true])
 
 # systemd notify support
 AC_ARG_ENABLE(systemd,
@@ -236,19 +250,12 @@ if test x$enable_event_tracing_debug = xyes; then
   AC_DEFINE([TOR_EVENT_TRACING_ENABLED], [1], [Compile the event tracing instrumentation])
 fi
 
-dnl Enable Android only features.
-AC_ARG_ENABLE(android,
-     AS_HELP_STRING(--enable-android, [build with Android features enabled]))
-AM_CONDITIONAL([USE_ANDROID], [test "x$enable_android" = "xyes"])
-
-if test "x$enable_android" = "xyes"; then
-  AC_DEFINE([USE_ANDROID], [1], [Compile with Android specific features enabled])
-
-  dnl Check if the Android log library is available.
-  AC_CHECK_HEADERS([android/log.h])
-  AC_SEARCH_LIBS(__android_log_write, [log])
-
-fi
+dnl Enable Android only standard libs
+case "$host" in
+    *android*)
+	AC_CHECK_LIB([log], [__android_log_write], [LIBS="-llog $LIBS"])
+	;;
+esac
 
 dnl ---
 dnl Tor modules options. These options are namespaced with --disable-module-XXX

--- a/doc/HACKING/android/Simpleperf.md
+++ b/doc/HACKING/android/Simpleperf.md
@@ -85,8 +85,7 @@ was spend on the call.
   found in the `app_data` directory. The `torrc` can be found in the `app_bin/`
   directory.
 
-- You can enable logging in Tor via the syslog (or android) log
-  mechanism with:
+- You can enable logging to Android's logcat using the syslog mechanism:
 
       $ adb shell
       (device):/ $ run-as org.torproject.android

--- a/doc/tor.1.txt
+++ b/doc/tor.1.txt
@@ -661,9 +661,10 @@ GENERAL OPTIONS
     every NUM seconds on open connections that are in use. (Default: 5 minutes)
 
 [[Log]] **Log** __minSeverity__[-__maxSeverity__] **stderr**|**stdout**|**syslog**::
+
     Send all messages between __minSeverity__ and __maxSeverity__ to the standard
-    output stream, the standard error stream, or to the system log. (The
-    "syslog" value is only supported on Unix.) Recognized severity levels are
+    output stream, the standard error stream, or to the system log. (The "syslog"
+    value is not supported Windows or iOS). Recognized severity levels are
     debug, info, notice, warn, and err. We advise using "notice" in most cases,
     since anything more verbose may provide sensitive information to an
     attacker who obtains the logs. If only one severity level is given, all
@@ -675,8 +676,13 @@ GENERAL OPTIONS
     Signal-safe logs are always sent to stderr or stdout. They are also sent to
     a limited number of log files that are configured to log messages at error
     severity from the bug or general domains. They are never sent as syslogs,
-    android logs, control port log events, or to any API-based log
-    destinations.
+    Android logcat messages, control port log events, or to any API-based log
+    destinations. +
+ +
+    If tor is running as a shared library on Android, only "syslog" is available.
+    Native code have "stderr" and "stdout" piped to /dev/null by the Android OS.
+    Early errors like port conflicts with **ControlPort**, **SocksPort**, etc. will
+    not be logged, since the logging is added later.
 
 [[Log2]] **Log** __minSeverity__[-__maxSeverity__] **file** __FILENAME__::
     As above, but send log messages to the listed filename. The

--- a/src/app/config/config.c
+++ b/src/app/config/config.c
@@ -5805,14 +5805,14 @@ options_init_logs(const or_options_t *old_options, or_options_t *options,
       }
 
       if (!strcasecmp(smartlist_get(elts, 0), "android")) {
-#ifdef HAVE_ANDROID_LOG_H
+#ifdef __ANDROID__
         if (!validate_only) {
           add_android_log(severity, options->AndroidIdentityTag);
         }
 #else
         log_warn(LD_CONFIG, "Android logging is not supported"
                             " on this system. Sorry.");
-#endif /* defined(HAVE_ANDROID_LOG_H) */
+#endif /* defined(__ANDROID__) */
         goto cleanup;
       }
     }

--- a/src/lib/log/log.c
+++ b/src/lib/log/log.c
@@ -51,9 +51,9 @@
 #include "lib/fdio/fdio.h"
 #include "lib/cc/ctassert.h"
 
-#ifdef HAVE_ANDROID_LOG_H
+#ifdef __ANDROID__
 #include <android/log.h>
-#endif // HAVE_ANDROID_LOG_H.
+#endif // __ANDROID__
 
 /** @{ */
 /** The string we stick at the end of a log message when it is too long,
@@ -126,7 +126,7 @@ should_log_function_name(log_domain_mask_t domain, int severity)
   }
 }
 
-#ifdef HAVE_ANDROID_LOG_H
+#ifdef __ANDROID__
 /** Helper function to convert Tor's log severity into the matching
  * Android log priority.
  */
@@ -151,7 +151,7 @@ severity_to_android_log_priority(int severity)
       // LCOV_EXCL_STOP
   }
 }
-#endif /* defined(HAVE_ANDROID_LOG_H) */
+#endif /* defined(__ANDROID__) */
 
 /** A mutex to guard changes to logfiles and logging. */
 static tor_mutex_t log_mutex;
@@ -538,10 +538,10 @@ logfile_deliver(logfile_t *lf, const char *buf, size_t msg_len,
 #endif /* defined(MAXLINE) */
 #endif /* defined(HAVE_SYSLOG_H) */
   } else if (lf->is_android) {
-#ifdef HAVE_ANDROID_LOG_H
+#ifdef __ANDROID__
     int priority = severity_to_android_log_priority(severity);
     __android_log_write(priority, lf->android_tag, msg_after_prefix);
-#endif // HAVE_ANDROID_LOG_H.
+#endif // __ANDROID__
   } else if (lf->callback) {
     if (domain & LD_NOCB) {
       if (!*callbacks_deferred && pending_cb_messages) {
@@ -1265,7 +1265,7 @@ add_syslog_log(const log_severity_list_t *severity,
 }
 #endif /* defined(HAVE_SYSLOG_H) */
 
-#ifdef HAVE_ANDROID_LOG_H
+#ifdef __ANDROID__
 /**
  * Add a log handler to send messages to the Android platform log facility.
  */
@@ -1296,7 +1296,7 @@ add_android_log(const log_severity_list_t *severity,
   UNLOCK_LOGS();
   return 0;
 }
-#endif /* defined(HAVE_ANDROID_LOG_H) */
+#endif /* defined(__ANDROID__) */
 
 /** If <b>level</b> is a valid log severity, return the corresponding
  * numeric value.  Otherwise, return -1. */

--- a/src/lib/log/log.h
+++ b/src/lib/log/log.h
@@ -175,10 +175,10 @@ MOCK_DECL(int, add_file_log,(const log_severity_list_t *severity,
 int add_syslog_log(const log_severity_list_t *severity,
                    const char* syslog_identity_tag);
 #endif // HAVE_SYSLOG_H.
-#ifdef HAVE_ANDROID_LOG_H
+#ifdef __ANDROID__
 int add_android_log(const log_severity_list_t *severity,
                     const char *android_identity_tag);
-#endif // HAVE_ANDROID_LOG_H.
+#endif // __ANDROID__.
 int add_callback_log(const log_severity_list_t *severity, log_callback cb);
 typedef void (*pending_callback_callback)(void);
 void logs_set_pending_callback_callback(pending_callback_callback cb);


### PR DESCRIPTION
Guardian Project has maintained a wrapper build system for building tor for Android since the beginning. Since many more people are now building tor for Android, I'm working to upstream as much of that as possible. The goal is that the requirements for building on Android can be fulfilled by tor's own configure.ac.

full discussion here:
https://trac.torproject.org/projects/tor/ticket/31882

The GitLab-CI jobs are run here to show that `./configure` still works everywhere:
https://gitlab.com/eighthave/tor/pipelines/88974591

The extended _.gitlab-ci.yml_ additions can easily be handled separately from this pull request, as needed.

@n8fr8 @grote @akwizgran @yaronyg