### PR TITLE
Make doc/doxygen before running doxygen.

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -238,7 +238,7 @@ dist-rpm: dist-gzip
 
 .PHONY: doxygen
 doxygen: Doxyfile
-	doxygen
+	mkdir -p doc/doxygen && doxygen
 
 test: all
 	$(top_builddir)/src/test/test

--- a/changes/ticket32113
+++ b/changes/ticket32113
@@ -1,0 +1,3 @@
+  o Minor features (doxygen):
+    - "make doxygen" now works with out-of-tree builds. Closes ticket
+      32113.


### PR DESCRIPTION
This makes out-of-tree doxygen builds work.

Closes ticket 32113.