### PR TITLE
mainloop: Disable periodic events before a destroy

### DIFF
--- a/changes/ticket32058
+++ b/changes/ticket32058
@@ -1,0 +1,5 @@
+  o Minor bugfixes (mainloop, periodic events):
+    - Periodic events enabled flag was not unset properly when shutting down tor
+      cleanly. This had the side effect to not re-enable periodic events when
+      tor_api.h is used to relaunch tor after a shutdown. Fixes bug 32058;
+      bugfix on 0.3.3.1-alpha.

--- a/src/core/mainloop/mainloop.c
+++ b/src/core/mainloop/mainloop.c
@@ -1580,6 +1580,7 @@ teardown_periodic_events(void)
 {
   int i;
   for (i = 0; periodic_events[i].name; ++i) {
+    periodic_event_disable(&periodic_events[i]);
     periodic_event_destroy(&periodic_events[i]);
   }
   periodic_events_initialized = 0;


### PR DESCRIPTION
When tearing down all periodic events during shutdown, disable them first so
their enable flag is updated.

This allows the tor_api.h to relaunch tor properly after a clean shutdown.

Fixes #32058

Signed-off-by: David Goulet <dgoulet@torproject.org>