### PR TITLE
parseconf: Add ORPort and DirPort auto tests

### DIFF
--- a/src/test/conf_examples/relay_30/error_no_dirauth_relay
+++ b/src/test/conf_examples/relay_30/error_no_dirauth_relay
@@ -1,0 +1,1 @@
+This tor was built with relay mode disabled.

--- a/src/test/conf_examples/relay_30/expected
+++ b/src/test/conf_examples/relay_30/expected
@@ -1,0 +1,2 @@
+Nickname Unnamed
+ORPort auto

--- a/src/test/conf_examples/relay_30/expected_log
+++ b/src/test/conf_examples/relay_30/expected_log
@@ -1,0 +1,1 @@
+Your ContactInfo config option is not set

--- a/src/test/conf_examples/relay_30/torrc
+++ b/src/test/conf_examples/relay_30/torrc
@@ -1,0 +1,3 @@
+# Relay tests
+# default (IPv4) ORPort auto
+ORPort auto

--- a/src/test/conf_examples/relay_31/error_no_dirauth_relay
+++ b/src/test/conf_examples/relay_31/error_no_dirauth_relay
@@ -1,0 +1,1 @@
+This tor was built with relay mode disabled.

--- a/src/test/conf_examples/relay_31/expected
+++ b/src/test/conf_examples/relay_31/expected
@@ -1,0 +1,3 @@
+DirPort auto
+Nickname Unnamed
+ORPort auto

--- a/src/test/conf_examples/relay_31/expected_log
+++ b/src/test/conf_examples/relay_31/expected_log
@@ -1,0 +1,1 @@
+Your ContactInfo config option is not set

--- a/src/test/conf_examples/relay_31/torrc
+++ b/src/test/conf_examples/relay_31/torrc
@@ -1,0 +1,4 @@
+# Relay tests
+# default (IPv4) ORPort and DirPort auto
+ORPort auto
+DirPort auto

--- a/src/test/conf_examples/relay_32/error_no_dirauth_relay
+++ b/src/test/conf_examples/relay_32/error_no_dirauth_relay
@@ -1,0 +1,1 @@
+This tor was built with relay mode disabled.

--- a/src/test/conf_examples/relay_32/expected
+++ b/src/test/conf_examples/relay_32/expected
@@ -1,0 +1,3 @@
+Nickname Unnamed
+ORPort auto
+ORPort [::1]:auto

--- a/src/test/conf_examples/relay_32/expected_log
+++ b/src/test/conf_examples/relay_32/expected_log
@@ -1,0 +1,1 @@
+Your ContactInfo config option is not set

--- a/src/test/conf_examples/relay_32/torrc
+++ b/src/test/conf_examples/relay_32/torrc
@@ -1,0 +1,4 @@
+# Relay tests
+# default (IPv4) ORPort auto and IPv6 ORPort auto
+ORPort auto
+ORPort [::1]:auto

--- a/src/test/conf_examples/relay_33/error_no_dirauth_relay
+++ b/src/test/conf_examples/relay_33/error_no_dirauth_relay
@@ -1,0 +1,1 @@
+This tor was built with relay mode disabled.

--- a/src/test/conf_examples/relay_33/expected
+++ b/src/test/conf_examples/relay_33/expected
@@ -1,0 +1,3 @@
+Nickname Unnamed
+ORPort 127.0.0.1:auto
+ORPort [::1]:auto

--- a/src/test/conf_examples/relay_33/expected_log
+++ b/src/test/conf_examples/relay_33/expected_log
@@ -1,0 +1,1 @@
+Your ContactInfo config option is not set

--- a/src/test/conf_examples/relay_33/torrc
+++ b/src/test/conf_examples/relay_33/torrc
@@ -1,0 +1,4 @@
+# Relay tests
+# explicit IPv4 ORPort auto and IPv6 ORPort auto
+ORPort 127.0.0.1:auto
+ORPort [::1]:auto

--- a/src/test/conf_examples/relay_34/error_no_dirauth_relay
+++ b/src/test/conf_examples/relay_34/error_no_dirauth_relay
@@ -1,0 +1,1 @@
+This tor was built with relay mode disabled.

--- a/src/test/conf_examples/relay_34/expected
+++ b/src/test/conf_examples/relay_34/expected
@@ -1,0 +1,4 @@
+DirPort 127.0.0.1:auto
+Nickname Unnamed
+ORPort 127.0.0.1:auto
+ORPort [::1]:auto

--- a/src/test/conf_examples/relay_34/expected_log
+++ b/src/test/conf_examples/relay_34/expected_log
@@ -1,0 +1,1 @@
+Your ContactInfo config option is not set

--- a/src/test/conf_examples/relay_34/torrc
+++ b/src/test/conf_examples/relay_34/torrc
@@ -1,0 +1,5 @@
+# Relay tests
+# explicit IPv4 ORPort and DirPort auto and IPv6 ORPort auto
+ORPort 127.0.0.1:auto
+ORPort [::1]:auto
+DirPort 127.0.0.1:auto


### PR DESCRIPTION
These tests don't actually trigger bug 32588, but they do increase
the coverage of the auto port config code.

Tests for 32588.