### PR TITLE
configure: reject Python 2.

### DIFF
--- a/changes/ticket32608
+++ b/changes/ticket32608
@@ -1,0 +1,4 @@
+  o New system requirements:
+    - When building Tor, you now need to have Python 3 in order to
+      run the integration tests. (Python 2 is officially unsupported
+      upstream, as of 1 Jan 2020.) Closes ticket 32608.

--- a/configure.ac
+++ b/configure.ac
@@ -352,15 +352,20 @@ AM_CONDITIONAL(BUILD_HTML_DOCS, [test "x$enable_html_manual" != "xno"])
 AM_PROG_CC_C_O
 AC_PROG_CC_C99
 
-AC_ARG_VAR([PYTHON], [path to Python binary])
-AC_CHECK_PROGS(PYTHON, [ \
+AC_CACHE_CHECK([for Python 3], [tor_cv_PYTHON],
+   [AC_PATH_PROGS_FEATURE_CHECK([PYTHON], [ \
 	python3 \
 	python3.8 python3.7 python3.6 python3.5 python3.4 \
-	python \
-	python2 python2.7])
+	python ],
+   [["$ac_path_PYTHON" -c 'import sys; sys.exit(sys.version_info[0]<3)' && tor_cv_PYTHON="$ac_path_PYTHON" ac_path_PYTHON_found=:]] )])
+AC_SUBST([PYTHON], [$tor_cv_PYTHON])
+
+PYTHON="$tor_cv_PYTHON"
+
 if test "x$PYTHON" = "x"; then
-  AC_MSG_WARN([Python unavailable; some tests will not be run.])
+  AC_MSG_WARN([Python 3 unavailable; some tests will not be run.])
 fi
+
 AM_CONDITIONAL(USEPYTHON, [test "x$PYTHON" != "x"])
 
 dnl List all external rust crates we depend on here. Include the version


### PR DESCRIPTION
Python 2 will be end-of-life as of 1 Jan 2020, so we can finally
stop supporting it.  As a first step, we should make our configure
script stop accepting python 2 as something acceptable to run our
tests with.

Closes ticket 32608.