### PR TITLE
#31147: Sanity checks for tor_vasprintf().

### DIFF
--- a/changes/31147
+++ b/changes/31147
@@ -1,0 +1,3 @@
+  o Minor features (defense in depth):
+    - Add additional sanity checks around tor_vasprintf() usage in case the
+      function returns an error. Patch by Tobias Stoeckmann. Fixes ticket 31147.

--- a/src/feature/control/control_events.c
+++ b/src/feature/control/control_events.c
@@ -1653,7 +1653,10 @@ control_event_status(int type, int severity, const char *format, va_list args)
     log_warn(LD_BUG, "Format string too long.");
     return -1;
   }
-  tor_vasprintf(&user_buf, format, args);
+  if (tor_vasprintf(&user_buf, format, args)<0) {
+    log_warn(LD_BUG, "Failed to create user buffer.");
+    return -1;
+  }
 
   send_control_event(type,  "%s %s\r\n", format_buf, user_buf);
   tor_free(user_buf);

--- a/src/lib/buf/buffers.c
+++ b/src/lib/buf/buffers.c
@@ -578,6 +578,7 @@ buf_add_vprintf(buf_t *buf, const char *format, va_list args)
   /* XXXX Faster implementations are easy enough, but let's optimize later */
   char *tmp;
   tor_vasprintf(&tmp, format, args);
+  tor_assert(tmp != NULL);
   buf_add(buf, tmp, strlen(tmp));
   tor_free(tmp);
 }

--- a/src/lib/process/process.c
+++ b/src/lib/process/process.c
@@ -550,6 +550,7 @@ process_vprintf(process_t *process,
   char *data;
 
   size = tor_vasprintf(&data, format, args);
+  tor_assert(data != NULL);
   process_write(process, (uint8_t *)data, size);
   tor_free(data);
 }


### PR DESCRIPTION
Add extra sanity checks around tor_vasprintf().