### PR TITLE
Replace an assertion with a check-and-log

### DIFF
--- a/changes/log_32868
+++ b/changes/log_32868
@@ -1,0 +1,4 @@
+  o Minor features (debugging, directory system):
+    - Don't crash when we find a non-guard with a guard-fraction value set.
+      Instead, log a bug warning, in an attempt to figure out how this
+      happened. Diagnostic for ticket 32868.


### PR DESCRIPTION
We hit this assertion with bug 32868, but I'm stymied figuring out
how we wound up with a routerstatus like this.  This patch is a
diagnostic to attempt to figure out what is going on, and to avoid a
crash in the meantime.