### PR TITLE
hs-v3: Return bad address SOCKS5 extended error

### DIFF
--- a/src/core/or/connection_edge.c
+++ b/src/core/or/connection_edge.c
@@ -2123,7 +2123,7 @@ connection_ap_handshake_rewrite_and_attach(entry_connection_t *conn,
     control_event_client_status(LOG_WARN, "SOCKS_BAD_HOSTNAME HOSTNAME=%s",
                                 escaped(socks->address));
     if (addresstype == ONION_V3_HOSTNAME) {
-      conn->socks_request->socks_extended_error_code = SOCKS5_HS_IS_INVALID;
+      conn->socks_request->socks_extended_error_code = SOCKS5_HS_BAD_ADDRESS;
     }
     connection_mark_unattached_ap(conn, END_STREAM_REASON_TORPROTOCOL);
     return -1;

--- a/src/lib/net/socks5_status.h
+++ b/src/lib/net/socks5_status.h
@@ -36,6 +36,7 @@ typedef enum {
   SOCKS5_HS_REND_FAILED             = 0xF3,
   SOCKS5_HS_MISSING_CLIENT_AUTH     = 0xF4,
   SOCKS5_HS_BAD_CLIENT_AUTH         = 0xF5,
+  SOCKS5_HS_BAD_ADDRESS             = 0xF6,
 } socks5_reply_status_t;
 
 #endif /* !defined(TOR_SOCKS5_STATUS_H) */


### PR DESCRIPTION
If ExtendedErrors is set for the SocksPort, an invalid .onion address now
returns the 0xF6 error code per prop304.

Closes #30022

Signed-off-by: David Goulet <dgoulet@torproject.org>