### PR TITLE
hs-v2: Lookup intro failure cache when picking an intro from descriptor

### DIFF
--- a/changes/bug25568
+++ b/changes/bug25568
@@ -1,0 +1,5 @@
+  o Minor bugfixes (onion service v2):
+    - When sending the INTRO cell for a v2 Onion Service, look at the failure
+      cache alongside timeout values to check if the intro point is marked
+      as failed. Previously, we only looked at if the relay timeout values.
+      Fixes bug 25568; bugfix on 0.2.7.3-rc. Patch by Neel Chauhan.

--- a/src/feature/rend/rendcache.c
+++ b/src/feature/rend/rendcache.c
@@ -228,6 +228,17 @@ rend_cache_entry_free_void(void *p)
   rend_cache_entry_free_(p);
 }
 
+/** Check if a failure cache entry exists for the given intro point. */
+bool
+rend_cache_intro_failure_exists(const char *service_id,
+                                const uint8_t *intro_identity)
+{
+  tor_assert(service_id);
+  tor_assert(intro_identity);
+
+  return cache_failure_intro_lookup(intro_identity, service_id, NULL);
+}
+
 /** Free all storage held by the service descriptor cache. */
 void
 rend_cache_free_all(void)

--- a/src/feature/rend/rendcache.h
+++ b/src/feature/rend/rendcache.h
@@ -80,6 +80,8 @@ int rend_cache_store_v2_desc_as_client(const char *desc,
                                        rend_cache_entry_t **entry);
 size_t rend_cache_get_total_allocation(void);
 
+bool rend_cache_intro_failure_exists(const char *service_id,
+                                     const uint8_t *intro_identity);
 void rend_cache_intro_failure_note(rend_intro_point_failure_t failure,
                                    const uint8_t *identity,
                                    const char *service_id);


### PR DESCRIPTION
When picking an intro point from the service descriptor, the client failed to
lookup the failure cache.

It made an HS v2 client re-pick bad intro points for which we already know it
won't work in the first place.

Based on Neel Chauhan original patch.

Fixes #25568

Signed-off-by: David Goulet <dgoulet@torproject.org>