### PR TITLE
Makefile: Fix "make check-includes" for out-of-tree builds

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -370,7 +370,7 @@ endif
 
 check-includes:
 if USEPYTHON
-	$(PYTHON) $(top_srcdir)/scripts/maint/practracker/includes.py
+	$(PYTHON) $(top_srcdir)/scripts/maint/practracker/includes.py $(top_srcdir)
 endif
 
 check-best-practices:

--- a/changes/bug31335
+++ b/changes/bug31335
@@ -1,0 +1,3 @@
+  o Minor bugfixes (code quality):
+    - Fix "make check-includes" so it runs correctly on out-of-tree builds.
+      Fixes bug 31335; bugfix on 0.3.5.1-alpha.


### PR DESCRIPTION
Previously, it would run on the build tree, which did not contain
any sources.

Fixes bug 31335; bugfix on 0.3.5.1-alpha.