### PR TITLE
Another attempt to fix Doxygen references in out-of-tree builds

### DIFF
--- a/Doxyfile.in
+++ b/Doxyfile.in
@@ -61,7 +61,7 @@ PROJECT_LOGO           =
 # entered, it will be relative to the location where doxygen was started. If
 # left blank the current directory will be used.
 
-OUTPUT_DIRECTORY       = @top_builddir@/doc/doxygen
+OUTPUT_DIRECTORY       = @abs_top_builddir@/doc/doxygen
 
 # If the CREATE_SUBDIRS tag is set to YES then doxygen will create 4096 sub-
 # directories (in 2 levels) under the output directory of each output format and
@@ -173,7 +173,7 @@ FULL_PATH_NAMES        = YES
 # will be relative from the directory where doxygen is started.
 # This tag requires that the tag FULL_PATH_NAMES is set to YES.
 
-STRIP_FROM_PATH        = @top_srcdir@/src
+STRIP_FROM_PATH        = ./src
 
 # The STRIP_FROM_INC_PATH tag can be used to strip a user-defined part of the
 # path mentioned in the documentation of a class, which tells the reader which
@@ -256,7 +256,7 @@ TAB_SIZE               = 8
 
 ALIASES                =
 
-ALIASES += refdir{1}="\ref @top_srcdir@/src/\1 \"\1\""
+ALIASES += refdir{1}="\ref ./src/\1 \"\1\""
 
 # This tag can be used to specify a number of word-keyword mappings (TCL only).
 # A mapping has the form "name=value". For example adding "class=itcl::class"
@@ -818,7 +818,7 @@ WARN_LOGFILE           =
 # spaces. See also FILE_PATTERNS and EXTENSION_MAPPING
 # Note: If this tag is empty the current directory is searched.
 
-INPUT                  = @top_srcdir@/src/
+INPUT                  = ./src/
 
 # This tag can be used to specify the character encoding of the source files
 # that doxygen parses. Internally doxygen uses the UTF-8 encoding. Doxygen uses
@@ -860,9 +860,9 @@ RECURSIVE              = YES
 # Note that relative paths are relative to the directory from which doxygen is
 # run.
 
-EXCLUDE                = @top_srcdir@/src/ext \
-                         @top_srcdir@/src/trunnel \
-                         @top_srcdir@/src/test
+EXCLUDE                = ./src/ext \
+                         ./src/trunnel \
+                         ./src/test
 
 # The EXCLUDE_SYMLINKS tag can be used to select whether or not files or
 # directories that are symbolic links (a Unix file system feature) are excluded

--- a/Doxyfile.in
+++ b/Doxyfile.in
@@ -256,7 +256,7 @@ TAB_SIZE               = 8
 
 ALIASES                =
 
-ALIASES += refdir{1}="\ref ./src/\1 \"\1\""
+ALIASES += refdir{1}="\ref src/\1 \"\1\""
 
 # This tag can be used to specify a number of word-keyword mappings (TCL only).
 # A mapping has the form "name=value". For example adding "class=itcl::class"

--- a/Makefile.am
+++ b/Makefile.am
@@ -244,7 +244,8 @@ dist-rpm: dist-gzip
 
 .PHONY: doxygen
 doxygen: Doxyfile
-	mkdir -p doc/doxygen && doxygen
+	mkdir -p doc/doxygen
+	(cd "$(top_srcdir)" && doxygen "$(abs_top_builddir)/Doxyfile")
 
 test: all
 	$(top_builddir)/src/test/test


### PR DESCRIPTION
This time, we're using cd to run doxygen from inside the source
directory, not the build directory at all.  This lets us call the
source directory ".", which (I hope) both Doxygen 1.8.13 and 1.8.15
will understand.

Naturally, this requires a corresponding change in the doxygen
configuration so that we are directing the output to the correct
place.

Fix for 32378.