### PR TITLE
Script to set us up for building all of our headers by themselves

### DIFF
--- a/scripts/test/build_headers.sh
+++ b/scripts/test/build_headers.sh
@@ -1,0 +1,41 @@
+#!/bin/sh
+
+mkdir -p test_headers
+rm -f test_headers/Makefile
+
+cat >> test_headers/Makefile <<EOF
+
+all: objects
+
+%.o: %.c
+	gcc -c -Wall -Werror @../warning_flags -I .. -I ../src -I ../src/ext -o \$@ \$<
+EOF
+
+add_obj()
+{
+    NAME="$1"
+    HDR="$2"
+    cat >> test_headers/Makefile <<EOF
+objects: ${NAME}.o
+${NAME}.o: ${NAME}.c ${HDR}
+EOF
+}
+
+
+for hdr in $(cd ./src && find lib core feature app -name '*.h'); do
+  name=$(basename "$hdr" .h)
+
+  grep '^ *# *ifdef *[A-Z_]*_PRIVATE' "src/${hdr}" | \
+      sed -e 's/.*ifdef */#define /' | \
+      uniq > \
+           test_headers/"${name}"_t.c
+
+  cat >>test_headers/"${name}"_t.c <<EOF
+
+#include "$hdr"
+
+EOF
+
+  add_obj "${name}_t" "../src/${hdr}"
+
+done


### PR DESCRIPTION
This script makes a directory called "test_headers", then populates
it with one C file for each header.  The C file defines all of the
*_PRIVATE macros listed in the header, and then includes the header.

The script also makes a Makefile in this directory that tries to
build every C file it generates.

This script is not production-ready: it does not handle out-of-tree
operation, and doesn't look at the flags actually set by autoconf.