### PR TITLE
doxygen: Use @SRCDIR@ instead of @top_srcdir@.

### DIFF
--- a/Doxyfile.in
+++ b/Doxyfile.in
@@ -256,7 +256,7 @@ TAB_SIZE               = 8
 
 ALIASES                =
 
-ALIASES += refdir{1}="\ref @top_srcdir@/src/\1 \"\1\""
+ALIASES += refdir{1}="\ref @SRCDIR@/src/\1 \"\1\""
 
 # This tag can be used to specify a number of word-keyword mappings (TCL only).
 # A mapping has the form "name=value". For example adding "class=itcl::class"
@@ -818,7 +818,7 @@ WARN_LOGFILE           =
 # spaces. See also FILE_PATTERNS and EXTENSION_MAPPING
 # Note: If this tag is empty the current directory is searched.
 
-INPUT                  = @top_srcdir@/src/
+INPUT                  = @SRCDIR@/src/
 
 # This tag can be used to specify the character encoding of the source files
 # that doxygen parses. Internally doxygen uses the UTF-8 encoding. Doxygen uses
@@ -860,9 +860,9 @@ RECURSIVE              = YES
 # Note that relative paths are relative to the directory from which doxygen is
 # run.
 
-EXCLUDE                = @top_srcdir@/src/ext \
-                         @top_srcdir@/src/trunnel \
-                         @top_srcdir@/src/test
+EXCLUDE                = @SRCDIR@/src/ext \
+                         @SRCDIR@/src/trunnel \
+                         @SRCDIR@/src/test
 
 # The EXCLUDE_SYMLINKS tag can be used to select whether or not files or
 # directories that are symbolic links (a Unix file system feature) are excluded

--- a/configure.ac
+++ b/configure.ac
@@ -2129,6 +2129,7 @@ if test "x$SRCDIR" = "x"; then
   SRCDIR=$(cd "$srcdir"; pwd)
 fi
 AH_TEMPLATE([SRCDIR],[tor's sourcedir directory])
+AC_SUBST(SRCDIR)
 AC_DEFINE_UNQUOTED(SRCDIR,"$SRCDIR")
 
 if test "x$CONFDIR" = "x"; then


### PR DESCRIPTION
Our @top_srcdir@ directory can contain "..", which confuses doxygen
when it tries to make references to directories.  Using
@abs_top_srcdir@ has the same problem.  Instead, we should use our
@SRCDIR@ configuration variable, which is canonicalized.