### PR TITLE
Git hooks: remove support for 0.2.9 directory layout.

### DIFF
--- a/scripts/git/pre-commit.git-hook
+++ b/scripts/git/pre-commit.git-hook
@@ -17,13 +17,14 @@ if [ $# -eq 0 ]; then
     # When called in pre-commit, check the files modified in this commit
     CHECK_FILTER="git diff --cached --name-only --diff-filter=ACMR"
     # Use the appropriate owned tor source list to filter the changed files
-    if [ -d src/lib ]; then
-        # This is the layout in 0.3.5
-        # Keep these lists consistent:
-        #   - OWNED_TOR_C_FILES in Makefile.am
-        #   - CHECK_FILES in pre-commit.git-hook and pre-push.git-hook
-        #   - try_parse in check_cocci_parse.sh
-        CHECK_FILES="$($CHECK_FILTER \
+
+    # This is the layout in 0.3.5 and later.
+
+    # Keep these lists consistent:
+    #   - OWNED_TOR_C_FILES in Makefile.am
+    #   - CHECK_FILES in pre-commit.git-hook and pre-push.git-hook
+    #   - try_parse in check_cocci_parse.sh
+    CHECK_FILES="$($CHECK_FILTER \
                            src/lib/*/*.[ch] \
                            src/core/*/*.[ch] \
                            src/feature/*/*.[ch] \
@@ -31,17 +32,7 @@ if [ $# -eq 0 ]; then
                            src/test/*.[ch] \
                            src/test/*/*.[ch] \
                            src/tools/*.[ch] \
-                      )"
-    elif [ -d src/common ]; then
-        # This was the layout before 0.3.5
-        CHECK_FILES="$($CHECK_FILTER \
-                           src/common/*/*.[ch] \
-                           src/or/*/*.[ch] \
-                           src/test/*.[ch] \
-                           src/test/*/*.[ch] \
-                           src/tools/*.[ch]
-                      )"
-    fi
+                  )"
 else
     # When called in pre-push, concatenate the argument array
     # Fails on special characters in file names

--- a/scripts/git/pre-push.git-hook
+++ b/scripts/git/pre-push.git-hook
@@ -63,13 +63,12 @@ do
             CHECK_FILTER="git diff --name-only --diff-filter=ACMR $range"
             # Use the appropriate owned tor source list to filter the changed
             # files
-            if [ -d src/lib ]; then
-                # This is the layout in 0.3.5
-                # Keep these lists consistent:
-                #   - OWNED_TOR_C_FILES in Makefile.am
-                #   - CHECK_FILES in pre-commit.git-hook and pre-push.git-hook
-                #   - try_parse in check_cocci_parse.sh
-                CHECK_FILES="$($CHECK_FILTER \
+            # This is the layout in 0.3.5
+            # Keep these lists consistent:
+            #   - OWNED_TOR_C_FILES in Makefile.am
+            #   - CHECK_FILES in pre-commit.git-hook and pre-push.git-hook
+            #   - try_parse in check_cocci_parse.sh
+            CHECK_FILES="$($CHECK_FILTER \
                                    src/lib/*/*.[ch] \
                                    src/core/*/*.[ch] \
                                    src/feature/*/*.[ch] \
@@ -77,17 +76,7 @@ do
                                    src/test/*.[ch] \
                                    src/test/*/*.[ch] \
                                    src/tools/*.[ch] \
-                              )"
-            elif [ -d src/common ]; then
-                # This was the layout before 0.3.5
-                CHECK_FILES="$($CHECK_FILTER \
-                                   src/common/*/*.[ch] \
-                                   src/or/*/*.[ch] \
-                                   src/test/*.[ch] \
-                                   src/test/*/*.[ch] \
-                                   src/tools/*.[ch] \
-                              )"
-            fi
+                          )"
 
             # We want word splitting here, because file names are space
             # separated


### PR DESCRIPTION
We no longer will be pushing or committing things in branches that
use src/common or src/or.

Resolves ticket 32957.