### PR TITLE
Appveyor: Use Windows Server 2019

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -6,8 +6,8 @@ clone_depth: 50
 # But we compile using MinGW, not Visual Studio.
 # We use these images because they have different Windows versions.
 image:
-  # Windows Server 2016
-  - Visual Studio 2017
+  # Windows Server 2019
+  - Visual Studio 2019
   # Windows Server 2012 R2
   - Visual Studio 2015
 
@@ -28,11 +28,11 @@ environment:
 matrix:
   # Don't keep building failing jobs
   fast_finish: true
-  # Skip the 32-bit Windows Server 2016 job, and the 64-bit Windows Server
+  # Skip the 32-bit Windows Server 2019 job, and the 64-bit Windows Server
   # 2012 R2 job, to speed up the build.
   # The environment variables must be listed without the 'environment' tag.
   exclude:
-    - image: Visual Studio 2017
+    - image: Visual Studio 2019
       target: i686-w64-mingw32
       compiler_path: mingw32
       mingw_prefix: mingw-w64-i686


### PR DESCRIPTION
Instead of Windows Server 2016.

Closes ticket 32086.