### PR TITLE
Appveyor: Install OpenSSL to resolve a header/library mismatch

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -62,7 +62,7 @@ install:
      #
      # Use pacman --debug to show package downloads and install locations
      #>
-    Execute-Command "C:\msys64\usr\bin\pacman" -Sy --verbose --needed --noconfirm ${env:mingw_prefix}-libevent ${env:mingw_prefix}-pkg-config ${env:mingw_prefix}-xz ${env:mingw_prefix}-zstd ;
+    Execute-Command "C:\msys64\usr\bin\pacman" -Sy --verbose --needed --noconfirm ${env:mingw_prefix}-libevent ${env:mingw_prefix}-openssl ${env:mingw_prefix}-pkg-config ${env:mingw_prefix}-xz ${env:mingw_prefix}-zstd ;
 
 build_script:
 - ps: >-

--- a/changes/bug32449
+++ b/changes/bug32449
@@ -1,0 +1,5 @@
+  o Minor bugfixes (CI, appveyor):
+    - Install the mingw OpenSSL package in Appveyor. This makes sure that
+      the OpenSSL headers and libraries match in Tor's Appveyor builds.
+      (This bug was triggered by an Appveyor image update.)
+      Fixes bug 32449; bugfix on 0.3.5.6-rc.


### PR DESCRIPTION
Install the mingw OpenSSL package in Appveyor. This makes sure that
the OpenSSL headers and libraries match in Tor's Appveyor builds.

(This bug was triggered by an Appveyor image update.)

Fixes bug 32449; bugfix on 0.3.5.6-rc.