### PR TITLE
Correct how we use libseccomp

### DIFF
--- a/changes/bug29819
+++ b/changes/bug29819
@@ -1,0 +1,8 @@
+  o Minor bugfixes (linux seccomp sandbox):
+    - Correct how we use libseccomp. Particularly, stop assuming that
+      rules are applied in a particular order or that more rules are
+      processed after the first match. Neither is the case! In libseccomp
+      <2.4.0 this lead to some rules having no effect. Libseccomp 2.4.0
+      changed how rules are generated leading to a different ordering
+      which in turn lead to a fatal crash during startup. Fixes bug
+      29819; bugfix on 0.2.5.1-alpha. Patch by Peter Gerber.

--- a/src/lib/sandbox/sandbox.c
+++ b/src/lib/sandbox/sandbox.c
@@ -491,24 +491,6 @@ sb_open(scmp_filter_ctx ctx, sandbox_cfg_t *filter)
     }
   }
 
-  rc = seccomp_rule_add_1(ctx, SCMP_ACT_ERRNO(EACCES), SCMP_SYS(open),
-                SCMP_CMP_MASKED(1, O_CLOEXEC|O_NONBLOCK|O_NOCTTY|O_NOFOLLOW,
-                                O_RDONLY));
-  if (rc != 0) {
-    log_err(LD_BUG,"(Sandbox) failed to add open syscall, received libseccomp "
-        "error %d", rc);
-    return rc;
-  }
-
-  rc = seccomp_rule_add_1(ctx, SCMP_ACT_ERRNO(EACCES), SCMP_SYS(openat),
-                SCMP_CMP_MASKED(2, O_CLOEXEC|O_NONBLOCK|O_NOCTTY|O_NOFOLLOW,
-                                O_RDONLY));
-  if (rc != 0) {
-    log_err(LD_BUG,"(Sandbox) failed to add openat syscall, received "
-            "libseccomp error %d", rc);
-    return rc;
-  }
-
   return 0;
 }
 
@@ -557,23 +539,6 @@ sb_chown(scmp_filter_ctx ctx, sandbox_cfg_t *filter)
         return rc;
       }
     }
-  }
-
-  return 0;
-}
-
-static int
-sb__sysctl(scmp_filter_ctx ctx, sandbox_cfg_t *filter)
-{
-  int rc;
-  (void) filter;
-  (void) ctx;
-
-  rc = seccomp_rule_add_0(ctx, SCMP_ACT_ERRNO(EPERM), SCMP_SYS(_sysctl));
-  if (rc != 0) {
-    log_err(LD_BUG,"(Sandbox) failed to add _sysctl syscall, "
-        "received libseccomp error %d", rc);
-    return rc;
   }
 
   return 0;
@@ -1141,7 +1106,6 @@ static sandbox_filter_func_t filter_func[] = {
     sb_chmod,
     sb_open,
     sb_openat,
-    sb__sysctl,
     sb_rename,
 #ifdef __NR_fcntl64
     sb_fcntl64,
@@ -1518,14 +1482,14 @@ install_syscall_filter(sandbox_cfg_t* cfg)
   int rc = 0;
   scmp_filter_ctx ctx;
 
-  ctx = seccomp_init(SCMP_ACT_TRAP);
+  ctx = seccomp_init(SCMP_ACT_ERRNO(EPERM));
   if (ctx == NULL) {
     log_err(LD_BUG,"(Sandbox) failed to initialise libseccomp context");
     rc = -1;
     goto end;
   }
 
-  // protectign sandbox parameter strings
+  // protecting sandbox parameter strings
   if ((rc = prot_strings(ctx, cfg))) {
     goto end;
   }


### PR DESCRIPTION
This fixes a startup crash with libseccomp v2.4.0 if Sandbox is
set to 1.