### PR TITLE
Subsystem thread initialization and cleanup in all threads

### DIFF
--- a/src/app/main/main.c
+++ b/src/app/main/main.c
@@ -1274,6 +1274,7 @@ tor_run_main(const tor_main_configuration_t *tor_cfg)
 #endif
 
   subsystems_init();
+  subsystems_thread_init();
 
   init_protocol_warning_severity_level();
 

--- a/src/app/main/shutdown.c
+++ b/src/app/main/shutdown.c
@@ -158,6 +158,7 @@ tor_free_all(int postfork)
     release_lockfile();
   }
 
+  subsystems_thread_cleanup();
   subsystems_shutdown();
 
   /* Stuff in util.c and address.c*/

--- a/src/app/main/subsysmgr.c
+++ b/src/app/main/subsysmgr.c
@@ -231,6 +231,27 @@ subsystems_postfork(void)
 }
 
 /**
+ * Run thread-init code on all subsystems that declare any
+ **/
+void
+subsystems_thread_init(void)
+{
+  check_and_setup();
+
+  for (int i = (int)n_tor_subsystems - 1; i >= 0; --i) {
+    const subsys_fns_t *sys = tor_subsystems[i];
+    if (!sys->supported)
+      continue;
+    if (! sys_initialized[i])
+      continue;
+    if (sys->thread_init) {
+      log_debug(LD_GENERAL, "Thread init: %s", sys->name);
+      sys->thread_init();
+    }
+  }
+}
+
+/**
  * Run thread-cleanup code on all subsystems that declare any
  **/
 void

--- a/src/app/main/subsysmgr.c
+++ b/src/app/main/subsysmgr.c
@@ -238,7 +238,7 @@ subsystems_thread_init(void)
 {
   check_and_setup();
 
-  for (int i = (int)n_tor_subsystems - 1; i >= 0; --i) {
+  for (unsigned i = 0; i < n_tor_subsystems; ++i) {
     const subsys_fns_t *sys = tor_subsystems[i];
     if (!sys->supported)
       continue;

--- a/src/app/main/subsysmgr.h
+++ b/src/app/main/subsysmgr.h
@@ -24,6 +24,7 @@ void subsystems_shutdown_downto(int level);
 
 void subsystems_prefork(void);
 void subsystems_postfork(void);
+void subsystems_thread_init(void);
 void subsystems_thread_cleanup(void);
 
 #endif /* !defined(TOR_SUBSYSMGR_T) */

--- a/src/app/main/tor_threads.c
+++ b/src/app/main/tor_threads.c
@@ -1,0 +1,43 @@
+/* Copyright (c) 2003-2004, Roger Dingledine
+ * Copyright (c) 2004-2006, Roger Dingledine, Nick Mathewson.
+ * Copyright (c) 2007-2019, The Tor Project, Inc. */
+/* See LICENSE for licensing information */
+
+#include "app/main/tor_threads.h"
+
+#include "lib/thread/threads.h"
+#include "app/main/subsysmgr.h"
+
+/** Wraps a void (*)(void*) function and its argument so we can
+ * invoke them with proper subsystem thread management.
+ */
+typedef struct tor_thread_helper_info_t {
+  void (*func)(void *);
+  void *data;
+} tor_thread_helper_info_t;
+
+static void tor_thread_helper(void *_info) ATTR_NORETURN;
+
+static void
+tor_thread_helper(void *_info)
+{
+  tor_thread_helper_info_t *info = _info;
+  void (*func)(void*) = info->func;
+  void *data = info->data;
+  tor_free(_info);
+
+  subsystems_thread_init();
+  func(data);
+  subsystems_thread_cleanup();
+  spawn_exit();
+}
+
+int
+start_tor_thread(void (*func)(void *), void *data)
+{
+  tor_thread_helper_info_t *d = tor_malloc(sizeof(tor_thread_helper_info_t));
+  d->func = func;
+  d->data = data;
+
+  return spawn_func(tor_thread_helper, d);
+}

--- a/src/app/main/tor_threads.h
+++ b/src/app/main/tor_threads.h
@@ -1,0 +1,11 @@
+/* Copyright (c) 2003-2004, Roger Dingledine
+ * Copyright (c) 2004-2006, Roger Dingledine, Nick Mathewson.
+ * Copyright (c) 2007-2019, The Tor Project, Inc. */
+/* See LICENSE for licensing information */
+
+#ifndef TOR_APP_THREADS_H
+#define TOR_APP_THREADS_H
+
+int start_tor_thread(void (*func)(void *), void *data);
+
+#endif /* !defined(TOR_APP_THREADS_H) */

--- a/src/core/include.am
+++ b/src/core/include.am
@@ -14,6 +14,7 @@ LIBTOR_APP_A_SOURCES = 				\
 	src/app/main/shutdown.c			\
 	src/app/main/subsystem_list.c		\
 	src/app/main/subsysmgr.c		\
+	src/app/main/tor_threads.c		\
 	src/core/crypto/hs_ntor.c		\
 	src/core/crypto/onion_crypto.c		\
 	src/core/crypto/onion_fast.c		\
@@ -220,6 +221,7 @@ noinst_HEADERS +=					\
 	src/app/main/ntmain.h				\
 	src/app/main/shutdown.h 			\
 	src/app/main/subsysmgr.h			\
+	src/app/main/tor_threads.h			\
 	src/core/crypto/hs_ntor.h			\
 	src/core/crypto/onion_crypto.h	        	\
 	src/core/crypto/onion_fast.h			\

--- a/src/core/mainloop/cpuworker.c
+++ b/src/core/mainloop/cpuworker.c
@@ -33,6 +33,7 @@
 #include "lib/evloop/workqueue.h"
 #include "core/crypto/onion_crypto.h"
 #include "lib/thread/threads.h"
+#include "app/main/tor_threads.h"
 
 #include "core/or/or_circuit_st.h"
 
@@ -99,7 +100,7 @@ cpu_init(void)
                                 worker_state_new,
                                 worker_state_free_void,
                                 NULL,
-                                spawn_func);
+                                start_tor_thread);
 
     int r = threadpool_register_reply_event(threadpool, NULL);
 

--- a/src/core/mainloop/cpuworker.c
+++ b/src/core/mainloop/cpuworker.c
@@ -32,6 +32,7 @@
 #include "feature/relay/router.h"
 #include "lib/evloop/workqueue.h"
 #include "core/crypto/onion_crypto.h"
+#include "lib/thread/threads.h"
 
 #include "core/or/or_circuit_st.h"
 
@@ -97,7 +98,8 @@ cpu_init(void)
                                 replyqueue,
                                 worker_state_new,
                                 worker_state_free_void,
-                                NULL);
+                                NULL,
+                                spawn_func);
 
     int r = threadpool_register_reply_event(threadpool, NULL);
 

