### PR TITLE
[32753 backport to 0.4.2] Lowercase the BridgeDistribution value from torrc in descriptors.

### DIFF
--- a/changes/bug32753
+++ b/changes/bug32753
@@ -1,0 +1,3 @@
+  o Minor bugfixes (bridges):
+    - Lowercase the value of BridgeDistribution from torrc before adding it to
+      the descriptor. Fixes bug 32753; bugfix on 0.3.2.3-alpha.

--- a/src/app/config/config.c
+++ b/src/app/config/config.c
@@ -6801,7 +6801,7 @@ check_bridge_distribution_setting(const char *bd)
   };
   unsigned i;
   for (i = 0; i < ARRAY_LENGTH(RECOGNIZED); ++i) {
-    if (!strcmp(bd, RECOGNIZED[i]))
+    if (!strcasecmp(bd, RECOGNIZED[i]))
       return 0;
   }
 

--- a/src/feature/relay/router.c
+++ b/src/feature/relay/router.c
@@ -2911,15 +2911,20 @@ router_dump_router_to_string(routerinfo_t *router,
   }
 
   if (options->BridgeRelay) {
-    const char *bd;
+    char *bd = NULL;
+
     if (options->BridgeDistribution && strlen(options->BridgeDistribution)) {
-      bd = options->BridgeDistribution;
+      bd = tor_strdup(options->BridgeDistribution);
     } else {
-      bd = "any";
+      bd = tor_strdup("any");
     }
-    if (strchr(bd, '\n') || strchr(bd, '\r'))
-      bd = escaped(bd);
+
+    // Make sure our value is lowercased in the descriptor instead of just
+    // forwarding what the user wrote in their torrc directly.
+    tor_strlower(bd);
+
     smartlist_add_asprintf(chunks, "bridge-distribution-request %s\n", bd);
+    tor_free(bd);
   }
 
   if (router->onion_curve25519_pkey) {

--- a/src/test/test_config.c
+++ b/src/test/test_config.c
@@ -5663,11 +5663,27 @@ test_config_check_bridge_distribution_setting_not_a_bridge(void *arg)
 static void
 test_config_check_bridge_distribution_setting_valid(void *arg)
 {
-  int ret = check_bridge_distribution_setting("https");
-
   (void)arg;
 
-  tt_int_op(ret, OP_EQ, 0);
+  // Check all the possible values we support right now.
+  tt_int_op(check_bridge_distribution_setting("none"), OP_EQ, 0);
+  tt_int_op(check_bridge_distribution_setting("any"), OP_EQ, 0);
+  tt_int_op(check_bridge_distribution_setting("https"), OP_EQ, 0);
+  tt_int_op(check_bridge_distribution_setting("email"), OP_EQ, 0);
+  tt_int_op(check_bridge_distribution_setting("moat"), OP_EQ, 0);
+
+  // Check all the possible values we support right now with weird casing.
+  tt_int_op(check_bridge_distribution_setting("NoNe"), OP_EQ, 0);
+  tt_int_op(check_bridge_distribution_setting("anY"), OP_EQ, 0);
+  tt_int_op(check_bridge_distribution_setting("hTTps"), OP_EQ, 0);
+  tt_int_op(check_bridge_distribution_setting("emAIl"), OP_EQ, 0);
+  tt_int_op(check_bridge_distribution_setting("moAt"), OP_EQ, 0);
+
+  // Invalid values.
+  tt_int_op(check_bridge_distribution_setting("x\rx"), OP_EQ, -1);
+  tt_int_op(check_bridge_distribution_setting("x\nx"), OP_EQ, -1);
+  tt_int_op(check_bridge_distribution_setting("\t\t\t"), OP_EQ, -1);
+
  done:
   return;
 }


### PR DESCRIPTION
This patch ensures that we always lowercase the BridgeDistribution from
torrc in descriptors before submitting it.

See: https://bugs.torproject.org/32753