### PR TITLE
#32108: respect accountingmax during soft hibernation [0.4.0]

### DIFF
--- a/changes/bug32108
+++ b/changes/bug32108
@@ -1,0 +1,8 @@
+  o Major bugfixes (relay):
+    - Relays now respect their AccountingMax bandwidth again. When relays
+      entered "soft" hibernation (which typically starts when we've hit
+      90% of our AccountingMax), we had stopped checking whether we should
+      enter hard hibernation. Soft hibernation refuses new connections and
+      new circuits, but the existing circuits can continue, meaning that
+      relays could have exceeded their configured AccountingMax. Fixes
+      bug 32108; bugfix on 0.4.0.1-alpha.

--- a/src/core/mainloop/mainloop.c
+++ b/src/core/mainloop/mainloop.c
@@ -1397,7 +1397,7 @@ STATIC periodic_event_item_t periodic_events[] = {
   /* This is a legacy catch-all callback that runs once per second if
    * we are online and active. */
   CALLBACK(second_elapsed, NET_PARTICIPANT,
-           FL(NEED_NET)|FL(RUN_ON_DISABLE)),
+           FL(RUN_ON_DISABLE)),
 
   /* XXXX Do we have a reason to do this on a callback? Does it do any good at
    * all?  For now, if we're dormant, we can let our listeners decay. */


### PR DESCRIPTION
Relays now respect their AccountingMax bandwidth again. When relays
entered "soft" hibernation (which typically starts when we've hit
90% of our AccountingMax), we had stopped checking whether we should
enter hard hibernation. Soft hibernation refuses new connections and
new circuits, but the existing circuits can continue, meaning that
relays could have exceeded their configured AccountingMax.

This commit rolls back some of the cpu-saving fixes, where we tried
to avoid calling so many of our events while we're off the network.

That's because PERIODIC_EVENT_FLAG_NEED_NET checks net_is_disabled(),
which returns true even if we're only in soft hibernation.

Fixes bug 32108; bugfix on 0.4.0.1-alpha.