### PR TITLE
Ticket32178

### DIFF
--- a/changes/ticket32178
+++ b/changes/ticket32178
@@ -1,0 +1,3 @@
+  o Minor bugfixes (logging):
+    - Remove trailing whitespaces from control event log messages. Fixes bug
+      32178; bugfix on 0.1.1.1-alpha.

--- a/src/feature/control/control_events.c
+++ b/src/feature/control/control_events.c
@@ -1318,6 +1318,16 @@ control_event_logmsg(int severity, log_domain_mask_t domain, const char *msg)
       for (cp = b; *cp; ++cp)
         if (*cp == '\r' || *cp == '\n')
           *cp = ' ';
+
+      /* Remove trailing spaces */
+      for (--cp; *cp == ' ' && cp >= b; --cp)
+        *cp = '\0';
+
+      if (cp == b) {
+        ++disable_log_messages;
+        tor_assert_nonfatal(*b);
+        --disable_log_messages;
+      }
     }
     switch (severity) {
       case LOG_DEBUG: s = "DEBUG"; break;


### PR DESCRIPTION
Removes trailing whitespaces from control event log messages. Checks for empty strings.
Closes ticket 32178