### PR TITLE
Lower log level of standard error messages from PT's.

### DIFF
--- a/changes/bug32034
+++ b/changes/bug32034
@@ -1,0 +1,3 @@
+  o Minor bugfixes (pluggable transports):
+    - Lower the log level of standard error messages from a PT from warning to
+      debug. Fixes bug 32034; bugfix on 0.4.0.1-alpha.

--- a/src/feature/client/transports.c
+++ b/src/feature/client/transports.c
@@ -1858,7 +1858,9 @@ managed_proxy_stderr_callback(process_t *process,
   if (BUG(mp == NULL))
     return;
 
-  log_warn(LD_PT, "Managed proxy at '%s' reported: %s", mp->argv[0], line);
+  log_debug(LD_PT,
+            "Managed proxy at '%s' reported via standard error: %s",
+            mp->argv[0], line);
 }
 
 /** Callback function that is called when our PT process terminates. The


### PR DESCRIPTION
This patch lowers the log level of error messages from PT processes from
warning to debug.

See: https://bugs.torproject.org/32034