### PR TITLE
Travis: Use zstd in our Travis Linux builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -103,8 +103,7 @@ addons:
       - libnss3-dev
       - libscrypt-dev
       - libseccomp-dev
-      ## zstd doesn't exist in Ubuntu Trusty
-      #- libzstd
+      - libzstd-dev
       ## Conditional build dependencies
       ## Always installed, so we don't need sudo
       - asciidoc

--- a/changes/ticket32242
+++ b/changes/ticket32242
@@ -1,0 +1,2 @@
+  o Testing (continuous integration):
+    - Use zstd in our Travis Linux builds. Closes ticket 32242.


### PR DESCRIPTION
Recent Ubuntu versions have zstd >= 1.1, which is an optional tor build
dependency.

Closes ticket 32242.