### PR TITLE
Ticket 32604: Add two new config directives for onion services.

### DIFF
--- a/changes/ticket32604
+++ b/changes/ticket32604
@@ -1,0 +1,7 @@
+  o Minor features (onion services):
+    - Version 3 onion services can now use HiddenServiceExportRendPoint
+      to get the IP and port of the rendezvous point they are connecting.
+    - Version 3 onion services can now use HiddenServiceExportInstanceID
+      which enables them to differenciate traffic when multiple tor
+      instances share the same backend.
+    - Closes ticket 32604. Patch by Moonsik Park.

--- a/doc/tor.1.txt
+++ b/doc/tor.1.txt
@@ -3044,6 +3044,31 @@ The next section describes the per service options that can only be set
    The HAProxy version 1 protocol is described in detail at
    https://www.haproxy.org/download/1.8/doc/proxy-protocol.txt
 
+[[HiddenServiceExportRendPoint]] **HiddenServiceExportRendPoint** **0**|**1**::
+   When HiddenServiceExportCircuitID along with this feature is enabled, export IP
+   and port of the rendezvous point along with the circuit ID. +
+ +
+   When this feature is enabled, tor will export IP and port of the rendezvous
+   point in the following way. +
+ +
+   "PROXY TCP6 fc00::AAAA:BBBB:CCCC:0:ffff:ffff ::1 65535 42\r\n" +
+ +
+      ip = (0xAAAA << 16) + 0xBBBB; +
+      port = 0xCCCC; +
+ +
+   For example, if the IP is 0x7f000001 and the port is 0x1bb, you can translate
+   to 127.30.0.1:443. (Default: 0)
+
+[[HiddenServiceExportInstanceID]] **HiddenServiceExportInstanceID** __N__::
+   When HiddenServiceExportCircuitID is enabled, export an instance ID along
+   with the circuit ID. The maximum allowed value is 65535. +
+ +
+   When this feature is enabled, tor will export an instance ID in the following way. +
+ +
+   "PROXY TCP6 fc00::0:0:0:AAAA:ffff:ffff ::1 65535 42\r\n" +
+ +
+   Where 0xAAAA will be your provided instance ID in hex. (Default: 0)
+
 [[HiddenServiceMaxStreams]] **HiddenServiceMaxStreams** __N__::
    The maximum number of simultaneous streams (connections) per rendezvous
    circuit. The maximum value allowed is 65535. (Setting this to 0 will allow

--- a/src/app/config/config.c
+++ b/src/app/config/config.c
@@ -513,6 +513,8 @@ static const config_var_t option_vars_[] = {
   VAR("HiddenServiceMaxStreamsCloseCircuit",LINELIST_S, RendConfigLines, NULL),
   VAR("HiddenServiceNumIntroductionPoints", LINELIST_S, RendConfigLines, NULL),
   VAR("HiddenServiceExportCircuitID", LINELIST_S,  RendConfigLines, NULL),
+  V(HiddenServiceExportRendPoint, BOOL, "0"),
+  V(HiddenServiceExportInstanceID, POSINT, "0"),
   VAR("HiddenServiceEnableIntroDoSDefense", LINELIST_S, RendConfigLines, NULL),
   VAR("HiddenServiceEnableIntroDoSRatePerSec",
       LINELIST_S, RendConfigLines, NULL),
@@ -3938,6 +3940,10 @@ options_validate_cb(const void *old_options_, void *options_, char **msg)
 
   if (options_validate_scheduler(options, msg) < 0) {
     return -1;
+  }
+
+  if (options->HiddenServiceExportInstanceID > 65535) {
+    REJECT("HiddenServiceExportInstanceID must be in range of 0 to 65535");
   }
 
   return 0;

--- a/src/app/config/or_options_st.h
+++ b/src/app/config/or_options_st.h
@@ -1103,6 +1103,12 @@ struct or_options_t {
    **/
   int DormantCanceledByStartup;
 
+  /** Boolean: true if we should export rend point when exporting CircuitID. */
+  int HiddenServiceExportRendPoint;
+
+  /** Instance ID to export when exporting CircuitID. */
+  int HiddenServiceExportInstanceID;
+
   /**
    * Configuration objects for individual modules.
    *

--- a/src/test/test_hs_service.c
+++ b/src/test/test_hs_service.c
@@ -2127,7 +2127,7 @@ test_export_client_circuit_id(void *arg)
   /* Check contents */
   cp1 = buf_get_contents(conn->outbuf, &sz);
   tt_str_op(cp1, OP_EQ,
-            "PROXY TCP6 fc00:dead:beef:4dad::0:29a ::1 666 42\r\n");
+            "PROXY TCP6 fc00::0:0:0:0:0:29a ::1 666 42\r\n");
 
   /* Change circ GID and see that the reported circuit ID also changes */
   or_circ->global_identifier = 22;
@@ -2144,7 +2144,7 @@ test_export_client_circuit_id(void *arg)
   export_hs_client_circuit_id(edge_conn, service->config.circuit_id_protocol);
   cp1 = buf_get_contents(conn->outbuf, &sz);
   tt_str_op(cp1, OP_EQ,
-            "PROXY TCP6 fc00:dead:beef:4dad::ffff:ffff ::1 65535 42\r\n");
+            "PROXY TCP6 fc00::0:0:0:0:ffff:ffff ::1 65535 42\r\n");
   tor_free(cp1);
 
   /* Check that GID with UINT16_MAX works. */
@@ -2153,7 +2153,7 @@ test_export_client_circuit_id(void *arg)
   export_hs_client_circuit_id(edge_conn, service->config.circuit_id_protocol);
   cp1 = buf_get_contents(conn->outbuf, &sz);
   tt_str_op(cp1, OP_EQ,
-            "PROXY TCP6 fc00:dead:beef:4dad::0:ffff ::1 65535 42\r\n");
+            "PROXY TCP6 fc00::0:0:0:0:0:ffff ::1 65535 42\r\n");
   tor_free(cp1);
 
   /* Check that GID with UINT16_MAX + 7 works. */
@@ -2161,7 +2161,7 @@ test_export_client_circuit_id(void *arg)
 
   export_hs_client_circuit_id(edge_conn, service->config.circuit_id_protocol);
   cp1 = buf_get_contents(conn->outbuf, &sz);
-  tt_str_op(cp1, OP_EQ, "PROXY TCP6 fc00:dead:beef:4dad::1:6 ::1 6 42\r\n");
+  tt_str_op(cp1, OP_EQ, "PROXY TCP6 fc00::0:0:0:0:1:6 ::1 6 42\r\n");
 
  done:
   UNMOCK(connection_write_to_buf_impl_);


### PR DESCRIPTION
Add HiddenServiceExportRendPoint and HiddenServiceExportInstanceID
config directive to export rendezvous point information and instance
ID along with circuit ID. Closes ticket #32604.