### PR TITLE
Do not try to shut down the event loop when it is not initialized.

### DIFF
--- a/changes/ticket32407
+++ b/changes/ticket32407
@@ -1,0 +1,4 @@
+  o Minor bugfixes (crash):
+    - When running Tor with an option like --verify-config or --dump-config
+      that does not start the event loop, avoid crashing if we try to exit
+      early because of an error. Fixes bug 32407; bugfix on 0.3.3.1-alpha.

--- a/src/core/mainloop/mainloop.c
+++ b/src/core/mainloop/mainloop.c
@@ -774,6 +774,10 @@ tor_shutdown_event_loop_and_exit(int exitcode)
   main_loop_should_exit = 1;
   main_loop_exit_value = exitcode;
 
+  if (! tor_libevent_is_initialized()) {
+    return; /* No event loop to shut down. */
+  }
+
   /* Die with an assertion failure in ten seconds, if for some reason we don't
    * exit normally. */
   /* XXXX We should consider this code if it's never used. */

--- a/src/lib/evloop/compat_libevent.c
+++ b/src/lib/evloop/compat_libevent.c
@@ -181,6 +181,16 @@ tor_libevent_initialize(tor_libevent_cfg *torcfg)
       event_get_version(), tor_libevent_get_method());
 }
 
+/**
+ * Return true iff the libevent module has been successfully initialized,
+ * and not subsequently shut down.
+ **/
+bool
+tor_libevent_is_initialized(void)
+{
+  return the_event_base != NULL;
+}
+
 /** Return the current Libevent event base that we're set up to use. */
 MOCK_IMPL(struct event_base *,
 tor_libevent_get_base, (void))

--- a/src/lib/evloop/compat_libevent.h
+++ b/src/lib/evloop/compat_libevent.h
@@ -13,6 +13,8 @@
 #include "lib/testsupport/testsupport.h"
 #include "lib/malloc/malloc.h"
 
+#include <stdbool.h>
+
 void configure_libevent_logging(void);
 void suppress_libevent_log_msg(const char *msg);
 
@@ -68,6 +70,7 @@ typedef struct tor_libevent_cfg {
 } tor_libevent_cfg;
 
 void tor_libevent_initialize(tor_libevent_cfg *cfg);
+bool tor_libevent_is_initialized(void);
 MOCK_DECL(struct event_base *, tor_libevent_get_base, (void));
 const char *tor_libevent_get_method(void);
 void tor_check_libevent_header_compatibility(void);


### PR DESCRIPTION
Doing so caused us to crash in some unusual circumstances, such as
using --verify-config to verify a configuration that failed during
the options_act() stage.

Fixes bug 32407; bugfix on 0.3.3.1-alpha.