### PR TITLE
Fix a memory leak in handling GETINFO.

### DIFF
--- a/changes/ticket33103
+++ b/changes/ticket33103
@@ -1,0 +1,3 @@
+  o Minor bugfixes (controller):
+    - Fix a memory leak in GETINFO responses. Fixes bug 33103;
+      bugfix on 0.4.3.1-alpha.

--- a/src/feature/control/control_getinfo.c
+++ b/src/feature/control/control_getinfo.c
@@ -1735,6 +1735,7 @@ handle_control_getinfo(control_connection_t *conn,
       }
     } else {
       control_reply_add_one_kv(answers, 250, KV_RAW, q, ans);
+      tor_free(ans);
     }
   } SMARTLIST_FOREACH_END(q);
 


### PR DESCRIPTION
Fixes bug 33103; bugfix on 0.4.3.1-alpha.