### PR TITLE
hs-v2: Turn logs into protocol warning

### DIFF
--- a/changes/ticket32706
+++ b/changes/ticket32706
@@ -1,0 +1,4 @@
+  o Minor bugfixes (onion service v2):
+    - Move a series of warnings to protocol warning level because they can all
+      be triggered remotely by a malformed request. Fixes bug 32706; bugfix on
+      0.1.1.14-alpha.

--- a/src/feature/rend/rendmid.c
+++ b/src/feature/rend/rendmid.c
@@ -59,7 +59,7 @@ rend_mid_establish_intro_legacy(or_circuit_t *circ, const uint8_t *request,
   pk = crypto_pk_asn1_decode((char*)(request+2), asn1len);
   if (!pk) {
     reason = END_CIRC_REASON_TORPROTOCOL;
-    log_warn(LD_PROTOCOL, "Couldn't decode public key.");
+    log_fn(LOG_PROTOCOL_WARN, LD_PROTOCOL, "Couldn't decode public key.");
     goto err;
   }
 
@@ -81,7 +81,7 @@ rend_mid_establish_intro_legacy(or_circuit_t *circ, const uint8_t *request,
                                        (char*)request, 2+asn1len+DIGEST_LEN,
                                        (char*)(request+2+DIGEST_LEN+asn1len),
                                        request_len-(2+DIGEST_LEN+asn1len))<0) {
-    log_warn(LD_PROTOCOL,
+    log_fn(LOG_PROTOCOL_WARN, LD_PROTOCOL,
              "Incorrect signature on ESTABLISH_INTRO cell; rejecting.");
     reason = END_CIRC_REASON_TORPROTOCOL;
     goto err;
@@ -162,9 +162,9 @@ rend_mid_introduce_legacy(or_circuit_t *circ, const uint8_t *request,
   if (request_len < (DIGEST_LEN+(MAX_NICKNAME_LEN+1)+REND_COOKIE_LEN+
                      DH1024_KEY_LEN+CIPHER_KEY_LEN+
                      PKCS1_OAEP_PADDING_OVERHEAD)) {
-    log_warn(LD_PROTOCOL, "Impossibly short INTRODUCE1 cell on circuit %u; "
-             "responding with nack.",
-             (unsigned)circ->p_circ_id);
+    log_fn(LOG_PROTOCOL_WARN, LD_PROTOCOL,
+           "Impossibly short INTRODUCE1 cell on circuit %u; "
+           "responding with nack.", (unsigned)circ->p_circ_id);
     goto err;
   }
 
@@ -258,7 +258,7 @@ rend_mid_establish_rendezvous(or_circuit_t *circ, const uint8_t *request,
   }
 
   if (circ->base_.n_chan) {
-    log_warn(LD_PROTOCOL,
+    log_fn(LOG_PROTOCOL_WARN, LD_PROTOCOL,
              "Tried to establish rendezvous on non-edge circuit");
     goto err;
   }
@@ -270,8 +270,8 @@ rend_mid_establish_rendezvous(or_circuit_t *circ, const uint8_t *request,
   }
 
   if (hs_circuitmap_get_rend_circ_relay_side(request)) {
-    log_warn(LD_PROTOCOL,
-             "Duplicate rendezvous cookie in ESTABLISH_RENDEZVOUS.");
+    log_fn(LOG_PROTOCOL_WARN, LD_PROTOCOL,
+           "Duplicate rendezvous cookie in ESTABLISH_RENDEZVOUS.");
     goto err;
   }
 
@@ -313,9 +313,9 @@ rend_mid_rendezvous(or_circuit_t *circ, const uint8_t *request,
   int reason = END_CIRC_REASON_INTERNAL;
 
   if (circ->base_.purpose != CIRCUIT_PURPOSE_OR || circ->base_.n_chan) {
-    log_info(LD_REND,
-             "Tried to complete rendezvous on non-OR or non-edge circuit %u.",
-             (unsigned)circ->p_circ_id);
+    log_fn(LOG_PROTOCOL_WARN, LD_PROTOCOL,
+           "Tried to complete rendezvous on non-OR or non-edge circuit %u.",
+           (unsigned)circ->p_circ_id);
     reason = END_CIRC_REASON_TORPROTOCOL;
     goto err;
   }


### PR DESCRIPTION
All of those can be triggered remotely so change them to protocol warnings.

Fixes #32706

Signed-off-by: David Goulet <dgoulet@torproject.org>