### PR TITLE
dirauth: Remove a HAVE_MODULE_DIRAUTH inside a function

### DIFF
--- a/changes/ticket32163
+++ b/changes/ticket32163
@@ -1,0 +1,3 @@
+  o Code simplification and refactoring:
+    - Remove the last remaining HAVE_MODULE_DIRAUTH inside a function.
+      Closes ticket 32163.

--- a/src/feature/dirauth/reachability.h
+++ b/src/feature/dirauth/reachability.h
@@ -24,10 +24,10 @@
 #define REACHABILITY_TEST_CYCLE_PERIOD \
   (REACHABILITY_TEST_INTERVAL*REACHABILITY_MODULO_PER_TEST)
 
+#ifdef HAVE_MODULE_DIRAUTH
 void dirserv_single_reachability_test(time_t now, routerinfo_t *router);
 void dirserv_test_reachability(time_t now);
 
-#ifdef HAVE_MODULE_DIRAUTH
 int dirserv_should_launch_reachability_test(const routerinfo_t *ri,
                                             const routerinfo_t *ri_old);
 void dirserv_orconn_tls_done(const tor_addr_t *addr,
@@ -35,25 +35,16 @@ void dirserv_orconn_tls_done(const tor_addr_t *addr,
                              const char *digest_rcvd,
                              const struct ed25519_public_key_t *ed_id_rcvd);
 #else /* !defined(HAVE_MODULE_DIRAUTH) */
-static inline int
-dirserv_should_launch_reachability_test(const routerinfo_t *ri,
-                                            const routerinfo_t *ri_old)
-{
-  (void)ri;
-  (void)ri_old;
-  return 0;
-}
-static inline void
-dirserv_orconn_tls_done(const tor_addr_t *addr,
-                        uint16_t or_port,
-                        const char *digest_rcvd,
-                        const struct ed25519_public_key_t *ed_id_rcvd)
-{
-  (void)addr;
-  (void)or_port;
-  (void)digest_rcvd;
-  (void)ed_id_rcvd;
-}
+#define dirserv_single_reachability_test(now, router) \
+  (((void)(now)),((void)(router)))
+#define dirserv_test_reachability(now) \
+  (((void)(now)))
+
+#define dirserv_should_launch_reachability_test(ri, ri_old) \
+  (((void)(ri)),((void)(ri_old)),0)
+#define dirserv_orconn_tls_done(addr, or_port, digest_rcvd, ed_id_rcvd) \
+  (((void)(addr)),((void)(or_port)),((void)(digest_rcvd)), \
+   ((void)(ed_id_rcvd)))
 #endif /* defined(HAVE_MODULE_DIRAUTH) */
 
 #endif /* !defined(TOR_REACHABILITY_H) */

--- a/src/feature/nodelist/routerlist.c
+++ b/src/feature/nodelist/routerlist.c
@@ -1936,9 +1936,7 @@ routerlist_descriptors_added(smartlist_t *sl, int from_cache)
       learned_bridge_descriptor(ri, from_cache);
     if (ri->needs_retest_if_added) {
       ri->needs_retest_if_added = 0;
-#ifdef HAVE_MODULE_DIRAUTH
       dirserv_single_reachability_test(approx_time(), ri);
-#endif
     }
   } SMARTLIST_FOREACH_END(ri);
 }


### PR DESCRIPTION
There are now no HAVE_MODULE_{DIRAUTH,RELAY} inside functions.

Closes ticket 32163.