### PR TITLE
[Tor Trac #31531]: Make control_event_conf_changed() take a smartlist of config_line_t

### DIFF
--- a/changes/bug31531
+++ b/changes/bug31531
@@ -1,0 +1,4 @@
+  o Minor bugfixes (configuration handling):
+    - Make control_event_conf_changed() take in a smartlist(config_line_t)
+      instead of a smartlist(k, v, k, v, ...) where keys are followed by
+      values. Fixes bug 31531; bugfix on 0.2.3.3-alpha. Patch by Neel Chauhan.

--- a/src/app/config/config.c
+++ b/src/app/config/config.c
@@ -1005,8 +1005,7 @@ set_options(or_options_t *new_val, char **msg)
     config_line_t *changes =
       config_get_changes(get_options_mgr(), old_options, new_val);
     for (config_line_t *line = changes; line; line = line->next) {
-      smartlist_add(elements, line->key);
-      smartlist_add(elements, line->value);
+      smartlist_add(elements, line);
     }
     control_event_conf_changed(elements);
     smartlist_free(elements);


### PR DESCRIPTION
For the bug [here](https://trac.torproject.org/projects/tor/ticket/31531).