### PR TITLE
add FUNDING.yml to link GitHub Sponsor button to donate.torproject.org

### DIFF
--- a/FUNDING.yml
+++ b/FUNDING.yml
@@ -1,0 +1,2 @@
+custom:
+  - https://donate.torproject.org/


### PR DESCRIPTION
GitHub has a big push right now to drive donations to open source projects. This adds the existing Tor donate page as the donation option.  The Sponsor button needs to be enabled in the GitHub settings:
https://help.github.com/en/github/building-a-strong-community/displaying-a-sponsor-button-in-your-repository

Signed-off-by: Hans-Christoph Steiner <hans@eds.org>