### PR TITLE
[Tor Trac #32626]: Remove extra space in #define in ed25519-donna-portable-identify.h

### DIFF
--- a/src/ext/ed25519/donna/ed25519-donna-portable-identify.h
+++ b/src/ext/ed25519/donna/ed25519-donna-portable-identify.h
@@ -45,7 +45,7 @@
 
 
 /* cpu */
-#if defined(__amd64__) || defined(__amd64) || defined(__x86_64__ ) || defined(_M_X64)
+#if defined(__amd64__) || defined(__amd64) || defined(__x86_64__) || defined(_M_X64)
 	#define CPU_X86_64
 #elif defined(__i586__) || defined(__i686__) || (defined(_M_IX86) && (_M_IX86 >= 500))
 	#define CPU_X86 500


### PR DESCRIPTION
Ticket: https://trac.torproject.org/projects/tor/ticket/32626