### PR TITLE
Initialize publish/subscribe code when running as an NT service.

### DIFF
--- a/changes/bug32778
+++ b/changes/bug32778
@@ -1,0 +1,3 @@
+  o Minor bugfixes (windows service):
+    - Initialize publish/subscribe system when running as a windows service.
+      Fixes bug 32778; bugfix on 0.4.1.1-alpha.

--- a/src/app/main/main.c
+++ b/src/app/main/main.c
@@ -1236,7 +1236,7 @@ run_tor_main_loop(void)
 }
 
 /** Install the publish/subscribe relationships for all the subsystems. */
-static void
+void
 pubsub_install(void)
 {
     pubsub_builder_t *builder = pubsub_builder_new();
@@ -1248,7 +1248,7 @@ pubsub_install(void)
 
 /** Connect the mainloop to its publish/subscribe message delivery events if
  * appropriate, and configure the global channels appropriately. */
-static void
+void
 pubsub_connect(void)
 {
   if (get_options()->command == CMD_RUN_TOR) {

--- a/src/app/main/main.h
+++ b/src/app/main/main.h
@@ -25,4 +25,7 @@ int tor_init(int argc, char **argv);
 
 int run_tor_main_loop(void);
 
+void pubsub_install(void);
+void pubsub_connect(void);
+
 #endif /* !defined(TOR_MAIN_H) */

--- a/src/app/main/ntmain.c
+++ b/src/app/main/ntmain.c
@@ -283,7 +283,9 @@ nt_service_body(int argc, char **argv)
     return;
   }
 
+  pubsub_install();
   r = tor_init(backup_argc, backup_argv);
+
   if (r) {
     /* Failed to start the Tor service */
     r = NT_SERVICE_ERROR_TORINIT_FAILED;
@@ -293,6 +295,8 @@ nt_service_body(int argc, char **argv)
     service_fns.SetServiceStatus_fn(hStatus, &service_status);
     return;
   }
+
+  pubsub_connect();
 
   /* Set the service's status to SERVICE_RUNNING and start the main
    * event loop */
@@ -322,9 +326,12 @@ nt_service_main(void)
     errmsg = format_win32_error(result);
     printf("Service error %d : %s\n", (int) result, errmsg);
     tor_free(errmsg);
+
+    pubsub_install();
     if (result == ERROR_FAILED_SERVICE_CONTROLLER_CONNECT) {
       if (tor_init(backup_argc, backup_argv))
         return;
+      pubsub_connect();
       switch (get_options()->command) {
       case CMD_RUN_TOR:
         run_tor_main_loop();


### PR DESCRIPTION
Fixes bug 32778; bugfix on 0.4.1.1-alpha.