### PR TITLE
#4310: Alphabetically reordered config options in the General Options category

### DIFF
--- a/doc/tor.1.txt
+++ b/doc/tor.1.txt
@@ -227,6 +227,44 @@ forward slash (/) in the configuration file and on the command line.
 
 GENERAL OPTIONS
 ---------------
+[[AccelDir]] **AccelDir** __DIR__::
+    Specify this option if using dynamic hardware acceleration and the engine
+    implementation library resides somewhere other than the OpenSSL default.
+    Can not be changed while tor is running.
+
+[[AccelName]] **AccelName** __NAME__::
+    When using OpenSSL hardware crypto acceleration attempt to load the dynamic
+    engine of this name. This must be used for any dynamic hardware engine.
+    Names can be verified with the openssl engine command. Can not be changed
+    while tor is running. +
+     +
+    If the engine name is prefixed with a "!", then Tor will exit if the
+    engine cannot be loaded.
+
+[[AlternateBridgeAuthority]] **AlternateBridgeAuthority** [__nickname__] [**flags**] __ipv4address__:__port__ __ fingerprint__::
+    These options behave as DirAuthority, but they replace fewer of the
+    default directory authorities. Using
+    AlternateDirAuthority replaces the default Tor directory authorities, but
+    leaves the default bridge authorities in
+    place.  Similarly,
+    AlternateBridgeAuthority replaces the default bridge authority,
+    but leaves the directory authorities alone.
+
+[[AlternateDirAuthority]] **AlternateDirAuthority** [__nickname__] [**flags**] __ipv4address__:__port__ __fingerprint__ +
+
+[[AndroidIdentityTag]] **AndroidIdentityTag** __tag__::
+    When logging to Android's logging subsystem, adds a tag to the log identity
+    such that log entries are marked with "Tor-__tag__". Can not be changed while
+    tor is running. (Default: none)
+
+[[AvoidDiskWrites]] **AvoidDiskWrites** **0**|**1**::
+    If non-zero, try to write to disk less frequently than we would otherwise.
+    This is useful when running on flash memory or other media that support
+    only a limited number of writes. (Default: 0)
+
+[[BandwidthBurst]] **BandwidthBurst** __N__ **bytes**|**KBytes**|**MBytes**|**GBytes**|**TBytes**|**KBits**|**MBits**|**GBits**|**TBits**::
+    Limit the maximum token bucket size (also known as the burst) to the given
+    number of bytes in each direction. (Default: 1 GByte)
 
 [[BandwidthRate]] **BandwidthRate** __N__ **bytes**|**KBytes**|**MBytes**|**GBytes**|**TBytes**|**KBits**|**MBits**|**GBits**|**TBits**::
     A token bucket limits the average incoming bandwidth usage on this node
@@ -236,14 +274,13 @@ GENERAL OPTIONS
     relay (that is, 600 kbits) or 50 KBytes for a bridge (400 kbits) -- but of
     course, more is better; we recommend at least 250 KBytes (2 mbits) if
     possible.  (Default: 1 GByte) +
- +
+    +
     Note that this option, and other bandwidth-limiting options, apply to TCP
     data only: They do not count TCP headers or DNS traffic. +
- +
+    +
     Tor uses powers of two, not powers of ten, so 1 GByte is
-    1024*1024*1024 bytes as opposed to 1 billion bytes. +
- +
-    With this option, and in other options that take arguments in bytes,
+    1024*1024*1024 bytes as opposed to 1 billion bytes.
+   With this option, and in other options that take arguments in bytes,
     KBytes, and so on, other formats are also supported. Notably, "KBytes" can
     also be written as "kilobytes" or "kb"; "MBytes" can be written as
     "megabytes" or "MB"; "kbits" can be written as "kilobits"; and so forth.
@@ -253,221 +290,6 @@ GENERAL OPTIONS
     If no units are given, we default to bytes.
     To avoid confusion, we recommend writing "bytes" or "bits" explicitly,
     since it's easy to forget that "B" means bytes, not bits.
