### PR TITLE
hs-v3: Purge ephemeral client auth on NEWNYM

### DIFF
--- a/changes/ticket33139
+++ b/changes/ticket33139
@@ -1,0 +1,3 @@
+  o Minor bugfixes (Onion service client, authorization):
+    - On a NEWNYM signal, purge the ephemeral client authorization cache. The
+      permanent ones are kept. Fixes bug 33139; bugfix on 0.4.3.1-alpha.

--- a/src/feature/hs/hs_client.h
+++ b/src/feature/hs/hs_client.h
@@ -162,6 +162,8 @@ MOCK_DECL(STATIC hs_client_fetch_status_t,
 
 STATIC void retry_all_socks_conn_waiting_for_desc(void);
 
+STATIC void purge_ephemeral_client_auth(void);
+
 #ifdef TOR_UNIT_TESTS
 
 STATIC void set_hs_client_auths_map(digest256map_t *map);


### PR DESCRIPTION
Fixes #33139.

Signed-off-by: David Goulet <dgoulet@torproject.org>