### PR TITLE
buf_read_from_tls: Return ERROR_MISC, not WANTWRITE, on BUG().

### DIFF
--- a/changes/bug32673
+++ b/changes/bug32673
@@ -1,0 +1,5 @@
+  o Minor bugfixes (TLS bug handling):
+    - When encountering a bug in buf_read_freom_tls(), return a
+      "MISC" error code rather than "WANTWRITE".  This change might
+      help avoid some CPU-wasting loops if the bug is ever triggered.
+      Bug reported by opara.    Fixes bug 32673; bugfix on 0.3.0.4-alpha.

--- a/src/lib/tls/buffers_tls.c
+++ b/src/lib/tls/buffers_tls.c
@@ -69,9 +69,9 @@ buf_read_from_tls(buf_t *buf, tor_tls_t *tls, size_t at_most)
   check_no_tls_errors();
 
   IF_BUG_ONCE(buf->datalen >= INT_MAX)
-    return -1;
+    return TOR_TLS_ERROR_MISC;
   IF_BUG_ONCE(buf->datalen >= INT_MAX - at_most)
-    return -1;
+    return TOR_TLS_ERROR_MISC;
 
   while (at_most > total_read) {
     size_t readlen = at_most - total_read;


### PR DESCRIPTION
Fixes bug 32673; bugfix on 0.3.0.4-alpha.  We introduced these
checks in ee5471f9aab5526 to help diagnose 21369, but we used "-1"
when "TOR_TLS_ERROR_MISC" would have been correct.  Found by opara.

I don't think that this is actually getting triggered in the wild,
but if it were, it could cause nasty behavior: spurious
WANTREAD/WANTWRITE returns have a way of turning into CPU-eating
busy-loops.