### PR TITLE
test_options: Use 64-bit comparisons when checking domain masks.

### DIFF
--- a/src/test/test_options.c
+++ b/src/test/test_options.c
@@ -4006,9 +4006,9 @@ test_options_init_logs_quiet(void *arg)
   tt_assert(a);
   tt_assert(a->stream);
   tt_int_op(a->fd, OP_EQ, fileno(stdout));
-  tt_int_op(a->sev.masks[LOG_INFO-LOG_ERR], OP_EQ, 0);
-  tt_int_op(a->sev.masks[LOG_NOTICE-LOG_ERR], OP_EQ, 0);
-  tt_int_op(a->sev.masks[LOG_WARN-LOG_ERR], OP_EQ, LD_ALL_DOMAINS);
+  tt_u64_op(a->sev.masks[LOG_INFO-LOG_ERR], OP_EQ, 0);
+  tt_u64_op(a->sev.masks[LOG_NOTICE-LOG_ERR], OP_EQ, 0);
+  tt_u64_op(a->sev.masks[LOG_WARN-LOG_ERR], OP_EQ, LD_ALL_DOMAINS);
   clear_added_logs();
 
   quiet_level = QUIET_NONE;
@@ -4019,9 +4019,9 @@ test_options_init_logs_quiet(void *arg)
   tt_assert(a);
   tt_assert(a->stream);
   tt_int_op(a->fd, OP_EQ, fileno(stdout));
-  tt_int_op(a->sev.masks[LOG_INFO-LOG_ERR], OP_EQ, 0);
-  tt_int_op(a->sev.masks[LOG_NOTICE-LOG_ERR], OP_EQ, LD_ALL_DOMAINS);
-  tt_int_op(a->sev.masks[LOG_WARN-LOG_ERR], OP_EQ, LD_ALL_DOMAINS);
+  tt_u64_op(a->sev.masks[LOG_INFO-LOG_ERR], OP_EQ, 0);
+  tt_u64_op(a->sev.masks[LOG_NOTICE-LOG_ERR], OP_EQ, LD_ALL_DOMAINS);
+  tt_u64_op(a->sev.masks[LOG_WARN-LOG_ERR], OP_EQ, LD_ALL_DOMAINS);
   clear_added_logs();
 
   /* Make sure that adding a configured log makes the default logs go away. */
@@ -4035,9 +4035,9 @@ test_options_init_logs_quiet(void *arg)
   tt_assert(a);
   tt_assert(! a->stream);
   tt_int_op(a->fd, OP_NE, fileno(stdout));
-  tt_int_op(a->sev.masks[LOG_INFO-LOG_ERR], OP_EQ, LD_ALL_DOMAINS);
-  tt_int_op(a->sev.masks[LOG_NOTICE-LOG_ERR], OP_EQ, LD_ALL_DOMAINS);
-  tt_int_op(a->sev.masks[LOG_WARN-LOG_ERR], OP_EQ, LD_ALL_DOMAINS);
+  tt_u64_op(a->sev.masks[LOG_INFO-LOG_ERR], OP_EQ, LD_ALL_DOMAINS);
+  tt_u64_op(a->sev.masks[LOG_NOTICE-LOG_ERR], OP_EQ, LD_ALL_DOMAINS);
+  tt_u64_op(a->sev.masks[LOG_WARN-LOG_ERR], OP_EQ, LD_ALL_DOMAINS);
 
  done:
   free_options_test_data(tdata);


### PR DESCRIPTION
This prevents a warning when building for 32-bit targets.

Fixes bug 32269; bug not in any released Tor.