### PR TITLE
test_practracker.sh: never disable practracker

### DIFF
--- a/changes/ticket32705_disable
+++ b/changes/ticket32705_disable
@@ -1,0 +1,4 @@
+  o Minor bugfixes (testing):
+    - When TOR_DISABLE_PRACTRACKER is set, do not apply it to the
+      test_practracker.sh script.  Doing so caused a test failure.
+      Fixes bug 32705; bugfix on 0.4.2.1-alpha.

--- a/scripts/maint/practracker/test_practracker.sh
+++ b/scripts/maint/practracker/test_practracker.sh
@@ -1,6 +1,7 @@
 #!/bin/sh
 
 umask 077
+unset TOR_DISABLE_PRACTRACKER
 
 TMPDIR=""
 clean () {


### PR DESCRIPTION
When practracker is disabled, its output will be empty.  We don't
want that happening during our tests.

Fixes bug 32705; bugfix on 0.4.2.1-alpha, when test_practracker.sh
was introduced.