--- a/src/lib/evloop/workqueue.h
+++ b/src/lib/evloop/workqueue.h
@@ -57,7 +57,8 @@ threadpool_t *threadpool_new(int n_threads,
                              replyqueue_t *replyqueue,
                              void *(*new_thread_state_fn)(void*),
                              void (*free_thread_state_fn)(void*),
-                             void *arg);
+                             void *arg,
+                             int (*thread_spawn_fn)(void (*func)(void *), void *data));
 replyqueue_t *threadpool_get_replyqueue(threadpool_t *tp);
 
 replyqueue_t *replyqueue_new(uint32_t alertsocks_flags);

--- a/src/lib/evloop/workqueue.h
+++ b/src/lib/evloop/workqueue.h
@@ -58,7 +58,8 @@ threadpool_t *threadpool_new(int n_threads,
                              void *(*new_thread_state_fn)(void*),
                              void (*free_thread_state_fn)(void*),
                              void *arg,
-                             int (*thread_spawn_fn)(void (*func)(void *), void *data));
+                             int (*thread_spawn_fn)
+                                 (void (*func)(void *), void *data));
 replyqueue_t *threadpool_get_replyqueue(threadpool_t *tp);
 
 replyqueue_t *replyqueue_new(uint32_t alertsocks_flags);

--- a/src/lib/subsys/subsys.h
+++ b/src/lib/subsys/subsys.h
@@ -71,6 +71,12 @@ typedef struct subsys_fns_t {
   void (*postfork)(void);
 
   /**
+   * Initialize any thread-local resources held by this subsystem. Called
+   * after the subsystem's global components are initialized.
+   */
+  void (*thread_init)(void);
+
+  /**
    * Free any thread-local resources held by this subsystem. Called before
    * the thread exits.
    */

--- a/src/test/test_workqueue.c
+++ b/src/test/test_workqueue.c
@@ -405,7 +405,7 @@ main(int argc, char **argv)
 
   tor_assert(rq);
   tp = threadpool_new(opt_n_threads,
-                      rq, new_state, free_state, NULL);
+                      rq, new_state, free_state, NULL, spawn_func);
   tor_assert(tp);
 
   crypto_seed_weak_rng(&weak_rng);


### PR DESCRIPTION
This fixes [ticket \#32103](https://trac.torproject.org/projects/tor/ticket/32103). It extends the threadpool to accept a custom thread spawn function. This allows us to use our own spawn function which calls `subsystems_thread_cleanup` and the new `subsystems_thread_init`. It also calls `spawn_exit`, which negates the need for #1412. Finally the above two functions are called in the main thread before `subsystems_shutdown` and after `subsystems_init` respectively.