### PR TITLE
[Tor Trac #32942]: Deprecate the ClientAutoIPv6ORPort option

### DIFF
--- a/changes/bug32942
+++ b/changes/bug32942
@@ -1,0 +1,4 @@
+  o Deprecated features:
+   - Deprecate the ClientAutoIPv6ORPort option. This option was not true
+     Happy Eyeballs, and often failed on connections that weren't reliably
+     dual-stack. Closes ticket 32942. Patch by Neel Chauhan.

--- a/doc/tor.1.txt
+++ b/doc/tor.1.txt
@@ -1045,7 +1045,8 @@ The following options are useful only for clients (that is, if
     If this option is set to 1, Tor clients randomly prefer a node's IPv4 or
     IPv6 ORPort. The random preference is set every time a node is loaded
     from a new consensus or bridge config. When this option is set to 1,
-    **ClientPreferIPv6ORPort** is ignored. (Default: 0)
+    **ClientPreferIPv6ORPort** is ignored. (Default: 0) (DEPRECATED: This
+    option is unreliable if a connection isn't reliably dual-stack.)
 
 [[ClientBootstrapConsensusAuthorityDownloadInitialDelay]] **ClientBootstrapConsensusAuthorityDownloadInitialDelay** __N__::
     Initial delay in seconds for when clients should download consensuses from authorities

--- a/src/app/config/config.c
+++ b/src/app/config/config.c
@@ -831,6 +831,11 @@ static const config_deprecation_t option_deprecation_notes_[] = {
     "effect on clients since 0.2.8." },
   /* End of options deprecated since 0.3.2.2-alpha. */
 
+  /* Options deprecated since 0.4.3.1-alpha. */
+  { "ClientAutoIPv6ORPort", "This option is unreliable if a connection isn't "
+    "reliably dual-stack."},
+  /* End of options deprecated since 0.4.3.1-alpha. */
+
   { NULL, NULL }
 };
 


### PR DESCRIPTION
Ticket: https://trac.torproject.org/projects/tor/ticket/32942