### PR TITLE
#32753: Lowercase BridgeDistribution from torrc

### DIFF
--- a/changes/bug32753
+++ b/changes/bug32753
@@ -1,0 +1,3 @@
+  o Minor bugfixes (bridges):
+    - Lowercase the value of BridgeDistribution from torrc before adding it to
+      the descriptor. Fixes bug 32753; bugfix on 0.3.2.3-alpha.

--- a/src/feature/relay/relay_config.c
+++ b/src/feature/relay/relay_config.c
@@ -485,7 +485,7 @@ check_bridge_distribution_setting(const char *bd)
   };
   unsigned i;
   for (i = 0; i < ARRAY_LENGTH(RECOGNIZED); ++i) {
-    if (!strcmp(bd, RECOGNIZED[i]))
+    if (!strcasecmp(bd, RECOGNIZED[i]))
       return 0;
   }
 

--- a/src/feature/relay/relay_config.c
+++ b/src/feature/relay/relay_config.c
@@ -468,7 +468,6 @@ compute_publishserverdescriptor(or_options_t *options)
  * - "https"
  * - "email"
  * - "moat"
- * - "hyphae"
  *
  * If the option string is unrecognised, a warning will be logged and 0 is
  * returned.  If the option string contains an invalid character, -1 is
@@ -481,7 +480,7 @@ check_bridge_distribution_setting(const char *bd)
     return 0;
 
   const char *RECOGNIZED[] = {
-    "none", "any", "https", "email", "moat", "hyphae"
+    "none", "any", "https", "email", "moat"
   };
   unsigned i;
   for (i = 0; i < ARRAY_LENGTH(RECOGNIZED); ++i) {

--- a/src/feature/relay/router.c
+++ b/src/feature/relay/router.c
@@ -2914,9 +2914,8 @@ router_dump_router_to_string(routerinfo_t *router,
     } else {
       bd = "any";
     }
-    if (strchr(bd, '\n') || strchr(bd, '\r'))
-      bd = escaped(bd);
-    smartlist_add_asprintf(chunks, "bridge-distribution-request %s\n", bd);
+    smartlist_add_asprintf(chunks, "bridge-distribution-request %s\n",
+                           escaped(bd));
   }
 
   if (router->onion_curve25519_pkey) {

--- a/src/feature/relay/router.c
+++ b/src/feature/relay/router.c
@@ -2920,8 +2920,7 @@ router_dump_router_to_string(routerinfo_t *router,
     // forwarding what the user wrote in their torrc directly.
     tor_strlower(bd);
 
-    smartlist_add_asprintf(chunks, "bridge-distribution-request %s\n",
-                           escaped(bd));
+    smartlist_add_asprintf(chunks, "bridge-distribution-request %s\n", bd);
     tor_free(bd);
   }
 

--- a/src/feature/relay/router.c
+++ b/src/feature/relay/router.c
@@ -2908,14 +2908,21 @@ router_dump_router_to_string(routerinfo_t *router,
   }
 
   if (options->BridgeRelay) {
-    const char *bd;
+    char *bd = NULL;
+
     if (options->BridgeDistribution && strlen(options->BridgeDistribution)) {
-      bd = options->BridgeDistribution;
+      bd = tor_strdup(options->BridgeDistribution);
     } else {
-      bd = "any";
+      bd = tor_strdup("any");
     }
+
+    // Make sure our value is lowercased in the descriptor instead of just
+    // forwarding what the user wrote in their torrc directly.
+    tor_strlower(bd);
+
     smartlist_add_asprintf(chunks, "bridge-distribution-request %s\n",
                            escaped(bd));
+    tor_free(bd);
   }
 
   if (router->onion_curve25519_pkey) {

--- a/src/test/test_config.c
+++ b/src/test/test_config.c
@@ -5711,11 +5711,27 @@ test_config_check_bridge_distribution_setting_not_a_bridge(void *arg)
 static void
 test_config_check_bridge_distribution_setting_valid(void *arg)
 {
-  int ret = check_bridge_distribution_setting("https");
-
   (void)arg;
 
-  tt_int_op(ret, OP_EQ, 0);
+  // Check all the possible values we support right now.
+  tt_int_op(check_bridge_distribution_setting("none"), OP_EQ, 0);
+  tt_int_op(check_bridge_distribution_setting("any"), OP_EQ, 0);
+  tt_int_op(check_bridge_distribution_setting("https"), OP_EQ, 0);
+  tt_int_op(check_bridge_distribution_setting("email"), OP_EQ, 0);
+  tt_int_op(check_bridge_distribution_setting("moat"), OP_EQ, 0);
+
+  // Check all the possible values we support right now with weird casing.
+  tt_int_op(check_bridge_distribution_setting("NoNe"), OP_EQ, 0);
+  tt_int_op(check_bridge_distribution_setting("anY"), OP_EQ, 0);
+  tt_int_op(check_bridge_distribution_setting("hTTps"), OP_EQ, 0);
+  tt_int_op(check_bridge_distribution_setting("emAIl"), OP_EQ, 0);
+  tt_int_op(check_bridge_distribution_setting("moAt"), OP_EQ, 0);
+
+  // Invalid values.
+  tt_int_op(check_bridge_distribution_setting("x\rx"), OP_EQ, -1);
+  tt_int_op(check_bridge_distribution_setting("x\nx"), OP_EQ, -1);
+  tt_int_op(check_bridge_distribution_setting("\t\t\t"), OP_EQ, -1);
+
  done:
   return;
 }


### PR DESCRIPTION
This PR contains patches that adds test for the BridgeDistribution option validator and makes sure we lowercase the value before adding it to the descriptor.