### PR TITLE
Travis: Stop allowing stem test failures

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -93,8 +93,6 @@ matrix:
       os: osx
     - env: CHUTNEY="yes" CHUTNEY_ALLOW_FAILURES="2" SKIP_MAKE_CHECK="yes"
       os: osx
-    ## test-stem sometimes hangs on Travis
-    - env: TEST_STEM="yes" SKIP_MAKE_CHECK="yes"
 
 ## (Linux only) Use a recent Linux image (Ubuntu Bionic)
 dist: bionic

--- a/changes/ticket33075
+++ b/changes/ticket33075
@@ -1,0 +1,4 @@
+  o Testing:
+    - Stop allowing failures on the Travis CI stem tests job. It looks like all
+      the stem hangs we were seeing are now fixed, but let's make sure we see
+      them if they happen again. Closes ticket 33075.


### PR DESCRIPTION
Stop allowing failures on the Travis CI stem tests job. It looks like
all the stem hangs we were seeing are now fixed, but let's make sure we
see them if they happen again.

Closes ticket 33075.