### PR TITLE
Travis CI: Use flake8 to find Python syntax errors

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,8 +16,8 @@ compiler:
 os:
   - linux
 
-## We don't use the build matrix cross-product, because it makes too many jobs
-## Instead, we list each job under matrix: include:
+## We don't use the build jobs cross-product, because it makes too many jobs
+## Instead, we list each job under jobs: include:
 env:
   global:
     ## The Travis CI environment allows us two cores, so let's use both.  Also,
@@ -34,11 +34,11 @@ env:
     ## Turn off tor's sandbox in chutney, until we fix sandbox errors that are
     ## triggered by Ubuntu Xenial and Bionic. See #32722.
     - CHUTNEY_TOR_SANDBOX="0"
-  matrix:
-    ## This matrix entry is required, but it doesn't actually create any jobs
+  jobs:
+    ## This jobs entry is required, but it doesn't actually create any jobs
     -
 
-matrix:
+jobs:
   ## include creates builds with gcc, linux, unless we override those defaults
   include:
     - name: Detect Python syntax errors

--- a/.travis.yml
+++ b/.travis.yml
@@ -34,16 +34,16 @@ env:
     ## Turn off tor's sandbox in chutney, until we fix sandbox errors that are
     ## triggered by Ubuntu Xenial and Bionic. See #32722.
     - CHUTNEY_TOR_SANDBOX="0"
-  jobs:
-    ## This jobs entry is required, but it doesn't actually create any jobs
+  matrix:
+    ## This matrix entry is required, but it doesn't actually create any jobs
     -
 
-jobs:
+matrix:
   ## include creates builds with gcc, linux, unless we override those defaults
   include:
     - name: Detect Python syntax errors
       language: python
-      python: 2.7
+      python: 3.6
       before_install: pip install --upgrade pip
       install: pip install flake8
       script: flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics

--- a/.travis.yml
+++ b/.travis.yml
@@ -41,7 +41,8 @@ env:
 matrix:
   ## include creates builds with gcc, linux, unless we override those defaults
   include:
-    - language: python
+    - name: Detect Python syntax errors
+      language: python
       python: 2.7
       before_install: pip install --upgrade pip
       install: pip install flake8

--- a/.travis.yml
+++ b/.travis.yml
@@ -41,6 +41,11 @@ env:
 matrix:
   ## include creates builds with gcc, linux, unless we override those defaults
   include:
+    - language: python
+      python: 2.7
+      before_install: pip install --upgrade pip
+      install: pip install flake8
+      script: flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
     ## We run basic tests on macOS
     - compiler: clang
       os: osx

--- a/scripts/codegen/makedesc.py
+++ b/scripts/codegen/makedesc.py
@@ -252,8 +252,8 @@ class OnDemandKeys(object):
 
 
 def signdesc(body, args_out=None):
-    rsa, ident_pem, id_digest = make_key()
-    _, onion_pem, _ = make_key()
+    rsa, ident_pem, id_digest = make_rsa_key()
+    _, onion_pem, _ = make_rsa_key()
 
     need_ed = '{ED25519-CERT}' in body or '{ED25519-SIGNATURE}' in body
     if need_ed:


### PR DESCRIPTION
Blocked by ~#1687~

`from __future__ import print_function` changes the way that Python 2 operates so that legacy __print__ statements are syntax errors.  This PR demonstrates that this is the case in a dozen files.