### PR TITLE
force pkg-config to only use --prefix when cross-compiling

### DIFF
--- a/changes/ticket32191
+++ b/changes/ticket32191
@@ -1,0 +1,3 @@
+  o Minor features (build system):
+    - force pkg-config to only use --prefix when cross-compiling.
+      Closes ticket 32191.

--- a/configure.ac
+++ b/configure.ac
@@ -39,6 +39,16 @@ else
     pkg_config_user_action="check the PKG_CONFIG_PATH environment variable"
 fi
 
+if test "x$PKG_CONFIG_PATH" = "x" && test "x$prefix" != "xNONE" && test "$host" != "$build"; then
+   export PKG_CONFIG_PATH=$prefix/lib/pkgconfig
+   AC_MSG_NOTICE([set PKG_CONFIG_PATH=$PKG_CONFIG_PATH to support cross-compiling])
+   if test -f "$PKG_CONFIG_PATH/libevent.pc"; then
+       echo "checking for $PKG_CONFIG_PATH/libevent.pc... yes"
+   else
+       AC_MSG_ERROR([$PKG_CONFIG_PATH/libevent.pc not found!])
+   fi
+fi
+
 AC_ARG_ENABLE(openbsd-malloc,
    AS_HELP_STRING(--enable-openbsd-malloc, [use malloc code from OpenBSD.  Linux only. Deprecated: see --with-malloc]))
 AC_ARG_ENABLE(static-openssl,


### PR DESCRIPTION
The current pkg-config setup has no sense of whether it is cross-compiling, so it will detect things on the build system that are not present or are wrong for the host system.  This forces the cross-compiling build to only look for pkg-config .pc files in --prefix.

A version of this has been the setup for many years with the Android builds.

Fixes #32191

Signed-off-by: Hans-Christoph Steiner <hans@eds.org>