### PR TITLE
configure: Fix variable name typos

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1080,10 +1080,10 @@ dnl Where we do we find lzma?
 AC_ARG_ENABLE(lzma,
       AS_HELP_STRING(--enable-lzma, [enable support for the LZMA compression scheme.]),
       [case "${enableval}" in
-        "yes") lzma=true ;;
-        "no")  lzma=false ;;
+        "yes") ;;
+        "no")  ;;
         * ) AC_MSG_ERROR(bad value for --enable-lzma) ;;
-      esac], [lzma=auto])
+      esac], [enable_lzma=auto])
 
 if test "x$enable_lzma" = "xno"; then
     have_lzma=no;
@@ -1112,10 +1112,10 @@ dnl Where we do we find zstd?
 AC_ARG_ENABLE(zstd,
       AS_HELP_STRING(--enable-zstd, [enable support for the Zstandard compression scheme.]),
       [case "${enableval}" in
-        "yes") zstd=true ;;
-        "no")  zstd=false ;;
+        "yes") ;;
+        "no")  ;;
         * ) AC_MSG_ERROR(bad value for --enable-zstd) ;;
-      esac], [zstd=auto])
+      esac], [enable_zstd=auto])
 
 if test "x$enable_zstd" = "xno"; then
     have_zstd=no;


### PR DESCRIPTION
The "if-present" clause of AC_ARG_ENABLE() sets enable_{lzma,zstd},
so we don't need to set it. The "if-not-present" clause needs to set
enable_{lzma,zstd}, rather than just {lzma,zstd}.

The rest of the script only ever checks for enable_{lzma,zstd} = no,
so these changes do not actually change the behaviour of configure.

Fixes bug 32401.