### PR TITLE
Mark TestingEstimatedDescriptorPropagationTime as obsolete.

### DIFF
--- a/changes/ticket32807
+++ b/changes/ticket32807
@@ -1,0 +1,4 @@
+  o Removed features:
+    - The option "TestingEstimatedDescriptorPropagationTime" is now marked as
+      obsolete.  It has had no effect since 0.3.0.7, when clients stopped
+      rejecting consensuses "from the future".  Closes ticket 32807.

--- a/doc/tor.1.txt
+++ b/doc/tor.1.txt
@@ -3256,7 +3256,6 @@ The following options are used for running a testing Tor network.
        TestingV3AuthInitialVoteDelay 20 seconds
        TestingV3AuthInitialDistDelay 20 seconds
        TestingAuthDirTimeToLearnReachability 0 minutes
-       TestingEstimatedDescriptorPropagationTime 0 minutes
        TestingServerDownloadInitialDelay 0
        TestingClientDownloadInitialDelay 0
        TestingServerConsensusDownloadInitialDelay 0
@@ -3291,11 +3290,6 @@ The following options are used for running a testing Tor network.
     After starting as an authority, do not make claims about whether routers
     are Running until this much time has passed. Changing this requires
     that **TestingTorNetwork** is set.  (Default: 30 minutes)
-
-[[TestingEstimatedDescriptorPropagationTime]] **TestingEstimatedDescriptorPropagationTime** __N__ **minutes**|**hours**::
-    Clients try downloading server descriptors from directory caches after this
-    time. Changing this requires that **TestingTorNetwork** is set. (Default:
-    10 minutes)
 
 [[TestingMinFastFlagThreshold]] **TestingMinFastFlagThreshold** __N__ **bytes**|**KBytes**|**MBytes**|**GBytes**|**TBytes**|**KBits**|**MBits**|**GBits**|**TBits**::
     Minimum value for the Fast flag.  Overrides the ordinary minimum taken

