### PR TITLE
Change BUG() messages in buf_flush_to_tls() to IF_BUG_ONCE()

### DIFF
--- a/changes/bug33093_logging
+++ b/changes/bug33093_logging
@@ -1,0 +1,5 @@
+  o Minor bugfixes (logging):
+    - If we encounter a bug when flushing a buffer to a TLS connection,
+      only log the bug once per invocation of the Tor process.  Previously we
+      would log with every occurrence, which could cause us to run out of
+      disk space.  Fixes bug 33093; bugfix on 0.3.2.2-alpha.

--- a/src/lib/tls/buffers_tls.c
+++ b/src/lib/tls/buffers_tls.c
@@ -146,10 +146,10 @@ buf_flush_to_tls(buf_t *buf, tor_tls_t *tls, size_t flushlen,
   size_t flushed = 0;
   ssize_t sz;
   tor_assert(buf_flushlen);
-  if (BUG(*buf_flushlen > buf->datalen)) {
+  IF_BUG_ONCE(*buf_flushlen > buf->datalen) {
     *buf_flushlen = buf->datalen;
   }
-  if (BUG(flushlen > *buf_flushlen)) {
+  IF_BUG_ONCE(flushlen > *buf_flushlen) {
     flushlen = *buf_flushlen;
   }
   sz = (ssize_t) flushlen;


### PR DESCRIPTION
We introduced these BUG() checks in b0ddaac07428a06 to prevent a
recurrence of bug 23690.  But there's a report of the BUG() message
getting triggered and filling up the disk.  Let's change it to
IF_BUG_ONCE().

Fixes bug 33093; bugfix on 0.3.2.2-alpha.