### PR TITLE
mainloop: Disable periodic events before a destroy

### DIFF
--- a/changes/ticket32058
+++ b/changes/ticket32058
@@ -1,0 +1,5 @@
+  o Minor bugfixes (mainloop, periodic events):
+    - Periodic events enabled flag was not unset properly when shutting down tor
+      cleanly. This had the side effect to not re-enable periodic events when
+      tor_api.h is used to relaunch tor after a shutdown. Fixes bug 32058;
+      bugfix on 0.3.3.1-alpha.

--- a/src/core/mainloop/periodic.c
+++ b/src/core/mainloop/periodic.c
@@ -137,6 +137,11 @@ periodic_event_destroy(periodic_event_item_t *event)
 {
   if (!event)
     return;
+
+  /* First disable the event so we first cancel the event and set its enabled
+   * flag properly. */
+  periodic_event_disable(event);
+
   mainloop_event_free(event->ev);
   event->last_action_time = 0;
 }


### PR DESCRIPTION
When tearing down all periodic events during shutdown, disable them first so
their enable flag is updated.

This allows the tor_api.h to relaunch tor properly after a clean shutdown.

Fixes #32058

Signed-off-by: David Goulet <dgoulet@torproject.org>