### PR TITLE
hs-v3: Remove descriptor when we remove client authorization

### DIFF
--- a/changes/ticket33148
+++ b/changes/ticket33148
@@ -1,0 +1,5 @@
+  o Minor bugfixes (onion service v3, client authorization):
+    - When removing client authorization credentials using the control port,
+      also remove the associated descriptor so they don't linger and still
+      usable making the onion service behind client authorization reachable.
+      Fixes bug 33148; bugfix on 0.4.3.1-alpha.

--- a/changes/ticket33148
+++ b/changes/ticket33148
@@ -1,5 +1,5 @@
   o Minor bugfixes (onion service v3, client authorization):
     - When removing client authorization credentials using the control port,
-      also remove the associated descriptor so they don't linger and still
-      usable making the onion service behind client authorization reachable.
-      Fixes bug 33148; bugfix on 0.4.3.1-alpha.
+      also remove the associated descriptor so they don't linger and are still
+      usable hence making the onion service behind client authorization
+      reachable. Fixes bug 33148; bugfix on 0.4.3.1-alpha.

--- a/src/feature/hs/hs_cache.c
+++ b/src/feature/hs/hs_cache.c
@@ -847,6 +847,33 @@ hs_cache_store_as_client(const char *desc_str,
   return ret;
 }
 
+/** Remove and free a client cache descriptor entry for the given onion
+ * service ed25519 public key. If the descriptor is decoded, the intro
+ * circuits are closed if any.
+ *
+ * This does nothing if no descriptor exists for the given key. */
+void
+hs_cache_remove_as_client(const ed25519_public_key_t *key)
+{
+  hs_cache_client_descriptor_t *cached_desc = NULL;
+
+  tor_assert(key);
+
+  cached_desc = lookup_v3_desc_as_client(key->pubkey);
+  if (!cached_desc) {
+    return;
+  }
+  /* If we have a decrypted/decoded descriptor, attempt to close its
+   * introduction circuit(s). We shouldn't have circuit(s) without a
+   * descriptor else it will lead to a failure. */
+  if (cached_desc->desc) {
+    hs_client_close_intro_circuits_from_desc(cached_desc->desc);
+  }
+  /* Remove and free. */
+  remove_v3_desc_as_client(cached_desc);
+  cache_client_desc_free(cached_desc);
+}
+
 /** Clean all client caches using the current time now. */
 void
 hs_cache_clean_as_client(time_t now)

--- a/src/feature/hs/hs_cache.c
+++ b/src/feature/hs/hs_cache.c
@@ -872,6 +872,15 @@ hs_cache_remove_as_client(const ed25519_public_key_t *key)
   /* Remove and free. */
   remove_v3_desc_as_client(cached_desc);
   cache_client_desc_free(cached_desc);
+
+  /* Logging. */
+  {
+    char key_b64[BASE64_DIGEST256_LEN + 1];
+    digest256_to_base64(key_b64, (const char *) key);
+    log_info(LD_REND, "Onion service v3 descriptor '%s' removed "
+                      "from client cache",
+             safe_str_client(key_b64));
+  }
 }
 
 /** Clean all client caches using the current time now. */

--- a/src/feature/hs/hs_cache.h
+++ b/src/feature/hs/hs_cache.h
@@ -85,6 +85,7 @@ const char *
 hs_cache_lookup_encoded_as_client(const struct ed25519_public_key_t *key);
 hs_desc_decode_status_t hs_cache_store_as_client(const char *desc_str,
                            const struct ed25519_public_key_t *identity_pk);
+void hs_cache_remove_as_client(const struct ed25519_public_key_t *key);
 void hs_cache_clean_as_client(time_t now);
 void hs_cache_purge_as_client(void);
 

--- a/src/feature/hs/hs_client.c
+++ b/src/feature/hs/hs_client.c
@@ -1735,6 +1735,9 @@ hs_client_remove_auth_credentials(const char *hsaddress)
       find_and_remove_client_auth_creds_file(cred);
     }
 
+    /* Remove associated descriptor if any. */
+    hs_cache_remove_as_client(&service_identity_pk);
+
     client_service_authorization_free(cred);
     return REMOVAL_SUCCESS;
   }

--- a/src/test/test_hs_control.c
+++ b/src/test/test_hs_control.c
@@ -218,6 +218,8 @@ test_hs_control_good_onion_client_auth_add(void *arg)
   char *cp1 = NULL;
   size_t sz;
 
+  hs_init();
+
   { /* Setup the control conn */
     memset(&conn, 0, sizeof(control_connection_t));
     TO_CONN(&conn)->outbuf = buf_new();
@@ -415,6 +417,8 @@ test_hs_control_bad_onion_client_auth_add(void *arg)
   size_t sz;
   char *args = NULL;
 
+  hs_init();
+
   { /* Setup the control conn */
     memset(&conn, 0, sizeof(control_connection_t));
     TO_CONN(&conn)->outbuf = buf_new();
@@ -492,6 +496,8 @@ test_hs_control_store_permanent_creds(void *arg)
   char *creds_fname = NULL;
 
   size_t sz;
+
+  hs_init();
 
   { /* Setup the control conn */
     memset(&conn, 0, sizeof(control_connection_t));


### PR DESCRIPTION
When the ONION_CLIENT_AUTH_REMOVE command is given to tor, now also remove the
descriptor associated with the client authorization credentials.

Fixes #33148

Signed-off-by: David Goulet <dgoulet@torproject.org>