--- a/src/app/config/config.c
+++ b/src/app/config/config.c
@@ -451,7 +451,7 @@ static const config_var_t option_vars_[] = {
   V(EnforceDistinctSubnets,      BOOL,     "1"),
   V_D(EntryNodes,                ROUTERSET,   NULL),
   V(EntryStatistics,             BOOL,     "0"),
-  V(TestingEstimatedDescriptorPropagationTime, INTERVAL, "10 minutes"),
+  OBSOLETE("TestingEstimatedDescriptorPropagationTime"),
   V_D(ExcludeNodes,              ROUTERSET, NULL),
   V_D(ExcludeExitNodes,          ROUTERSET, NULL),
   OBSOLETE("ExcludeSingleHopRelays"),
@@ -4123,7 +4123,6 @@ options_validate_cb(const void *old_options_, void *options_, char **msg)
     CHECK_DEFAULT(TestingV3AuthInitialDistDelay);
     CHECK_DEFAULT(TestingV3AuthVotingStartOffset);
     CHECK_DEFAULT(TestingAuthDirTimeToLearnReachability);
-    CHECK_DEFAULT(TestingEstimatedDescriptorPropagationTime);
     CHECK_DEFAULT(TestingServerDownloadInitialDelay);
     CHECK_DEFAULT(TestingClientDownloadInitialDelay);
     CHECK_DEFAULT(TestingServerConsensusDownloadInitialDelay);
@@ -4150,12 +4149,6 @@ options_validate_cb(const void *old_options_, void *options_, char **msg)
     return -1;
   if (options_validate_dirauth_testing(old_options, options, msg) < 0)
     return -1;
-
-  if (options->TestingEstimatedDescriptorPropagationTime < 0) {
-    REJECT("TestingEstimatedDescriptorPropagationTime must be non-negative.");
-  } else if (options->TestingEstimatedDescriptorPropagationTime > 60*60) {
-    COMPLAIN("TestingEstimatedDescriptorPropagationTime is insanely high.");
-  }
 
   if (options->TestingClientMaxIntervalWithoutRequest < 1) {
     REJECT("TestingClientMaxIntervalWithoutRequest is way too low.");

--- a/src/app/config/or_options_st.h
+++ b/src/app/config/or_options_st.h
@@ -723,11 +723,6 @@ struct or_options_t {
    * altered on testing networks. */
   int TestingAuthDirTimeToLearnReachability;
 
-  /** Clients don't download any descriptor this recent, since it will
-   * probably not have propagated to enough caches.  Only altered on testing
-   * networks. */
-  int TestingEstimatedDescriptorPropagationTime;
-
   /** Schedule for when servers should download things in general.  Only
    * altered on testing networks. */
   int TestingServerDownloadInitialDelay;

--- a/src/app/config/testnet.inc
+++ b/src/app/config/testnet.inc
@@ -17,7 +17,6 @@
 { "TestingV3AuthInitialVoteDelay", "20 seconds" },
 { "TestingV3AuthInitialDistDelay", "20 seconds" },
 { "TestingAuthDirTimeToLearnReachability", "0 minutes" },
-{ "TestingEstimatedDescriptorPropagationTime", "0 minutes" },
 { "MinUptimeHidServDirectoryV2", "0 minutes" },
 { "TestingServerDownloadInitialDelay", "0" },
 { "TestingClientDownloadInitialDelay", "0" },

--- a/src/test/test_options.c
+++ b/src/test/test_options.c
@@ -2001,7 +2001,6 @@ test_options_validate__testing(void *ignored)
   ENSURE_DEFAULT(TestingV3AuthInitialDistDelay, 3000);
   ENSURE_DEFAULT(TestingV3AuthVotingStartOffset, 3000);
   ENSURE_DEFAULT(TestingAuthDirTimeToLearnReachability, 3000);
-  ENSURE_DEFAULT(TestingEstimatedDescriptorPropagationTime, 3000);
   ENSURE_DEFAULT(TestingServerDownloadInitialDelay, 3000);
   ENSURE_DEFAULT(TestingClientDownloadInitialDelay, 3000);
   ENSURE_DEFAULT(TestingServerConsensusDownloadInitialDelay, 3000);
@@ -3872,22 +3871,16 @@ test_options_validate__testing_options(void *ignored)
   TEST_TESTING_OPTION(TestingAuthDirTimeToLearnReachability, -1, 8000,
                       "must be non-negative.", ENABLE_AUTHORITY_BRIDGE);
 
-  TEST_TESTING_OPTION(TestingEstimatedDescriptorPropagationTime, -1, 3601,
-                      "must be non-negative.", "");
   TEST_TESTING_OPTION(TestingClientMaxIntervalWithoutRequest, -1, 3601,
                       "is way too low.", "");
   TEST_TESTING_OPTION(TestingDirConnectionMaxStall, 1, 3601,
                       "is way too low.", "");
 
-  TEST_TESTING_OPTION(TestingEstimatedDescriptorPropagationTime, -1, 3601,
-                      "must be non-negative.", ENABLE_AUTHORITY_V3);
   TEST_TESTING_OPTION(TestingClientMaxIntervalWithoutRequest, -1, 3601,
                       "is way too low.", ENABLE_AUTHORITY_V3);
   TEST_TESTING_OPTION(TestingDirConnectionMaxStall, 1, 3601,
                       "is way too low.", ENABLE_AUTHORITY_V3);
 
-  TEST_TESTING_OPTION(TestingEstimatedDescriptorPropagationTime, -1, 3601,
-                      "must be non-negative.", ENABLE_AUTHORITY_BRIDGE);
   TEST_TESTING_OPTION(TestingClientMaxIntervalWithoutRequest, -1, 3601,
                       "is way too low.", ENABLE_AUTHORITY_BRIDGE);
   TEST_TESTING_OPTION(TestingDirConnectionMaxStall, 1, 3601,


### PR DESCRIPTION
We stopped looking at this option in 85cf6dcba3693b, back when we
implemented the minimal pieces of prop275.  Since then, we've had
code to validate and adjust this option, and to give it a different
value in testing networks, but the option hasn't actually done
anything.

We can safely mark it as OBSOLETE, since doing so does not make any
old configuration get rejected.

Closes ticket 32807.