### PR TITLE
Ticket32172: port test suite to Android to run in emulator

### DIFF
--- a/src/test/testing_common.c
+++ b/src/test/testing_common.c
@@ -89,6 +89,22 @@ setup_directory(void)
                  (int)getpid(), rnd32);
     r = mkdir(temp_dir);
   }
+#elif defined(__ANDROID__)
+  /* tor might not like the default perms, so create a subdir */
+  tor_snprintf(temp_dir, sizeof(temp_dir),
+               "/data/local/tmp/tor_%d_%d_%s",
+               (int) getuid(), (int) getpid(), rnd32);
+  r = mkdir(temp_dir, 6770);
+  if (r) {
+    fprintf(stderr, "Can't create directory %s:", temp_dir);
+    perror("");
+    exit(1);
+  }
+  tor_snprintf(temp_dir, sizeof(temp_dir),
+               "/data/local/tmp/tor_%d_%d_%s/test_%d_%d_%s",
+               (int) getuid(), (int) getpid(), rnd32,
+               (int) getuid(), (int) getpid(), rnd32);
+  r = mkdir(temp_dir, 6770);
 #else /* !defined(_WIN32) */
   tor_snprintf(temp_dir, sizeof(temp_dir), "/tmp/tor_test_%d_%s",
                (int) getpid(), rnd32);


### PR DESCRIPTION
* there is no /tmp on Android, there is /data/local/tmp for root and the shell user
* no use in testing the user ID stuff, Android apps cannot ever change users, and it was failing

https://trac.torproject.org/projects/tor/ticket/32172

Once the GitLab-CI setup from  !1408 is merged, then I'll submit the final work for running these tests in the Android emulator in GitLab-CI.  That should be portable to Travis-CI as well.

@n8fr8 