### PR TITLE
Pass -bind_at_load on macOS

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -2206,12 +2206,12 @@ fi
 
 # OS X Lion started deprecating the system openssl. Let's just disable
 # all deprecation warnings on OS X. Also, to potentially make the binary
-# a little smaller, let's enable dead_strip.
+# a little smaller, let's enable dead_strip and bind_at_load.
 case "$host_os" in
 
  darwin*)
     CFLAGS="$CFLAGS -Wno-deprecated-declarations"
-    LDFLAGS="$LDFLAGS -dead_strip" ;;
+    LDFLAGS="$LDFLAGS -dead_strip -bind_at_load" ;;
 esac
 
 TOR_WARNING_FLAGS=""


### PR DESCRIPTION
From `man ld`.
```
-bind_at_load
                 Sets a bit in the mach header of the resulting binary which tells dyld to bind all symbols when the binary is loaded,
                 rather than lazily.
```
Before:
```
% wc -c tor
 5070084 tor

% otool -l tor
Load command 5
            cmd LC_DYLD_INFO_ONLY
        cmdsize 48
     rebase_off 3219456
    rebase_size 3176
       bind_off 3222632
      bind_size 128
  weak_bind_off 0
 weak_bind_size 0
  lazy_bind_off 3222760
 lazy_bind_size 10488
     export_off 3233248
    export_size 254744
```
After:
```
% wc -c tor
 5064380 tor

% otool -l tor
Load command 5
            cmd LC_DYLD_INFO_ONLY
        cmdsize 48
     rebase_off 3219456
    rebase_size 3176
       bind_off 3222632
      bind_size 8520
  weak_bind_off 0
 weak_bind_size 0
  lazy_bind_off 0
 lazy_bind_size 0
     export_off 3231152
    export_size 253752
```