### PR TITLE
When initializing pthreads, always set the main thread.

### DIFF
--- a/changes/bug32884
+++ b/changes/bug32884
@@ -1,0 +1,5 @@
+  o Minor bugfixes (embedded Tor):
+    - When starting Tor any time after the first time in a process, register
+      the thread in which it is running as the main thread.  Previously, we
+      only did this on Windows, which could lead to bugs like 23081 on
+      non-Windows platforms.  Fixes bug 32884; bugfix on 0.3.3.1-alpha.

--- a/src/lib/thread/compat_pthreads.c
+++ b/src/lib/thread/compat_pthreads.c
@@ -265,6 +265,6 @@ tor_threads_init(void)
       pthread_attr_setdetachstate(&attr_detached, PTHREAD_CREATE_DETACHED);
     tor_assert(ret2 == 0);
     threads_initialized = 1;
-    set_main_thread();
   }
+  set_main_thread();
 }


### PR DESCRIPTION
Fixes bug 32884.  This is a bugfix on 0.3.3.1-alpha, when we started
allowing restart-in-process with tor_api.h.