### PR TITLE
Do not set "once" when calling tor_bug_occurred_ from BUG().

### DIFF
--- a/changes/bug33095_041
+++ b/changes/bug33095_041
@@ -1,0 +1,5 @@
+  o Minor bugfixes (logging, bug reporting):
+    - When logging a bug, do not say "Future instances of this warning
+      will be silenced" unless we are actually going to do
+      so. Previously we would say this whenever a BUG() check failed in
+      the code.  Fixes bug 33095; bugfix on 0.4.1.1-alpha.

--- a/src/lib/log/util_bug.h
+++ b/src/lib/log/util_bug.h
@@ -196,7 +196,7 @@
   STMT_END
 #define BUG(cond)                                                       \
   (ASSERT_PREDICT_UNLIKELY_(cond) ?                                     \
-  (tor_bug_occurred_(SHORT_FILE__,__LINE__,__func__,"!("#cond")",1,NULL),1) \
+  (tor_bug_occurred_(SHORT_FILE__,__LINE__,__func__,"!("#cond")",0,NULL),1) \
    : 0)
 #endif /* defined(ALL_BUGS_ARE_FATAL) || ... */
 


### PR DESCRIPTION
The "once" flag makes tor_bug_occurred_() say that future instances
of the warning will be suppressed -- but that's not something that
BUG() does.  Fixes bug 33095; bugfix on 0.4.1.1-alpha.