### PR TITLE
cocci: Require spatch >= 1.0.4 to run checks

### DIFF
--- a/scripts/coccinelle/check_cocci_parse.sh
+++ b/scripts/coccinelle/check_cocci_parse.sh
@@ -23,6 +23,8 @@ export TOR_COCCI_EXCEPTIONS_FILE="${TOR_COCCI_EXCEPTIONS_FILE:-$scripts_cocci/ex
 
 PURPOSE="cocci C parsing"
 
+echo "Checking spatch:"
+
 if ! command -v spatch ; then
     echo "Install coccinelle's spatch to check $PURPOSE."
     exit "$exitcode"
@@ -48,6 +50,9 @@ if ! version_ge "1" "0" ; then
     echo "Some spatch version checks may give the wrong result."
     SORT_V="sort -n"
 fi
+
+# Print the full spatch version, for diagnostics
+spatch --version
 
 MIN_SPATCH_V="1.0.4"
 SPATCH_V=$(spatch --version | head -1 | \

--- a/scripts/coccinelle/check_cocci_parse.sh
+++ b/scripts/coccinelle/check_cocci_parse.sh
@@ -55,8 +55,11 @@ fi
 spatch --version
 
 MIN_SPATCH_V="1.0.4"
+# This pattern needs to handle version strings like:
+# spatch version 1.0.0-rc19
+# spatch version 1.0.6 compiled with OCaml version 4.05.0
 SPATCH_V=$(spatch --version | head -1 | \
-               sed 's/spatch version \([0-9][\.0-9]*\) .*/\1/')
+               sed 's/spatch version \([0-9][^ ]*\).*/\1/')
 
 if ! version_ge "$SPATCH_V" "$MIN_SPATCH_V" ; then
     echo "Tor requires coccinelle spatch >= $MIN_SPATCH_V to check $PURPOSE."


### PR DESCRIPTION
No changes file required: not in any released version of tor.

Fixes bug 32663.