### PR TITLE
Travis: Disable all but one macOS build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -39,8 +39,9 @@ matrix:
     ## We include a single coverage build with the best options for coverage
     - env: COVERAGE_OPTIONS="--enable-coverage" HARDENING_OPTIONS=""
     ## We run chutney on macOS, because macOS Travis has IPv6
-    - env: CHUTNEY="yes" CHUTNEY_ALLOW_FAILURES="2" SKIP_MAKE_CHECK="yes"
-      os: osx
+    # Disabled due to slow Travis macOS builds, see #32177
+    #- env: CHUTNEY="yes" CHUTNEY_ALLOW_FAILURES="2" SKIP_MAKE_CHECK="yes"
+    #  os: osx
 
   ## Allow the build to report success (with non-required sub-builds
   ## continuing to run) if all required sub-builds have succeeded.

--- a/changes/ticket32177
+++ b/changes/ticket32177
@@ -1,0 +1,3 @@
+  o Testing:
+    - Disable all but one Travis CI macOS build, to mitigate slow scheduling
+      of Travis macOS jobs. Closes ticket 32177.


### PR DESCRIPTION
We need to mitigate slow scheduling of Travis macOS jobs.

Closes ticket 32177.