### PR TITLE
relay: Stop failing on startup when the relay module is disabled

### DIFF
--- a/changes/ticket32410
+++ b/changes/ticket32410
@@ -1,0 +1,3 @@
+  o Minor features (relay):
+    - When the relay module is disabled, make "DirCache 0" the default.
+      Closes ticket 32410.

--- a/src/app/config/config.c
+++ b/src/app/config/config.c
@@ -363,7 +363,13 @@ static const config_var_t option_vars_[] = {
   V(CircuitStreamTimeout,        INTERVAL, "0"),
   V(CircuitPriorityHalflife,     DOUBLE,  "-1.0"), /*negative:'Use default'*/
   V(ClientDNSRejectInternalAddresses, BOOL,"1"),
+#if defined(HAVE_MODULE_RELAY) || defined(TOR_UNIT_TESTS)
+  /* The unit tests expect the ClientOnly default to be 0. */
   V(ClientOnly,                  BOOL,     "0"),
+#else
+  /* We must be a Client if the relay module is disabled. */
+  V(ClientOnly,                  BOOL,     "1"),
+#endif /* defined(HAVE_MODULE_RELAY) || defined(TOR_UNIT_TESTS) */
   V(ClientPreferIPv6ORPort,      AUTOBOOL, "auto"),
   V(ClientPreferIPv6DirPort,     AUTOBOOL, "auto"),
   V(ClientAutoIPv6ORPort,        BOOL,     "0"),
@@ -400,7 +406,13 @@ static const config_var_t option_vars_[] = {
   V(DirPortFrontPage,            FILENAME, NULL),
   VAR("DirReqStatistics",        BOOL,     DirReqStatistics_option, "1"),
   VAR("DirAuthority",            LINELIST, DirAuthorities, NULL),
+#if defined(HAVE_MODULE_RELAY) || defined(TOR_UNIT_TESTS)
+  /* The unit tests expect the DirCache default to be 1. */
   V(DirCache,                    BOOL,     "1"),
+#else
+  /* We can't be a DirCache if the relay module is disabled. */
+  V(DirCache,                    BOOL,     "0"),
+#endif /* defined(HAVE_MODULE_RELAY) || defined(TOR_UNIT_TESTS) */
   /* A DirAuthorityFallbackRate of 0.1 means that 0.5% of clients try an
    * authority when all fallbacks are up, and 2% try an authority when 25% of
    * fallbacks are down. (We rebuild the list when 25% of fallbacks are down).

--- a/src/app/config/or_options_st.h
+++ b/src/app/config/or_options_st.h
@@ -573,7 +573,9 @@ struct or_options_t {
 
   int DirCache; /**< Cache all directory documents and accept requests via
                  * tunnelled dir conns from clients. If 1, enabled (default);
-                 * If 0, disabled. */
+                 * If 0, disabled. Use dir_server_mode() rather than
+                 * referencing this option directly. (Except for routermode
+                 * and relay_config, which do direct checks.) */
 
   char *VirtualAddrNetworkIPv4; /**< Address and mask to hand out for virtual
                                  * MAPADDRESS requests for IPv4 addresses */

--- a/src/feature/relay/relay_config.h
+++ b/src/feature/relay/relay_config.h
@@ -122,9 +122,6 @@ options_validate_relay_mode(const or_options_t *old_options,
     return -1;
   }
 
-  /* 31851 / 29211: Set this option the correct way */
-  options->ClientOnly = 1;
-
   return 0;
 }
 

--- a/src/test/conf_examples/badnick_1/error_no_dirauth_relay
+++ b/src/test/conf_examples/badnick_1/error_no_dirauth_relay
@@ -1,1 +1,0 @@
-This tor was built with relay mode disabled.

--- a/src/test/conf_examples/badnick_1/expected_no_dirauth_relay
+++ b/src/test/conf_examples/badnick_1/expected_no_dirauth_relay
@@ -1,0 +1,1 @@
+Nickname TooManyCharactersInThisNickname

--- a/src/test/conf_examples/badnick_1/torrc
+++ b/src/test/conf_examples/badnick_1/torrc
@@ -1,2 +1,4 @@
 # This nickname is too long; we won't accept it.
+# (Unless the relay module is disabled, because Nickname is a
+# relay-only option. We'll ignore all relay-only options in #32395.)
 Nickname TooManyCharactersInThisNickname

--- a/src/test/conf_examples/badnick_2/error_no_dirauth_relay
+++ b/src/test/conf_examples/badnick_2/error_no_dirauth_relay
@@ -1,1 +1,0 @@
-This tor was built with relay mode disabled.

--- a/src/test/conf_examples/badnick_2/expected_no_dirauth_relay
+++ b/src/test/conf_examples/badnick_2/expected_no_dirauth_relay
@@ -1,0 +1,1 @@
+Nickname has a space

--- a/src/test/conf_examples/badnick_2/torrc
+++ b/src/test/conf_examples/badnick_2/torrc
@@ -1,2 +1,4 @@
 # this nickname has spaces in it and won't work.
+# (Unless the relay module is disabled, because Nickname is a
+# relay-only option. We'll ignore all relay-only options in #32395.)
 Nickname has a space

--- a/src/test/conf_examples/contactinfo_notutf8/error_no_dirauth_relay
+++ b/src/test/conf_examples/contactinfo_notutf8/error_no_dirauth_relay
@@ -1,1 +1,0 @@
-This tor was built with relay mode disabled.

--- a/src/test/conf_examples/contactinfo_notutf8/expected_no_dirauth_relay
+++ b/src/test/conf_examples/contactinfo_notutf8/expected_no_dirauth_relay
@@ -1,0 +1,1 @@
+ContactInfo "\304\353\304\353\304\353@example.com"

--- a/src/test/conf_examples/contactinfo_notutf8/torrc
+++ b/src/test/conf_examples/contactinfo_notutf8/torrc
@@ -1,1 +1,5 @@
+# We only accept ContactInfo in UTF-8 (or 7-bit ASCII)
+# (Unless the relay module is disabled, because ContactInfo is a
+# relay-only option. We'll ignore all relay-only options in #32395.
+# But at the moment, tor canonicalises and quotes the string.)
 ContactInfo ÄëÄëÄë@example.com

--- a/src/test/conf_examples/example_1/error_no_dirauth_relay
+++ b/src/test/conf_examples/example_1/error_no_dirauth_relay
@@ -1,1 +1,0 @@
-This tor was built with relay mode disabled.

--- a/src/test/conf_examples/example_3/error_no_dirauth_relay
+++ b/src/test/conf_examples/example_3/error_no_dirauth_relay
@@ -1,1 +1,0 @@
-This tor was built with relay mode disabled.

--- a/src/test/conf_examples/pt_01/error_no_dirauth_relay
+++ b/src/test/conf_examples/pt_01/error_no_dirauth_relay
@@ -1,1 +1,0 @@
-This tor was built with relay mode disabled.

--- a/src/test/conf_examples/pt_02/error_no_dirauth_relay
+++ b/src/test/conf_examples/pt_02/error_no_dirauth_relay
@@ -1,1 +1,0 @@
-This tor was built with relay mode disabled.

--- a/src/test/conf_examples/pt_02/expected_no_dirauth_relay
+++ b/src/test/conf_examples/pt_02/expected_no_dirauth_relay
@@ -1,0 +1,8 @@
+ExtORPort illegal_hostname_chars$()^*%(%
+ServerTransportListenAddr bad
+ServerTransportListenAddr bad2 illegal_hostname_chars$()^*%(%
+ServerTransportOptions bad
+ServerTransportOptions bad2 not_kv
+ServerTransportPlugin bad
+ServerTransportPlugin bad2 exec
+ServerTransportPlugin bad3 exec /

--- a/src/test/conf_examples/pt_02/torrc
+++ b/src/test/conf_examples/pt_02/torrc
@@ -1,6 +1,8 @@
 # Relay PT tests
 # Options from relay/transport_config.c
 # Bad options are also ignored
+# (Unless the relay module is disabled, because they are relay-only
+# options. We'll ignore all relay-only options in #32395.)
 ExtORPort illegal_hostname_chars$()^*%(%#%)#(%*
 ServerTransportPlugin bad
 ServerTransportPlugin bad2 exec

--- a/src/test/conf_examples/pt_03/error_no_dirauth_relay
+++ b/src/test/conf_examples/pt_03/error_no_dirauth_relay
@@ -1,1 +1,0 @@
-This tor was built with relay mode disabled.

--- a/src/test/conf_examples/pt_04/error_no_dirauth_relay
+++ b/src/test/conf_examples/pt_04/error_no_dirauth_relay
@@ -1,1 +1,0 @@
-This tor was built with relay mode disabled.

--- a/src/test/conf_examples/pt_06/error_no_dirauth_relay
+++ b/src/test/conf_examples/pt_06/error_no_dirauth_relay
@@ -1,1 +1,0 @@
-This tor was built with relay mode disabled.

--- a/src/test/conf_examples/pt_08/error_no_dirauth_relay
+++ b/src/test/conf_examples/pt_08/error_no_dirauth_relay
@@ -1,1 +1,0 @@
-This tor was built with relay mode disabled.

--- a/src/test/conf_examples/pt_08/expected_no_dirauth_relay
+++ b/src/test/conf_examples/pt_08/expected_no_dirauth_relay
@@ -1,0 +1,2 @@
+ExtORPort unix:/
+ServerTransportPlugin bad3 exec /

--- a/src/test/conf_examples/pt_08/torrc
+++ b/src/test/conf_examples/pt_08/torrc
@@ -1,5 +1,7 @@
 # Relay PT tests
 # Options from relay/transport_config.c
 # Try an invalid config with a unix socket for ExtORPort
+# (Unless the relay module is disabled, because they are relay-only
+# options. We'll ignore all relay-only options in #32395.)
 ExtORPort unix:/
 ServerTransportPlugin bad3 exec /

--- a/src/test/conf_examples/relay_01/error_no_dirauth_relay
+++ b/src/test/conf_examples/relay_01/error_no_dirauth_relay
@@ -1,1 +1,0 @@
-This tor was built with relay mode disabled.


### PR DESCRIPTION
When the relay module is disabled, make "DirCache 0" the default.
(But keep "DirCache 1" as the default for the unit tests.)

Closes ticket 32410.