### PR TITLE
#32165: use args to count_usable_descriptors() correctly [0.4.2]

### DIFF
--- a/changes/bug32165
+++ b/changes/bug32165
@@ -1,0 +1,5 @@
+  o Minor bugfixes (logging):
+    - When starting up without cached microdescriptors, stop mistakenly
+      printing out "The current consensus has no exit nodes. Tor can only
+      build internal paths, such as paths to onion services." Fixes bug
+      32165; bugfix on 0.2.6.2-alpha.

--- a/src/feature/nodelist/nodelist.c
+++ b/src/feature/nodelist/nodelist.c
@@ -2461,8 +2461,8 @@ compute_frac_paths_available(const networkstatus_t *consensus,
   log_debug(LD_NET,
             "%s: %d present, %d usable",
             "mid",
-            np,
-            nu);
+            *num_present_out,
+            *num_usable_out);
 
   if (options->EntryNodes) {
     count_usable_descriptors(&np, &nu, guards, consensus, now,

--- a/src/feature/nodelist/nodelist.c
+++ b/src/feature/nodelist/nodelist.c
@@ -2449,9 +2449,9 @@ compute_frac_paths_available(const networkstatus_t *consensus,
   smartlist_t *exits  = smartlist_new();
   double f_guard, f_mid, f_exit;
   double f_path = 0.0;
-  /* Used to determine whether there are any exits in the consensus */
-  int np = 0;
   /* Used to determine whether there are any exits with descriptors */
+  int np = 0;
+  /* Used to determine whether there are any exits with in the consensus */
   int nu = 0;
   const int authdir = authdir_mode_v3(options);
 
@@ -2501,7 +2501,7 @@ compute_frac_paths_available(const networkstatus_t *consensus,
    * building exit paths */
   /* Update our understanding of whether the consensus has exits */
   consensus_path_type_t old_have_consensus_path = have_consensus_path;
-  have_consensus_path = ((np > 0) ?
+  have_consensus_path = ((nu > 0) ?
                          CONSENSUS_PATH_EXIT :
                          CONSENSUS_PATH_INTERNAL);
 


### PR DESCRIPTION
When starting up without cached microdescriptors, stop mistakenly
printing out "The current consensus has no exit nodes. Tor can only
build internal paths, such as paths to onion services."

We were mixing up "present", i.e. listed in the descriptor, with "usable",
i.e. able to be used by us right now. (Yes they are terrible names;
we should fix that in a future commit.)

Fixes bug 32165; bugfix on 0.2.6.2-alpha.