### PR TITLE
Replace internal and not just null addresses.

### DIFF
--- a/changes/ticket31009
+++ b/changes/ticket31009
@@ -1,0 +1,6 @@
+  o Minor bugfix (pluggable transports):
+    - When Tor is about to advertize "0.0.0.0" in its extrainfo descriptor, it
+      replaces the bogus address 0.0.0.0 with its external address.  This patch
+      uses tor_addr_is_internal() instead of tor_addr_is_null(), so internal
+      addresses like 10.0.0.0/8 are also replaced. Fixes bug 31009; bugfix on
+      0.4.3.0-alpha.

--- a/src/feature/client/transports.c
+++ b/src/feature/client/transports.c
@@ -1638,12 +1638,12 @@ pt_get_extra_info_descriptor_string(void)
     SMARTLIST_FOREACH_BEGIN(mp->transports, const transport_t *, t) {
       char *transport_args = NULL;
 
-      /* If the transport proxy returned "0.0.0.0" as its address, and
-       * we know our external IP address, use it. Otherwise, use the
+      /* If the transport proxy returned an internal address, and we know our
+       * external IP address, use the external address. Otherwise, use the
        * returned address. */
       const char *addrport = NULL;
       uint32_t external_ip_address = 0;
-      if (tor_addr_is_null(&t->addr) &&
+      if (tor_addr_is_internal(&t->addr, 0) &&
           router_pick_published_address(get_options(),
                                         &external_ip_address, 0) >= 0) {
         tor_addr_t addr;


### PR DESCRIPTION
If Tor is about to advertize "0.0.0.0" in its extrainfo descriptor, it
replaces this address with its external address.  This patch uses
tor_addr_is_internal() instead of tor_addr_is_null(), so internal
addresses like 10.0.0.0/8 are also replaced.

Note that Roger originally wrote this patch:
<https://bugs.torproject.org/31009#comment:4>

This patch fixes <https://bugs.torproject.org/31009>.