-
-[[BandwidthBurst]] **BandwidthBurst** __N__ **bytes**|**KBytes**|**MBytes**|**GBytes**|**TBytes**|**KBits**|**MBits**|**GBits**|**TBits**::
-    Limit the maximum token bucket size (also known as the burst) to the given
-    number of bytes in each direction. (Default: 1 GByte)
-
-[[MaxAdvertisedBandwidth]] **MaxAdvertisedBandwidth** __N__ **bytes**|**KBytes**|**MBytes**|**GBytes**|**TBytes**|**KBits**|**MBits**|**GBits**|**TBits**::
-    If set, we will not advertise more than this amount of bandwidth for our
-    BandwidthRate. Server operators who want to reduce the number of clients
-    who ask to build circuits through them (since this is proportional to
-    advertised bandwidth rate) can thus reduce the CPU demands on their server
-    without impacting network performance.
-
-[[RelayBandwidthRate]] **RelayBandwidthRate** __N__ **bytes**|**KBytes**|**MBytes**|**GBytes**|**TBytes**|**KBits**|**MBits**|**GBits**|**TBits**::
-    If not 0, a separate token bucket limits the average incoming bandwidth
-    usage for \_relayed traffic_ on this node to the specified number of bytes
-    per second, and the average outgoing bandwidth usage to that same value.
-    Relayed traffic currently is calculated to include answers to directory
-    requests, but that may change in future versions. They do not include directory
-    fetches by the relay (from authority or other relays), because that is considered
-    "client" activity.  (Default: 0)
-
-[[RelayBandwidthBurst]] **RelayBandwidthBurst** __N__ **bytes**|**KBytes**|**MBytes**|**GBytes**|**TBytes**|**KBits**|**MBits**|**GBits**|**TBits**::
-    If not 0, limit the maximum token bucket size (also known as the burst) for
-    \_relayed traffic_ to the given number of bytes in each direction.
-    They do not include directory fetches by the relay (from authority
-    or other relays), because that is considered "client" activity. (Default: 0)
-
-[[PerConnBWRate]] **PerConnBWRate** __N__ **bytes**|**KBytes**|**MBytes**|**GBytes**|**TBytes**|**KBits**|**MBits**|**GBits**|**TBits**::
-    If this option is set manually, or via the "perconnbwrate" consensus
-    field, Tor will use it for separate rate limiting for each connection
-    from a non-relay. (Default: 0)
-
-[[PerConnBWBurst]] **PerConnBWBurst** __N__ **bytes**|**KBytes**|**MBytes**|**GBytes**|**TBytes**|**KBits**|**MBits**|**GBits**|**TBits**::
-    If this option is set manually, or via the "perconnbwburst" consensus
-    field, Tor will use it for separate rate limiting for each connection
-    from a non-relay. (Default: 0)
-
-[[ClientTransportPlugin]] **ClientTransportPlugin** __transport__ socks4|socks5 __IP__:__PORT__::
-**ClientTransportPlugin** __transport__ exec __path-to-binary__ [options]::
-    In its first form, when set along with a corresponding Bridge line, the Tor
-    client forwards its traffic to a SOCKS-speaking proxy on "IP:PORT".
-    (IPv4 addresses should written as-is; IPv6 addresses should be wrapped in
-    square brackets.) It's the
-    duty of that proxy to properly forward the traffic to the bridge. +
- +
-    In its second form, when set along with a corresponding Bridge line, the Tor
-    client launches the pluggable transport proxy executable in
-    __path-to-binary__ using __options__ as its command-line options, and
-    forwards its traffic to it. It's the duty of that proxy to properly forward
-    the traffic to the bridge. (Default: none)
-
-[[ServerTransportPlugin]] **ServerTransportPlugin** __transport__ exec __path-to-binary__ [options]::
-    The Tor relay launches the pluggable transport proxy in __path-to-binary__
-    using __options__ as its command-line options, and expects to receive
-    proxied client traffic from it. (Default: none)
-
-[[ServerTransportListenAddr]] **ServerTransportListenAddr** __transport__ __IP__:__PORT__::
-    When this option is set, Tor will suggest __IP__:__PORT__ as the
-    listening address of any pluggable transport proxy that tries to
-    launch __transport__. (IPv4 addresses should written as-is; IPv6
-    addresses should be wrapped in square brackets.) (Default: none)
-
-[[ServerTransportOptions]] **ServerTransportOptions** __transport__ __k=v__ __k=v__ ...::
-    When this option is set, Tor will pass the __k=v__ parameters to
-    any pluggable transport proxy that tries to launch __transport__. +
-    (Example: ServerTransportOptions obfs45 shared-secret=bridgepasswd cache=/var/lib/tor/cache) (Default: none)
-
-[[ExtORPort]] **ExtORPort** \['address':]__port__|**auto**::
-    Open this port to listen for Extended ORPort connections from your
-    pluggable transports. +
-    (Default: **DataDirectory**/extended_orport_auth_cookie)
-
-[[ExtORPortCookieAuthFile]] **ExtORPortCookieAuthFile** __Path__::
-    If set, this option overrides the default location and file name
-    for the Extended ORPort's cookie file -- the cookie file is needed
-    for pluggable transports to communicate through the Extended ORPort.
-
-[[ExtORPortCookieAuthFileGroupReadable]] **ExtORPortCookieAuthFileGroupReadable** **0**|**1**::
-    If this option is set to 0, don't allow the filesystem group to read the
-    Extended OR Port cookie file. If the option is set to 1, make the cookie
-    file readable by the default GID. [Making the file readable by other
-    groups is not yet implemented; let us know if you need this for some
-    reason.] (Default: 0)
-
-[[ConnLimit]] **ConnLimit** __NUM__::
-    The minimum number of file descriptors that must be available to the Tor
-    process before it will start. Tor will ask the OS for as many file
-    descriptors as the OS will allow (you can find this by "ulimit -H -n").
-    If this number is less than ConnLimit, then Tor will refuse to start. +
- +
-    Tor relays need thousands of sockets, to connect to every other relay.
-    If you are running a private bridge, you can reduce the number of sockets
-    that Tor uses. For example, to limit Tor to 500 sockets, run
-    "ulimit -n 500" in a shell. Then start tor in the same shell, with
-    **ConnLimit 500**. You may also need to set **DisableOOSCheck 0**. +
- +
-    Unless you have severely limited sockets, you probably don't need to
-    adjust **ConnLimit** itself. It has no effect on Windows, since that
-    platform lacks getrlimit(). (Default: 1000)
-
-[[DisableNetwork]] **DisableNetwork** **0**|**1**::
-    When this option is set, we don't listen for or accept any connections
-    other than controller connections, and we close (and don't reattempt)
-    any outbound
-    connections.  Controllers sometimes use this option to avoid using
-    the network until Tor is fully configured.  Tor will make still certain
-    network-related calls (like DNS lookups) as a part of its configuration
-    process, even if DisableNetwork is set. (Default: 0)
-
-[[ConstrainedSockets]] **ConstrainedSockets** **0**|**1**::
-    If set, Tor will tell the kernel to attempt to shrink the buffers for all
-    sockets to the size specified in **ConstrainedSockSize**. This is useful for
-    virtual servers and other environments where system level TCP buffers may
-    be limited. If you're on a virtual server, and you encounter the "Error
-    creating network socket: No buffer space available" message, you are
-    likely experiencing this problem. +
- +
-    The preferred solution is to have the admin increase the buffer pool for
-    the host itself via /proc/sys/net/ipv4/tcp_mem or equivalent facility;
-    this configuration option is a second-resort. +
- +
-    The DirPort option should also not be used if TCP buffers are scarce. The
-    cached directory requests consume additional sockets which exacerbates
-    the problem. +
- +
-    You should **not** enable this feature unless you encounter the "no buffer
-    space available" issue. Reducing the TCP buffers affects window size for
-    the TCP stream and will reduce throughput in proportion to round trip
-    time on long paths. (Default: 0)
-
-[[ConstrainedSockSize]] **ConstrainedSockSize** __N__ **bytes**|**KBytes**::
-    When **ConstrainedSockets** is enabled the receive and transmit buffers for
-    all sockets will be set to this limit. Must be a value between 2048 and
-    262144, in 1024 byte increments. Default of 8192 is recommended.
-
-[[ControlPort]] **ControlPort** \['address':]__port__|**unix:**__path__|**auto** [__flags__]::
-    If set, Tor will accept connections on this port and allow those
-    connections to control the Tor process using the Tor Control Protocol
-    (described in control-spec.txt in
-    https://spec.torproject.org[torspec]). Note: unless you also
-    specify one or more of **HashedControlPassword** or
-    **CookieAuthentication**, setting this option will cause Tor to allow
-    any process on the local host to control it. (Setting both authentication
-    methods means either method is sufficient to authenticate to Tor.) This
-    option is required for many Tor controllers; most use the value of 9051.
-    If a unix domain socket is used, you may quote the path using standard
-    C escape sequences. You can specify this directive multiple times, to
-    bind to multiple address/port pairs.
-    Set it to "auto" to have Tor pick a port for you. (Default: 0) +
- +
-    Recognized flags are...
-    **GroupWritable**;;
-        Unix domain sockets only: makes the socket get created as
-        group-writable.
-    **WorldWritable**;;
-        Unix domain sockets only: makes the socket get created as
-        world-writable.
-    **RelaxDirModeCheck**;;
-        Unix domain sockets only: Do not insist that the directory
-        that holds the socket be read-restricted.
-
-[[ControlSocket]] **ControlSocket** __Path__::
-    Like ControlPort, but listens on a Unix domain socket, rather than a TCP
-    socket. '0' disables ControlSocket. (Unix and Unix-like systems only.)
-    (Default: 0)
-
-[[ControlSocketsGroupWritable]] **ControlSocketsGroupWritable** **0**|**1**::
-    If this option is set to 0, don't allow the filesystem group to read and
-    write unix sockets (e.g. ControlSocket). If the option is set to 1, make
-    the control socket readable and writable by the default GID. (Default: 0)
-
-[[HashedControlPassword]] **HashedControlPassword** __hashed_password__::
-    Allow connections on the control port if they present
-    the password whose one-way hash is __hashed_password__. You
-    can compute the hash of a password by running "tor --hash-password
-    __password__". You can provide several acceptable passwords by using more
-    than one HashedControlPassword line.
-
-[[CookieAuthentication]] **CookieAuthentication** **0**|**1**::
-    If this option is set to 1, allow connections on the control port
-    when the connecting process knows the contents of a file named
-    "control_auth_cookie", which Tor will create in its data directory. This
-    authentication method should only be used on systems with good filesystem
-    security. (Default: 0)
-
-[[CookieAuthFile]] **CookieAuthFile** __Path__::
-    If set, this option overrides the default location and file name
-    for Tor's cookie file. (See CookieAuthentication above.)
-
-[[CookieAuthFileGroupReadable]] **CookieAuthFileGroupReadable** **0**|**1**::
-    If this option is set to 0, don't allow the filesystem group to read the
-    cookie file. If the option is set to 1, make the cookie file readable by
-    the default GID. [Making the file readable by other groups is not yet
-    implemented; let us know if you need this for some reason.] (Default: 0)
-
-[[ControlPortWriteToFile]] **ControlPortWriteToFile** __Path__::
-    If set, Tor writes the address and port of any control port it opens to
-    this address.  Usable by controllers to learn the actual control port
-    when ControlPort is set to "auto".
-
-[[ControlPortFileGroupReadable]] **ControlPortFileGroupReadable** **0**|**1**::
-    If this option is set to 0, don't allow the filesystem group to read the
-    control port file. If the option is set to 1, make the control port
-    file readable by the default GID. (Default: 0)
-
-[[DataDirectory]] **DataDirectory** __DIR__::
-    Store working data in DIR. Can not be changed while tor is running.
-    (Default: ~/.tor if your home directory is not /; otherwise,
-    @LOCALSTATEDIR@/lib/tor.  On Windows, the default is
-    your ApplicationData folder.)
-
-[[DataDirectoryGroupReadable]] **DataDirectoryGroupReadable** **0**|**1**::
-    If this option is set to 0, don't allow the filesystem group to read the
-    DataDirectory. If the option is set to 1, make the DataDirectory readable
-    by the default GID. (Default: 0)
 
 [[CacheDirectory]] **CacheDirectory** __DIR__::
     Store cached directory data in DIR. Can not be changed while tor is
@@ -481,190 +303,593 @@ GENERAL OPTIONS
     setting for DataDirectoryGroupReadable when the CacheDirectory is the
     same as the DataDirectory, and 0 otherwise. (Default: auto)
 
-[[FallbackDir]] **FallbackDir** __ipv4address__:__dirport__ orport=__orport__ id=__fingerprint__ [weight=__num__] [ipv6=**[**__ipv6address__**]**:__orport__]::
-    When tor is unable to connect to any directory cache for directory info
-    (usually because it doesn't know about any yet) it tries a hard-coded
-    directory. Relays try one directory authority at a time. Clients try
-    multiple directory authorities and FallbackDirs, to avoid hangs on
-    startup if a hard-coded directory is down. Clients wait for a few seconds
-    between each attempt, and retry FallbackDirs more often than directory
-    authorities, to reduce the load on the directory authorities.  +
- +
-    FallbackDirs should be stable relays with stable IP addresses, ports,
-    and identity keys. They must have a DirPort. +
- +
-    By default, the directory authorities are also FallbackDirs. Specifying a
-    FallbackDir replaces Tor's default hard-coded FallbackDirs (if any).
-    (See the **DirAuthority** entry for an explanation of each flag.)
+[[CircuitPriorityHalflife]] **CircuitPriorityHalflife** __NUM__::
+    If this value is set, we override the default algorithm for choosing which
+    circuit's cell to deliver or relay next. It is delivered first to the
+    circuit that has the lowest weighted cell count, where cells are weighted
+    exponentially according to this value (in seconds). If the value is -1, it
+    is taken from the consensus if possible else it will fallback to the
+    default value of 30. Minimum: 1, Maximum: 2147483647. This can be defined
+    as a float value. This is an advanced option; you generally shouldn't have
+    to mess with it. (Default: -1)
 
-[[UseDefaultFallbackDirs]] **UseDefaultFallbackDirs** **0**|**1**::
-    Use Tor's default hard-coded FallbackDirs (if any). (When a
-    FallbackDir line is present, it replaces the hard-coded FallbackDirs,
-    regardless of the value of UseDefaultFallbackDirs.) (Default: 1)
+[[ClientTransportPlugin]] **ClientTransportPlugin** __transport__ socks4|socks5 __IP__:__PORT__::
+    **ClientTransportPlugin** __transport__ exec __path-to-binary__ [options]::
+        In its first form, when set along with a corresponding Bridge line, the Tor
+        client forwards its traffic to a SOCKS-speaking proxy on "IP:PORT".
+        (IPv4 addresses should written as-is; IPv6 addresses should be wrapped in
+        square brackets.) It's the
+        duty of that proxy to properly forward the traffic to the bridge. +
+         +
+        In its second form, when set along with a corresponding Bridge line, the Tor
+        client launches the pluggable transport proxy executable in
+        __path-to-binary__ using __options__ as its command-line options, and
+        forwards its traffic to it. It's the duty of that proxy to properly forward
+        the traffic to the bridge. (Default: none)
+
+[[ConnLimit]] **ConnLimit** __NUM__::
+        The minimum number of file descriptors that must be available to the Tor
+        process before it will start. Tor will ask the OS for as many file
+        descriptors as the OS will allow (you can find this by "ulimit -H -n").
+        If this number is less than ConnLimit, then Tor will refuse to start. +
+         +
+        Tor relays need thousands of sockets, to connect to every other relay.
+        If you are running a private bridge, you can reduce the number of sockets
+        that Tor uses. For example, to limit Tor to 500 sockets, run
+        "ulimit -n 500" in a shell. Then start tor in the same shell, with
+        **ConnLimit 500**. You may also need to set **DisableOOSCheck 0**. +
+         +
+        Unless you have severely limited sockets, you probably don't need to
+        adjust **ConnLimit** itself. It has no effect on Windows, since that
+        platform lacks getrlimit(). (Default: 1000)
+
+[[ConstrainedSockets]] **ConstrainedSockets** **0**|**1**::
+        If set, Tor will tell the kernel to attempt to shrink the buffers for all
+        sockets to the size specified in **ConstrainedSockSize**. This is useful for
+        virtual servers and other environments where system level TCP buffers may
+        be limited. If you're on a virtual server, and you encounter the "Error
+        creating network socket: No buffer space available" message, you are
+        likely experiencing this problem. +
+        +
+       The preferred solution is to have the admin increase the buffer pool for
+       the host itself via /proc/sys/net/ipv4/tcp_mem or equivalent facility;
+       this configuration option is a second-resort. +
+        +
+       The DirPort option should also not be used if TCP buffers are scarce. The
+       cached directory requests consume additional sockets which exacerbates
+       the problem. +
+        +
+       You should **not** enable this feature unless you encounter the "no buffer
+       space available" issue. Reducing the TCP buffers affects window size for
+       the TCP stream and will reduce throughput in proportion to round trip
+      time on long paths. (Default: 0)
+
+[[ConstrainedSockSize]] **ConstrainedSockSize** __N__ **bytes**|**KBytes**::
+        When **ConstrainedSockets** is enabled the receive and transmit buffers for
+        all sockets will be set to this limit. Must be a value between 2048 and
+        262144, in 1024 byte increments. Default of 8192 is recommended.
+
+[[ControlPort]] **ControlPort** \['address':]__port__|**unix:**__path__|**auto** [__flags__]::
+        If set, Tor will accept connections on this port and allow those
+        connections to control the Tor process using the Tor Control Protocol
+        (described in control-spec.txt in
+        https://spec.torproject.org[torspec]). Note: unless you also
+        specify one or more of **HashedControlPassword** or
+        **CookieAuthentication**, setting this option will cause Tor to allow
+        any process on the local host to control it. (Setting both authentication
+        methods means either method is sufficient to authenticate to Tor.) This
+        option is required for many Tor controllers; most use the value of 9051.
+        If a unix domain socket is used, you may quote the path using standard
+        C escape sequences. You can specify this directive multiple times, to
+        bind to multiple address/port pairs.
+        Set it to "auto" to have Tor pick a port for you. (Default: 0) +
+         +
+            Recognized flags are:
+            **GroupWritable**;;
+                Unix domain sockets only: makes the socket get created as
+                group-writable.
+            **WorldWritable**;;
+                Unix domain sockets only: makes the socket get created as
+                world-writable.
+            **RelaxDirModeCheck**;;
+                Unix domain sockets only: Do not insist that the directory
+                that holds the socket be read-restricted.
+
+[[ControlPortFileGroupReadable]] **ControlPortFileGroupReadable** **0**|**1**::
+        If this option is set to 0, don't allow the filesystem group to read the
+        control port file. If the option is set to 1, make the control port
+        file readable by the default GID. (Default: 0)
+
+[[ControlPortWriteToFile]] **ControlPortWriteToFile** __Path__::
+        If set, Tor writes the address and port of any control port it opens to
+        this address.  Usable by controllers to learn the actual control port
+        when ControlPort is set to "auto".
+
+[[ControlSocket]] **ControlSocket** __Path__::
+        Like ControlPort, but listens on a Unix domain socket, rather than a TCP
+        socket. '0' disables ControlSocket. (Unix and Unix-like systems only.)
+        (Default: 0)
+
+[[ControlSocketsGroupWritable]] **ControlSocketsGroupWritable** **0**|**1**::
+        If this option is set to 0, don't allow the filesystem group to read and
+        write unix sockets (e.g. ControlSocket). If the option is set to 1, make
+        the control socket readable and writable by the default GID. (Default: 0)
+
+[[CookieAuthentication]] **CookieAuthentication** **0**|**1**::
+        If this option is set to 1, allow connections on the control port
+        when the connecting process knows the contents of a file named
+        "control_auth_cookie", which Tor will create in its data directory. This
+        authentication method should only be used on systems with good filesystem
+        security. (Default: 0)
+
+[[CookieAuthFile]] **CookieAuthFile** __Path__::
+        If set, this option overrides the default location and file name
+        for Tor's cookie file. (See CookieAuthentication above.)
+
+[[CookieAuthFileGroupReadable]] **CookieAuthFileGroupReadable** **0**|**1**::
+        If this option is set to 0, don't allow the filesystem group to read the
+        cookie file. If the option is set to 1, make the cookie file readable by
+        the default GID. [Making the file readable by other groups is not yet
+        implemented; let us know if you need this for some reason.] (Default: 0)
+
+[[CountPrivateBandwidth]] **CountPrivateBandwidth** **0**|**1**::
+        If this option is set, then Tor's rate-limiting applies not only to
+        remote connections, but also to connections to private addresses like
+        127.0.0.1 or 10.0.0.1.  This is mostly useful for debugging
+        rate-limiting.  (Default: 0)
+
+[[DataDirectory]] **DataDirectory** __DIR__::
+        Store working data in DIR. Can not be changed while tor is running.
+        (Default: ~/.tor if your home directory is not /; otherwise,
+        @LOCALSTATEDIR@/lib/tor.  On Windows, the default is
+        your ApplicationData folder.)
+
+[[DataDirectoryGroupReadable]] **DataDirectoryGroupReadable** **0**|**1**::
+        If this option is set to 0, don't allow the filesystem group to read the
+        DataDirectory. If the option is set to 1, make the DataDirectory readable
+        by the default GID. (Default: 0)
 
 [[DirAuthority]] **DirAuthority** [__nickname__] [**flags**] __ipv4address__:__dirport__ __fingerprint__::
-    Use a nonstandard authoritative directory server at the provided address
-    and port, with the specified key fingerprint. This option can be repeated
-    many times, for multiple authoritative directory servers. Flags are
-    separated by spaces, and determine what kind of an authority this directory
-    is. By default, an authority is not authoritative for any directory style
-    or version unless an appropriate flag is given. +
- +
-    Tor will use this authority as a bridge authoritative directory if the
-    "bridge" flag is set. If a flag "orport=**orport**" is given, Tor will
-    use the given port when opening encrypted tunnels to the dirserver. If a
-    flag "weight=**num**" is given, then the directory server is chosen
-    randomly with probability proportional to that weight (default 1.0). If a
-    flag "v3ident=**fp**" is given, the dirserver is a v3 directory authority
-    whose v3 long-term signing key has the fingerprint **fp**. Lastly,
-    if an "ipv6=**[**__ipv6address__**]**:__orport__" flag is present, then
-    the directory authority is listening for IPv6 connections on the
-    indicated IPv6 address and OR Port. +
- +
-    Tor will contact the authority at __ipv4address__ to
-    download directory documents. Clients always use the ORPort. Relays
-    usually use the DirPort, but will use the ORPort in some circumstances.
-    If an IPv6 ORPort is supplied, clients will also download directory
-    documents at the IPv6 ORPort, if they are configured to use IPv6. +
- +
-    If no **DirAuthority** line is given, Tor will use the default directory
-    authorities. NOTE: this option is intended for setting up a private Tor
-    network with its own directory authorities. If you use it, you will be
-    distinguishable from other users, because you won't believe the same
-    authorities they do.
+        Use a nonstandard authoritative directory server at the provided address
+        and port, with the specified key fingerprint. This option can be repeated
+        many times, for multiple authoritative directory servers. Flags are
+        separated by spaces, and determine what kind of an authority this directory
+        is. By default, an authority is not authoritative for any directory style
+        or version unless an appropriate flag is given. +
+         +
+        Tor will use this authority as a bridge authoritative directory if the
+        "bridge" flag is set. If a flag "orport=**orport**" is given, Tor will
+        use the given port when opening encrypted tunnels to the dirserver. If a
+        flag "weight=**num**" is given, then the directory server is chosen
+        randomly with probability proportional to that weight (default 1.0). If a
+        flag "v3ident=**fp**" is given, the dirserver is a v3 directory authority
+        whose v3 long-term signing key has the fingerprint **fp**. Lastly,
+        if an "ipv6=**[**__ipv6address__**]**:__orport__" flag is present, then
+        the directory authority is listening for IPv6 connections on the
+        indicated IPv6 address and OR Port. +
+         +
+        Tor will contact the authority at __ipv4address__ to
+        download directory documents. Clients always use the ORPort. Relays
+        usually use the DirPort, but will use the ORPort in some circumstances.
+        If an IPv6 ORPort is supplied, clients will also download directory
+        documents at the IPv6 ORPort, if they are configured to use IPv6. +
+         +
+        If no **DirAuthority** line is given, Tor will use the default directory
+        authorities. NOTE: this option is intended for setting up a private Tor
+        network with its own directory authorities. If you use it, you will be
+        distinguishable from other users, because you won't believe the same
+        authorities they do.
 
 [[DirAuthorityFallbackRate]] **DirAuthorityFallbackRate** __NUM__::
-    When configured to use both directory authorities and fallback
-    directories, the directory authorities also work as fallbacks. They are
-    chosen with their regular weights, multiplied by this number, which
-    should be 1.0 or less. The default is less than 1, to reduce load on
-    authorities. (Default: 0.1)
-
-[[AlternateDirAuthority]] **AlternateDirAuthority** [__nickname__] [**flags**] __ipv4address__:__port__ __fingerprint__ +
-
-[[AlternateBridgeAuthority]] **AlternateBridgeAuthority** [__nickname__] [**flags**] __ipv4address__:__port__ __ fingerprint__::
-    These options behave as DirAuthority, but they replace fewer of the
-    default directory authorities. Using
-    AlternateDirAuthority replaces the default Tor directory authorities, but
-    leaves the default bridge authorities in
-    place.  Similarly,
-    AlternateBridgeAuthority replaces the default bridge authority,
-    but leaves the directory authorities alone.
+        When configured to use both directory authorities and fallback
+        directories, the directory authorities also work as fallbacks. They are
+        chosen with their regular weights, multiplied by this number, which
+        should be 1.0 or less. The default is less than 1, to reduce load on
+        authorities. (Default: 0.1)
 
 [[DisableAllSwap]] **DisableAllSwap** **0**|**1**::
-    If set to 1, Tor will attempt to lock all current and future memory pages,
-    so that memory cannot be paged out. Windows, OS X and Solaris are currently
-    not supported. We believe that this feature works on modern Gnu/Linux
-    distributions, and that it should work on *BSD systems (untested). This
-    option requires that you start your Tor as root, and you should use the
-    **User** option to properly reduce Tor's privileges.
-    Can not be changed while tor is running. (Default: 0)
+        If set to 1, Tor will attempt to lock all current and future memory pages,
+        so that memory cannot be paged out. Windows, OS X and Solaris are currently
+        not supported. We believe that this feature works on modern Gnu/Linux
+        distributions, and that it should work on *BSD systems (untested). This
+        option requires that you start your Tor as root, and you should use the
+        **User** option to properly reduce Tor's privileges.
+        Can not be changed while tor is running. (Default: 0)
 
 [[DisableDebuggerAttachment]] **DisableDebuggerAttachment** **0**|**1**::
-   If set to 1, Tor will attempt to prevent basic debugging attachment attempts
-   by other processes. This may also keep Tor from generating core files if
-   it crashes. It has no impact for users who wish to attach if they
-   have CAP_SYS_PTRACE or if they are root.  We believe that this feature
-   works on modern Gnu/Linux distributions, and that it may also work on *BSD
-   systems (untested).  Some modern Gnu/Linux systems such as Ubuntu have the
-   kernel.yama.ptrace_scope sysctl and by default enable it as an attempt to
-   limit the PTRACE scope for all user processes by default. This feature will
-   attempt to limit the PTRACE scope for Tor specifically - it will not attempt
-   to alter the system wide ptrace scope as it may not even exist. If you wish
-   to attach to Tor with a debugger such as gdb or strace you will want to set
-   this to 0 for the duration of your debugging. Normal users should leave it
-   on. Disabling this option while Tor is running is prohibited. (Default: 1)
+       If set to 1, Tor will attempt to prevent basic debugging attachment attempts
+       by other processes. This may also keep Tor from generating core files if
+       it crashes. It has no impact for users who wish to attach if they
+       have CAP_SYS_PTRACE or if they are root.  We believe that this feature
+       works on modern Gnu/Linux distributions, and that it may also work on *BSD
+       systems (untested).  Some modern Gnu/Linux systems such as Ubuntu have the
+       kernel.yama.ptrace_scope sysctl and by default enable it as an attempt to
+       limit the PTRACE scope for all user processes by default. This feature will
+       attempt to limit the PTRACE scope for Tor specifically - it will not attempt
+       to alter the system wide ptrace scope as it may not even exist. If you wish
+       to attach to Tor with a debugger such as gdb or strace you will want to set
+       this to 0 for the duration of your debugging. Normal users should leave it
+       on. Disabling this option while Tor is running is prohibited. (Default: 1)
+
+[[DisableNetwork]] **DisableNetwork** **0**|**1**::
+        When this option is set, we don't listen for or accept any connections
+        other than controller connections, and we close (and don't reattempt)
+        any outbound
+        connections.  Controllers sometimes use this option to avoid using
+        the network until Tor is fully configured.  Tor will make still certain
+        network-related calls (like DNS lookups) as a part of its configuration
+        process, even if DisableNetwork is set. (Default: 0)
+
+[[ExtendByEd25519ID]] **ExtendByEd25519ID** **0**|**1**|**auto**::
+        If this option is set to 1, we always try to include a relay's Ed25519 ID
+        when telling the proceeding relay in a circuit to extend to it.
+        If this option is set to 0, we never include Ed25519 IDs when extending
+        circuits.  If the option is set to "default", we obey a
+        parameter in the consensus document. (Default: auto)
+
+[[ExtORPort]] **ExtORPort** \['address':]__port__|**auto**::
+       Open this port to listen for Extended ORPort connections from your
+       pluggable transports. +
+      (Default: **DataDirectory**/extended_orport_auth_cookie)
+
+[[ExtORPortCookieAuthFile]] **ExtORPortCookieAuthFile** __Path__::
+        If set, this option overrides the default location and file name
+        for the Extended ORPort's cookie file -- the cookie file is needed
+        for pluggable transports to communicate through the Extended ORPort.
+
+[[ExtORPortCookieAuthFileGroupReadable]] **ExtORPortCookieAuthFileGroupReadable** **0**|**1**::
+        If this option is set to 0, don't allow the filesystem group to read the
+        Extended OR Port cookie file. If the option is set to 1, make the cookie
+        file readable by the default GID. [Making the file readable by other
+        groups is not yet implemented; let us know if you need this for some
+        reason.] (Default: 0)
+
+[[FallbackDir]] **FallbackDir** __ipv4address__:__dirport__ orport=__orport__ id=__fingerprint__ [weight=__num__] [ipv6=**[**__ipv6address__**]**:__orport__]::
+        When tor is unable to connect to any directory cache for directory info
+        (usually because it doesn't know about any yet) it tries a hard-coded
+        directory. Relays try one directory authority at a time. Clients try
+        multiple directory authorities and FallbackDirs, to avoid hangs on
+        startup if a hard-coded directory is down. Clients wait for a few seconds
+        between each attempt, and retry FallbackDirs more often than directory
+        authorities, to reduce the load on the directory authorities.  +
+         +
+        FallbackDirs should be stable relays with stable IP addresses, ports,
+        and identity keys. They must have a DirPort. +
+         +
+        By default, the directory authorities are also FallbackDirs. Specifying a
+        FallbackDir replaces Tor's default hard-coded FallbackDirs (if any).
+        (See the **DirAuthority** entry for an explanation of each flag.)
 
 [[FetchDirInfoEarly]] **FetchDirInfoEarly** **0**|**1**::
-    If set to 1, Tor will always fetch directory information like other
-    directory caches, even if you don't meet the normal criteria for fetching
-    early. Normal users should leave it off. (Default: 0)
+        If set to 1, Tor will always fetch directory information like other
+        directory caches, even if you don't meet the normal criteria for fetching
+        early. Normal users should leave it off. (Default: 0)
 
 [[FetchDirInfoExtraEarly]] **FetchDirInfoExtraEarly** **0**|**1**::
-    If set to 1, Tor will fetch directory information before other directory
-    caches. It will attempt to download directory information closer to the
-    start of the consensus period. Normal users should leave it off.
-    (Default: 0)
+        If set to 1, Tor will fetch directory information before other directory
+        caches. It will attempt to download directory information closer to the
+        start of the consensus period. Normal users should leave it off.
+        (Default: 0)
 
 [[FetchHidServDescriptors]] **FetchHidServDescriptors** **0**|**1**::
-    If set to 0, Tor will never fetch any hidden service descriptors from the
-    rendezvous directories. This option is only useful if you're using a Tor
-    controller that handles hidden service fetches for you. (Default: 1)
+        If set to 0, Tor will never fetch any hidden service descriptors from the
+        rendezvous directories. This option is only useful if you're using a Tor
+        controller that handles hidden service fetches for you. (Default: 1)
 
 [[FetchServerDescriptors]] **FetchServerDescriptors** **0**|**1**::
-    If set to 0, Tor will never fetch any network status summaries or server
-    descriptors from the directory servers. This option is only useful if
-    you're using a Tor controller that handles directory fetches for you.
-    (Default: 1)
+        If set to 0, Tor will never fetch any network status summaries or server
+        descriptors from the directory servers. This option is only useful if
+        you're using a Tor controller that handles directory fetches for you.
+        (Default: 1)
 
 [[FetchUselessDescriptors]] **FetchUselessDescriptors** **0**|**1**::
-    If set to 1, Tor will fetch every consensus flavor, and all server
-    descriptors and authority certificates referenced by those consensuses,
-    except for extra info descriptors. When this option is 1, Tor will also
-    keep fetching descriptors, even when idle.
-    If set to 0, Tor will avoid fetching useless descriptors: flavors that it
-    is not using to build circuits, and authority certificates it does not
-    trust. When Tor hasn't built any application circuits, it will go idle,
-    and stop fetching descriptors. This option is useful if you're using a
-    tor client with an external parser that uses a full consensus.
-    This option fetches all documents except extrainfo descriptors,
-    **DirCache** fetches and serves all documents except extrainfo
-    descriptors, **DownloadExtraInfo*** fetches extrainfo documents, and serves
-    them if **DirCache** is on, and **UseMicrodescriptors** changes the
-    flavour of consensues and descriptors that is fetched and used for
-    building circuits. (Default: 0)
+        If set to 1, Tor will fetch every consensus flavor, and all server
+        descriptors and authority certificates referenced by those consensuses,
+        except for extra info descriptors. When this option is 1, Tor will also
+        keep fetching descriptors, even when idle.
+        If set to 0, Tor will avoid fetching useless descriptors: flavors that it
+        is not using to build circuits, and authority certificates it does not
+        trust. When Tor hasn't built any application circuits, it will go idle,
+        and stop fetching descriptors. This option is useful if you're using a
+        tor client with an external parser that uses a full consensus.
+        This option fetches all documents except extrainfo descriptors,
+        **DirCache** fetches and serves all documents except extrainfo
+        descriptors, **DownloadExtraInfo*** fetches extrainfo documents, and serves
+        them if **DirCache** is on, and **UseMicrodescriptors** changes the
+        flavour of consensues and descriptors that is fetched and used for
+        building circuits. (Default: 0)
+
+[[HardwareAccel]] **HardwareAccel** **0**|**1**::
+        If non-zero, try to use built-in (static) crypto hardware acceleration when
+        available. Can not be changed while tor is running. (Default: 0)
+
+[[HashedControlPassword]] **HashedControlPassword** __hashed_password__::
+        Allow connections on the control port if they present
+        the password whose one-way hash is __hashed_password__. You
+        can compute the hash of a password by running "tor --hash-password
+        __password__". You can provide several acceptable passwords by using more
+        than one HashedControlPassword line.
 
 [[HTTPProxy]] **HTTPProxy** __host__[:__port__]::
-    Tor will make all its directory requests through this host:port (or host:80
-    if port is not specified), rather than connecting directly to any directory
-    servers. (DEPRECATED: As of 0.3.1.0-alpha you should use HTTPSProxy.)
+        Tor will make all its directory requests through this host:port (or host:80
+        if port is not specified), rather than connecting directly to any directory
+        servers. (DEPRECATED: As of 0.3.1.0-alpha you should use HTTPSProxy.)
 
 [[HTTPProxyAuthenticator]] **HTTPProxyAuthenticator** __username:password__::
-    If defined, Tor will use this username:password for Basic HTTP proxy
-    authentication, as in RFC 2617. This is currently the only form of HTTP
-    proxy authentication that Tor supports; feel free to submit a patch if you
-    want it to support others. (DEPRECATED: As of 0.3.1.0-alpha you should use
-    HTTPSProxyAuthenticator.)
+        If defined, Tor will use this username:password for Basic HTTP proxy
+        authentication, as in RFC 2617. This is currently the only form of HTTP
+        proxy authentication that Tor supports; feel free to submit a patch if you
+        want it to support others. (DEPRECATED: As of 0.3.1.0-alpha you should use
+        HTTPSProxyAuthenticator.)
 
 [[HTTPSProxy]] **HTTPSProxy** __host__[:__port__]::
-    Tor will make all its OR (SSL) connections through this host:port (or
-    host:443 if port is not specified), via HTTP CONNECT rather than connecting
-    directly to servers. You may want to set **FascistFirewall** to restrict
-    the set of ports you might try to connect to, if your HTTPS proxy only
-    allows connecting to certain ports.
+        Tor will make all its OR (SSL) connections through this host:port (or
+        host:443 if port is not specified), via HTTP CONNECT rather than connecting
+        directly to servers. You may want to set **FascistFirewall** to restrict
+        the set of ports you might try to connect to, if your HTTPS proxy only
+        allows connecting to certain ports.
 
 [[HTTPSProxyAuthenticator]] **HTTPSProxyAuthenticator** __username:password__::
-    If defined, Tor will use this username:password for Basic HTTPS proxy
-    authentication, as in RFC 2617. This is currently the only form of HTTPS
-    proxy authentication that Tor supports; feel free to submit a patch if you
-    want it to support others.
+        If defined, Tor will use this username:password for Basic HTTPS proxy
+        authentication, as in RFC 2617. This is currently the only form of HTTPS
+        proxy authentication that Tor supports; feel free to submit a patch if you
+        want it to support others.
+
+[[KeepalivePeriod]] **KeepalivePeriod** __NUM__::
+        To keep firewalls from expiring connections, send a padding keepalive cell
+        every NUM seconds on open connections that are in use. (Default: 5 minutes)
+
+[[KeepBindCapabilities]] **KeepBindCapabilities** **0**|**1**|**auto**::
+        On Linux, when we are started as root and we switch our identity using
+        the **User** option, the **KeepBindCapabilities** option tells us whether to
+        try to retain our ability to bind to low ports.  If this value is 1, we
+        try to keep the capability; if it is 0 we do not; and if it is **auto**,
+        we keep the capability only if we are configured to listen on a low port.
+        Can not be changed while tor is running.
+        (Default: auto.)
+[[LogMessageDomains]] **LogMessageDomains** **0**|**1**::
+        If 1, Tor includes message domains with each log message.  Every log
+        message currently has at least one domain; most currently have exactly
+        one.  This doesn't affect controller log messages. (Default: 0)
+
+[[Log]] **Log** __minSeverity__[-__maxSeverity__] **stderr**|**stdout**|**syslog**::
+        Send all messages between __minSeverity__ and __maxSeverity__ to the standard
+        output stream, the standard error stream, or to the system log. (The
+        "syslog" value is only supported on Unix.) Recognized severity levels are
+        debug, info, notice, warn, and err. We advise using "notice" in most cases,
+        since anything more verbose may provide sensitive information to an
+        attacker who obtains the logs. If only one severity level is given, all
+        messages of that level or higher will be sent to the listed destination. +
+         +
+        Some low-level logs may be sent from signal handlers, so their destination
+        logs must be signal-safe. These low-level logs include backtraces,
+        logging function errors, and errors in code called by logging functions.
+        Signal-safe logs are always sent to stderr or stdout. They are also sent to
+        a limited number of log files that are configured to log messages at error
+        severity from the bug or general domains. They are never sent as syslogs,
+        android logs, control port log events, or to any API-based log
+        destinations.
+
+[[Log2]] **Log** __minSeverity__[-__maxSeverity__] **file** __FILENAME__::
+        As above, but send log messages to the listed filename. The
+        "Log" option may appear more than once in a configuration file.
+        Messages are sent to all the logs that match their severity
+        level.
+
+[[Log3]] **Log** **[**__domain__,...**]**__minSeverity__[-__maxSeverity__] ... **file** __FILENAME__ +
+
+[[Log4]] **Log** **[**__domain__,...**]**__minSeverity__[-__maxSeverity__] ... **stderr**|**stdout**|**syslog**::
+        As above, but select messages by range of log severity __and__ by a
+        set of "logging domains".  Each logging domain corresponds to an area of
+        functionality inside Tor.  You can specify any number of severity ranges
+        for a single log statement, each of them prefixed by a comma-separated
+        list of logging domains.  You can prefix a domain with $$~$$ to indicate
+        negation, and use * to indicate "all domains".  If you specify a severity
+        range without a list of domains, it matches all domains. +
+         +
+        This is an advanced feature which is most useful for debugging one or two
+        of Tor's subsystems at a time. +
+         +
+        The currently recognized domains are: general, crypto, net, config, fs,
+        protocol, mm, http, app, control, circ, rend, bug, dir, dirserv, or, edge,
+        acct, hist, handshake, heartbeat, channel, sched, guard, consdiff, dos,
+        process, pt, btrack, and mesg.
+        Domain names are case-insensitive. +
+         +
+        For example, "`Log [handshake]debug [~net,~mm]info notice stdout`" sends
+        to stdout: all handshake messages of any severity, all info-and-higher
+        messages from domains other than networking and memory management, and all
+        messages of severity notice or higher.
+
+[[LogTimeGranularity]] **LogTimeGranularity** __NUM__::
+        Set the resolution of timestamps in Tor's logs to NUM milliseconds.
+        NUM must be positive and either a divisor or a multiple of 1 second.
+        Note that this option only controls the granularity written by Tor to
+        a file or console log.  Tor does not (for example) "batch up" log
+        messages to affect times logged by a controller, times attached to
+        syslog messages, or the mtime fields on log files.  (Default: 1 second)
+
+[[MaxAdvertisedBandwidth]] **MaxAdvertisedBandwidth** __N__ **bytes**|**KBytes**|**MBytes**|**GBytes**|**TBytes**|**KBits**|**MBits**|**GBits**|**TBits**::
+       If set, we will not advertise more than this amount of bandwidth for our
+       BandwidthRate. Server operators who want to reduce the number of clients
+       who ask to build circuits through them (since this is proportional to
+       advertised bandwidth rate) can thus reduce the CPU demands on their server
+       without impacting network performance.
+
+[[MaxUnparseableDescSizeToLog]] **MaxUnparseableDescSizeToLog** __N__ **bytes**|**KBytes**|**MBytes**|**GBytes**|**TBytes**::
+       Unparseable descriptors (e.g. for votes, consensuses, routers) are logged
+       in separate files by hash, up to the specified size in total.  Note that
+       only files logged during the lifetime of this Tor process count toward the
+       total; this is intended to be used to debug problems without opening live
+       servers to resource exhaustion attacks. (Default: 10 MBytes)
+
+[[NoExec]] **NoExec** **0**|**1**::
+       If this option is set to 1, then Tor will never launch another
+       executable, regardless of the settings of ClientTransportPlugin
+       or ServerTransportPlugin.  Once this option has been set to 1,
+       it cannot be set back to 0 without restarting Tor. (Default: 0)
+
+
+[[OutboundBindAddress]] **OutboundBindAddress** __IP__::
+           Make all outbound connections originate from the IP address specified. This
+           is only useful when you have multiple network interfaces, and you want all
+           of Tor's outgoing connections to use a single one. This option may
+           be used twice, once with an IPv4 address and once with an IPv6 address.
+           IPv6 addresses should be wrapped in square brackets.
+           This setting will be ignored for connections to the loopback addresses
+           (127.0.0.0/8 and ::1), and is not used for DNS requests as well.
+
+[[OutboundBindAddressExit]] **OutboundBindAddressExit** __IP__::
+            Make all outbound exit connections originate from the IP address
+            specified. This option overrides **OutboundBindAddress** for the
+            same IP version. This option may be used twice, once with an IPv4
+            address and once with an IPv6 address.
+            IPv6 addresses should be wrapped in square brackets.
+            This setting will be ignored
+            for connections to the loopback addresses (127.0.0.0/8 and ::1).
+
+[[OutboundBindAddressOR]] **OutboundBindAddressOR** __IP__::
+           Make all outbound non-exit (relay and other) connections
+           originate from the IP address specified. This option overrides
+           **OutboundBindAddress** for the same IP version. This option may
+           be used twice, once with an IPv4 address and once with an IPv6
+           address. IPv6 addresses should be wrapped in square brackets.
+           This setting will be ignored for connections to the loopback
+           addresses (127.0.0.0/8 and ::1).
+
+[[PerConnBWBurst]] **PerConnBWBurst** __N__ **bytes**|**KBytes**|**MBytes**|**GBytes**|**TBytes**|**KBits**|**MBits**|**GBits**|**TBits**::
+    If this option is set manually, or via the "perconnbwburst" consensus
+    field, Tor will use it for separate rate limiting for each connection
+    from a non-relay. (Default: 0)
+
+[[PerConnBWRate]] **PerConnBWRate** __N__ **bytes**|**KBytes**|**MBytes**|**GBytes**|**TBytes**|**KBits**|**MBits**|**GBits**|**TBits**::
+     If this option is set manually, or via the "perconnbwrate" consensus
+     field, Tor will use it for separate rate limiting for each connection
+     from a non-relay. (Default: 0)
+
+[[PidFile]] **PidFile** __FILE__::
+      On startup, write our PID to FILE. On clean shutdown, remove
+      FILE. Can not be changed while tor is running.
+
+[[ProtocolWarnings]] **ProtocolWarnings** **0**|**1**::
+      If 1, Tor will log with severity \'warn' various cases of other parties not
+      following the Tor specification. Otherwise, they are logged with severity
+      \'info'. (Default: 0)
+
+[[RelayBandwidthBurst]] **RelayBandwidthBurst** __N__ **bytes**|**KBytes**|**MBytes**|**GBytes**|**TBytes**|**KBits**|**MBits**|**GBits**|**TBits**::
+      If not 0, limit the maximum token bucket size (also known as the burst) for
+      \_relayed traffic_ to the given number of bytes in each direction.
+      They do not include directory fetches by the relay (from authority
+      or other relays), because that is considered "client" activity. (Default: 0)
+
+[[RelayBandwidthRate]] **RelayBandwidthRate** __N__ **bytes**|**KBytes**|**MBytes**|**GBytes**|**TBytes**|**KBits**|**MBits**|**GBits**|**TBits**::
+     If not 0, a separate token bucket limits the average incoming bandwidth
+     usage for \_relayed traffic_ on this node to the specified number of bytes
+     per second, and the average outgoing bandwidth usage to that same value.
+     Relayed traffic currently is calculated to include answers to directory
+     requests, but that may change in future versions. They do not include directory
+     fetches by the relay (from authority or other relays), because that is considered
+     "client" activity.  (Default: 0)
+
+[[RunAsDaemon]] **RunAsDaemon** **0**|**1**::
+     If 1, Tor forks and daemonizes to the background. This option has no effect
+     on Windows; instead you should use the --service command-line option.
+     Can not be changed while tor is running.
+     (Default: 0)
+
+[[SafeLogging]] **SafeLogging** **0**|**1**|**relay**::
+     Tor can scrub potentially sensitive strings from log messages (e.g.
+     addresses) by replacing them with the string [scrubbed]. This way logs can
+     still be useful, but they don't leave behind personally identifying
+     information about what sites a user might have visited. +
+      +
+     If this option is set to 0, Tor will not perform any scrubbing, if it is
+     set to 1, all potentially sensitive strings are replaced. If it is set to
+     relay, all log messages generated when acting as a relay are sanitized, but
+     all messages generated when acting as a client are not.
+     Note: Tor may not heed this option when logging at log levels below Notice.
+     (Default: 1)
 
 [[Sandbox]] **Sandbox** **0**|**1**::
-    If set to 1, Tor will run securely through the use of a syscall sandbox.
-    Otherwise the sandbox will be disabled. The option is currently an
-    experimental feature. It only works on Linux-based operating systems,
-    and only when Tor has been built with the libseccomp library. This option
-    can not be changed while tor is running. +
- +
-    When the **Sandbox** is 1, the following options can not be changed when tor
-    is running:
-    **Address**,
-    **ConnLimit**,
-    **CookieAuthFile**,
-    **DirPortFrontPage**,
-    **ExtORPortCookieAuthFile**,
-    **Logs**,
-    **ServerDNSResolvConfFile**,
-    **ClientOnionAuthDir** (and any files in it won't reload on HUP signal).
- +
-    Launching new Onion Services through the control port is not supported
-    with current syscall sandboxing implementation.
- +
-    Tor must remain in client or server mode (some changes to **ClientOnly**
-    and **ORPort** are not allowed). Currently, if **Sandbox** is 1,
-    **ControlPort** command "GETINFO address" will not work.
- +
-    (Default: 0)
+     If set to 1, Tor will run securely through the use of a syscall sandbox.
+     Otherwise the sandbox will be disabled. The option is currently an
+     experimental feature. It only works on Linux-based operating systems,
+     and only when Tor has been built with the libseccomp library. This option
+     can not be changed while tor is running. +
+      +
+     When the **Sandbox** is 1, the following options can not be changed when tor
+     is running:
+     **Address**,
+     **ConnLimit**,
+     **CookieAuthFile**,
+     **DirPortFrontPage**,
+     **ExtORPortCookieAuthFile**,
+     **Logs**,
+     **ServerDNSResolvConfFile**,
+     **ClientOnionAuthDir** (and any files in it won't reload on HUP signal). +
+      +
+     Launching new Onion Services through the control port is not supported
+     with current syscall sandboxing implementation.
+     Tor must remain in client or server mode (some changes to **ClientOnly**
+     and **ORPort** are not allowed). Currently, if **Sandbox** is 1,
+     **ControlPort** command "GETINFO address" will not work.
+      +
+     (Default: 0)
+
+[[Schedulers]] **Schedulers** **KIST**|**KISTLite**|**Vanilla**::
+     Specify the scheduler type that tor should use. The scheduler is
+     responsible for moving data around within a Tor process. This is an ordered
+     list by priority which means that the first value will be tried first and if
+     unavailable, the second one is tried and so on. It is possible to change
+     these values at runtime. This option mostly effects relays, and most
+     operators should leave it set to its default value.
+     (Default: KIST,KISTLite,Vanilla) +
+      +
+     The possible scheduler types are:
+      +
+     **KIST**: Kernel-Informed Socket Transport. Tor will use TCP information
+     from the kernel to make informed decisions regarding how much data to send
+     and when to send it. KIST also handles traffic in batches (see
+     KISTSchedRunInterval) in order to improve traffic prioritization decisions.
+     As implemented, KIST will only work on Linux kernel version 2.6.39 or
+     higher. +
+      +
+     **KISTLite**: Same as KIST but without kernel support. Tor will use all
+     the same mechanics as with KIST, including the batching, but its decisions
+     regarding how much data to send will not be as good. KISTLite will work on
+     all kernels and operating systems, and the majority of the benefits of KIST
+     are still realized with KISTLite. +
+      +
+     **Vanilla**: The scheduler that Tor used before KIST was implemented. It
+     sends as much data as possible, as soon as possible. Vanilla will work on
+     all kernels and operating systems.
+
+[[KISTSchedRunInterval]] **KISTSchedRunInterval** __NUM__ **msec**::
+     If KIST or KISTLite is used in the Schedulers option, this controls at which
+     interval the scheduler tick is. If the value is 0 msec, the value is taken
+     from the consensus if possible else it will fallback to the default 10
+     msec. Maximum possible value is 100 msec. (Default: 0 msec)
+
+[[KISTSockBufSizeFactor]] **KISTSockBufSizeFactor** __NUM__::
+     If KIST is used in Schedulers, this is a multiplier of the per-socket
+     limit calculation of the KIST algorithm. (Default: 1.0)
+
+
+[[ServerTransportListenAddr]] **ServerTransportListenAddr** __transport__ __IP__:__PORT__::
+    When this option is set, Tor will suggest __IP__:__PORT__ as the
+    listening address of any pluggable transport proxy that tries to
+    launch __transport__. (IPv4 addresses should written as-is; IPv6
+    addresses should be wrapped in square brackets.) (Default: none)
+
+[[ServerTransportOptions]] **ServerTransportOptions** __transport__ __k=v__ __k=v__ ...::
+    When this option is set, Tor will pass the __k=v__ parameters to
+    any pluggable transport proxy that tries to launch __transport__. +
+    (Example: ServerTransportOptions obfs45 shared-secret=bridgepasswd cache=/var/lib/tor/cache) (Default: none)
+
+[[ServerTransportPlugin]] **ServerTransportPlugin** __transport__ exec __path-to-binary__ [options]::
+      The Tor relay launches the pluggable transport proxy in __path-to-binary__
+      using __options__ as its command-line options, and expects to receive
+      proxied client traffic from it. (Default: none)
 
 [[Socks4Proxy]] **Socks4Proxy** __host__[:__port__]::
     Tor will make all OR connections through the SOCKS 4 proxy at host:port
@@ -681,255 +906,28 @@ GENERAL OPTIONS
     in accordance to RFC 1929. Both username and password must be between 1 and
     255 characters.
 
-[[UnixSocksGroupWritable]] **UnixSocksGroupWritable** **0**|**1**::
-    If this option is set to 0, don't allow the filesystem group to read and
-    write unix sockets (e.g. SocksPort unix:). If the option is set to 1, make
-    the Unix socket readable and writable by the default GID. (Default: 0)
-
-[[KeepalivePeriod]] **KeepalivePeriod** __NUM__::
-    To keep firewalls from expiring connections, send a padding keepalive cell
-    every NUM seconds on open connections that are in use. (Default: 5 minutes)
-
-[[Log]] **Log** __minSeverity__[-__maxSeverity__] **stderr**|**stdout**|**syslog**::
-    Send all messages between __minSeverity__ and __maxSeverity__ to the standard
-    output stream, the standard error stream, or to the system log. (The
-    "syslog" value is only supported on Unix.) Recognized severity levels are
-    debug, info, notice, warn, and err. We advise using "notice" in most cases,
-    since anything more verbose may provide sensitive information to an
-    attacker who obtains the logs. If only one severity level is given, all
-    messages of that level or higher will be sent to the listed destination. +
- +
-    Some low-level logs may be sent from signal handlers, so their destination
-    logs must be signal-safe. These low-level logs include backtraces,
-    logging function errors, and errors in code called by logging functions.
-    Signal-safe logs are always sent to stderr or stdout. They are also sent to
-    a limited number of log files that are configured to log messages at error
-    severity from the bug or general domains. They are never sent as syslogs,
-    android logs, control port log events, or to any API-based log
-    destinations.
-
-[[Log2]] **Log** __minSeverity__[-__maxSeverity__] **file** __FILENAME__::
-    As above, but send log messages to the listed filename. The
-    "Log" option may appear more than once in a configuration file.
-    Messages are sent to all the logs that match their severity
-    level.
-
-[[Log3]] **Log** **[**__domain__,...**]**__minSeverity__[-__maxSeverity__] ... **file** __FILENAME__ +
-
-[[Log4]] **Log** **[**__domain__,...**]**__minSeverity__[-__maxSeverity__] ... **stderr**|**stdout**|**syslog**::
-    As above, but select messages by range of log severity __and__ by a
-    set of "logging domains".  Each logging domain corresponds to an area of
-    functionality inside Tor.  You can specify any number of severity ranges
-    for a single log statement, each of them prefixed by a comma-separated
-    list of logging domains.  You can prefix a domain with $$~$$ to indicate
-    negation, and use * to indicate "all domains".  If you specify a severity
-    range without a list of domains, it matches all domains. +
- +
-    This is an advanced feature which is most useful for debugging one or two
-    of Tor's subsystems at a time. +
- +
-    The currently recognized domains are: general, crypto, net, config, fs,
-    protocol, mm, http, app, control, circ, rend, bug, dir, dirserv, or, edge,
-    acct, hist, handshake, heartbeat, channel, sched, guard, consdiff, dos,
-    process, pt, btrack, and mesg.
-    Domain names are case-insensitive. +
- +
-    For example, "`Log [handshake]debug [~net,~mm]info notice stdout`" sends
-    to stdout: all handshake messages of any severity, all info-and-higher
-    messages from domains other than networking and memory management, and all
-    messages of severity notice or higher.
-
-[[LogMessageDomains]] **LogMessageDomains** **0**|**1**::
-    If 1, Tor includes message domains with each log message.  Every log
-    message currently has at least one domain; most currently have exactly
-    one.  This doesn't affect controller log messages. (Default: 0)
-
-[[MaxUnparseableDescSizeToLog]] **MaxUnparseableDescSizeToLog** __N__ **bytes**|**KBytes**|**MBytes**|**GBytes**|**TBytes**::
-    Unparseable descriptors (e.g. for votes, consensuses, routers) are logged
-    in separate files by hash, up to the specified size in total.  Note that
-    only files logged during the lifetime of this Tor process count toward the
-    total; this is intended to be used to debug problems without opening live
-    servers to resource exhaustion attacks. (Default: 10 MBytes)
-
-[[OutboundBindAddress]] **OutboundBindAddress** __IP__::
-    Make all outbound connections originate from the IP address specified. This
-    is only useful when you have multiple network interfaces, and you want all
-    of Tor's outgoing connections to use a single one. This option may
-    be used twice, once with an IPv4 address and once with an IPv6 address.
-    IPv6 addresses should be wrapped in square brackets.
-    This setting will be ignored for connections to the loopback addresses
-    (127.0.0.0/8 and ::1), and is not used for DNS requests as well.
-
-[[OutboundBindAddressOR]] **OutboundBindAddressOR** __IP__::
-    Make all outbound non-exit (relay and other) connections
-    originate from the IP address specified. This option overrides
-    **OutboundBindAddress** for the same IP version. This option may
-    be used twice, once with an IPv4 address and once with an IPv6
-    address. IPv6 addresses should be wrapped in square brackets.
-    This setting will be ignored for connections to the loopback
-    addresses (127.0.0.0/8 and ::1).
-
-[[OutboundBindAddressExit]] **OutboundBindAddressExit** __IP__::
-    Make all outbound exit connections originate from the IP address
-    specified. This option overrides **OutboundBindAddress** for the
-    same IP version. This option may be used twice, once with an IPv4
-    address and once with an IPv6 address.
-    IPv6 addresses should be wrapped in square brackets.
-    This setting will be ignored
-    for connections to the loopback addresses (127.0.0.0/8 and ::1).
-
-[[PidFile]] **PidFile** __FILE__::
-    On startup, write our PID to FILE. On clean shutdown, remove
-    FILE. Can not be changed while tor is running.
-
-[[ProtocolWarnings]] **ProtocolWarnings** **0**|**1**::
-    If 1, Tor will log with severity \'warn' various cases of other parties not
-    following the Tor specification. Otherwise, they are logged with severity
-    \'info'. (Default: 0)
-
-[[RunAsDaemon]] **RunAsDaemon** **0**|**1**::
-    If 1, Tor forks and daemonizes to the background. This option has no effect
-    on Windows; instead you should use the --service command-line option.
-    Can not be changed while tor is running.
-    (Default: 0)
-
-[[LogTimeGranularity]] **LogTimeGranularity** __NUM__::
-    Set the resolution of timestamps in Tor's logs to NUM milliseconds.
-    NUM must be positive and either a divisor or a multiple of 1 second.
-    Note that this option only controls the granularity written by Tor to
-    a file or console log.  Tor does not (for example) "batch up" log
-    messages to affect times logged by a controller, times attached to
-    syslog messages, or the mtime fields on log files.  (Default: 1 second)
-
-[[TruncateLogFile]] **TruncateLogFile** **0**|**1**::
-    If 1, Tor will overwrite logs at startup and in response to a HUP signal,
-    instead of appending to them. (Default: 0)
-
 [[SyslogIdentityTag]] **SyslogIdentityTag** __tag__::
     When logging to syslog, adds a tag to the syslog identity such that
     log entries are marked with "Tor-__tag__". Can not be changed while tor is
     running. (Default: none)
 
-[[AndroidIdentityTag]] **AndroidIdentityTag** __tag__::
-    When logging to Android's logging subsystem, adds a tag to the log identity
-    such that log entries are marked with "Tor-__tag__". Can not be changed while
-    tor is running. (Default: none)
+[[TruncateLogFile]] **TruncateLogFile** **0**|**1**::
+    If 1, Tor will overwrite logs at startup and in response to a HUP signal,
+        instead of appending to them. (Default: 0)
 
-[[SafeLogging]] **SafeLogging** **0**|**1**|**relay**::
-    Tor can scrub potentially sensitive strings from log messages (e.g.
-    addresses) by replacing them with the string [scrubbed]. This way logs can
-    still be useful, but they don't leave behind personally identifying
-    information about what sites a user might have visited. +
- +
-    If this option is set to 0, Tor will not perform any scrubbing, if it is
-    set to 1, all potentially sensitive strings are replaced. If it is set to
-    relay, all log messages generated when acting as a relay are sanitized, but
-    all messages generated when acting as a client are not.
-    Note: Tor may not heed this option when logging at log levels below Notice.
-    (Default: 1)
+[[UnixSocksGroupWritable]] **UnixSocksGroupWritable** **0**|**1**::
+    If this option is set to 0, don't allow the filesystem group to read and
+    write unix sockets (e.g. SocksPort unix:). If the option is set to 1, make
+    the Unix socket readable and writable by the default GID. (Default: 0)
+
+[[UseDefaultFallbackDirs]] **UseDefaultFallbackDirs** **0**|**1**::
+    Use Tor's default hard-coded FallbackDirs (if any). (When a
+    FallbackDir line is present, it replaces the hard-coded FallbackDirs,
+    regardless of the value of UseDefaultFallbackDirs.) (Default: 1)
 
 [[User]] **User** __Username__::
     On startup, setuid to this user and setgid to their primary group.
     Can not be changed while tor is running.
-
-[[KeepBindCapabilities]] **KeepBindCapabilities** **0**|**1**|**auto**::
-    On Linux, when we are started as root and we switch our identity using
-    the **User** option, the **KeepBindCapabilities** option tells us whether to
-    try to retain our ability to bind to low ports.  If this value is 1, we
-    try to keep the capability; if it is 0 we do not; and if it is **auto**,
-    we keep the capability only if we are configured to listen on a low port.
-    Can not be changed while tor is running.
-    (Default: auto.)
-
-[[HardwareAccel]] **HardwareAccel** **0**|**1**::
-    If non-zero, try to use built-in (static) crypto hardware acceleration when
-    available. Can not be changed while tor is running. (Default: 0)
-
-[[AccelName]] **AccelName** __NAME__::
-    When using OpenSSL hardware crypto acceleration attempt to load the dynamic
-    engine of this name. This must be used for any dynamic hardware engine.
-    Names can be verified with the openssl engine command. Can not be changed
-    while tor is running.
- +
-    If the engine name is prefixed with a "!", then Tor will exit if the
-    engine cannot be loaded.
-
-[[AccelDir]] **AccelDir** __DIR__::
-    Specify this option if using dynamic hardware acceleration and the engine
-    implementation library resides somewhere other than the OpenSSL default.
-    Can not be changed while tor is running.
-
-[[AvoidDiskWrites]] **AvoidDiskWrites** **0**|**1**::
-    If non-zero, try to write to disk less frequently than we would otherwise.
-    This is useful when running on flash memory or other media that support
-    only a limited number of writes. (Default: 0)
-
-[[CircuitPriorityHalflife]] **CircuitPriorityHalflife** __NUM__::
-    If this value is set, we override the default algorithm for choosing which
-    circuit's cell to deliver or relay next. It is delivered first to the
-    circuit that has the lowest weighted cell count, where cells are weighted
-    exponentially according to this value (in seconds). If the value is -1, it
-    is taken from the consensus if possible else it will fallback to the
-    default value of 30. Minimum: 1, Maximum: 2147483647. This can be defined
-    as a float value. This is an advanced option; you generally shouldn't have
-    to mess with it. (Default: -1)
-
-[[CountPrivateBandwidth]] **CountPrivateBandwidth** **0**|**1**::
-    If this option is set, then Tor's rate-limiting applies not only to
-    remote connections, but also to connections to private addresses like
-    127.0.0.1 or 10.0.0.1.  This is mostly useful for debugging
-    rate-limiting.  (Default: 0)
-
-[[ExtendByEd25519ID]] **ExtendByEd25519ID** **0**|**1**|**auto**::
-    If this option is set to 1, we always try to include a relay's Ed25519 ID
-    when telling the proceeding relay in a circuit to extend to it.
-    If this option is set to 0, we never include Ed25519 IDs when extending
-    circuits.  If the option is set to "default", we obey a
-    parameter in the consensus document. (Default: auto)
-
-[[NoExec]] **NoExec** **0**|**1**::
-    If this option is set to 1, then Tor will never launch another
-    executable, regardless of the settings of ClientTransportPlugin
-    or ServerTransportPlugin.  Once this option has been set to 1,
-    it cannot be set back to 0 without restarting Tor. (Default: 0)
-
-[[Schedulers]] **Schedulers** **KIST**|**KISTLite**|**Vanilla**::
-    Specify the scheduler type that tor should use. The scheduler is
-    responsible for moving data around within a Tor process. This is an ordered
-    list by priority which means that the first value will be tried first and if
-    unavailable, the second one is tried and so on. It is possible to change
-    these values at runtime. This option mostly effects relays, and most
-    operators should leave it set to its default value.
-    (Default: KIST,KISTLite,Vanilla)
- +
-    The possible scheduler types are:
- +
-    **KIST**: Kernel-Informed Socket Transport. Tor will use TCP information
-    from the kernel to make informed decisions regarding how much data to send
-    and when to send it. KIST also handles traffic in batches (see
-    KISTSchedRunInterval) in order to improve traffic prioritization decisions.
-    As implemented, KIST will only work on Linux kernel version 2.6.39 or
-    higher.
- +
-    **KISTLite**: Same as KIST but without kernel support. Tor will use all
-    the same mechanics as with KIST, including the batching, but its decisions
-    regarding how much data to send will not be as good. KISTLite will work on
-    all kernels and operating systems, and the majority of the benefits of KIST
-    are still realized with KISTLite.
- +
-    **Vanilla**: The scheduler that Tor used before KIST was implemented. It
-    sends as much data as possible, as soon as possible. Vanilla will work on
-    all kernels and operating systems.
-
-[[KISTSchedRunInterval]] **KISTSchedRunInterval** __NUM__ **msec**::
-    If KIST or KISTLite is used in the Schedulers option, this controls at which
-    interval the scheduler tick is. If the value is 0 msec, the value is taken
-    from the consensus if possible else it will fallback to the default 10
-    msec. Maximum possible value is 100 msec. (Default: 0 msec)
-
-[[KISTSockBufSizeFactor]] **KISTSockBufSizeFactor** __NUM__::
-    If KIST is used in Schedulers, this is a multiplier of the per-socket
-    limit calculation of the KIST algorithm. (Default: 1.0)
 
 CLIENT OPTIONS
 --------------


### PR DESCRIPTION
Working on bug https://trac.torproject.org/projects/tor/ticket/4310 to alphabetically categorize config options under each category. 

This Pull Request contains the alphabetical sorting of options under the General Options category.

Please review the changes.