### PR TITLE
Stop assuming that /usr/bin/python exists

### DIFF
--- a/changes/ticket33192
+++ b/changes/ticket33192
@@ -1,0 +1,5 @@
+  o Minor feature (python):
+    - Stop assuming that /usr/bin/python exists. Instead of using a
+      hardcoded path in scripts that still use Python 2, use /usr/bin/env,
+      similarly to the scripts that use Python 3. Fixes bug 33192; bugfix
+      on 0.4.2.

--- a/contrib/client-tools/tor-resolve.py
+++ b/contrib/client-tools/tor-resolve.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 
 # Future imports for Python 2.7, mandatory in 3.0
 from __future__ import division

--- a/scripts/codegen/fuzzing_include_am.py
+++ b/scripts/codegen/fuzzing_include_am.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 
 # Future imports for Python 2.7, mandatory in 3.0
 from __future__ import division

--- a/scripts/codegen/gen_server_ciphers.py
+++ b/scripts/codegen/gen_server_ciphers.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # Copyright 2014-2019, The Tor Project, Inc
 # See LICENSE for licensing information
 

--- a/scripts/codegen/get_mozilla_ciphers.py
+++ b/scripts/codegen/get_mozilla_ciphers.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # coding=utf-8
 # Copyright 2011-2019, The Tor Project, Inc
 # original version by Arturo Filastò

--- a/scripts/codegen/makedesc.py
+++ b/scripts/codegen/makedesc.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # Copyright 2014-2019, The Tor Project, Inc.
 # See LICENSE for license information
 

--- a/scripts/maint/annotate_ifdef_directives.py
+++ b/scripts/maint/annotate_ifdef_directives.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # Copyright (c) 2017-2019, The Tor Project, Inc.
 # See LICENSE for licensing information
 

--- a/scripts/maint/checkIncludes.py
+++ b/scripts/maint/checkIncludes.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # Copyright 2018 The Tor Project, Inc.  See LICENSE file for licensing info.
 
 # This file is no longer here; see practracker/includes.py for this

--- a/scripts/maint/format_changelog.py
+++ b/scripts/maint/format_changelog.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # Copyright (c) 2014-2019, The Tor Project, Inc.
 # See LICENSE for licensing information
 #

--- a/scripts/maint/lintChanges.py
+++ b/scripts/maint/lintChanges.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 
 # Future imports for Python 2.7, mandatory in 3.0
 from __future__ import division

--- a/scripts/maint/locatemissingdoxygen.py
+++ b/scripts/maint/locatemissingdoxygen.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 
 """
   This script parses the stderr output of doxygen and looks for undocumented

--- a/scripts/maint/practracker/includes.py
+++ b/scripts/maint/practracker/includes.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # Copyright 2018 The Tor Project, Inc.  See LICENSE file for licensing info.
 
 """This script looks through all the directories for files matching *.c or

--- a/scripts/maint/practracker/metrics.py
+++ b/scripts/maint/practracker/metrics.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 
 # Implementation of various source code metrics.
 # These are currently ad-hoc string operations and regexps.

--- a/scripts/maint/practracker/practracker.py
+++ b/scripts/maint/practracker/practracker.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 
 """
 Best-practices tracker for Tor source code.

--- a/scripts/maint/practracker/practracker_tests.py
+++ b/scripts/maint/practracker/practracker_tests.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 
 """Some simple tests for practracker metrics"""
 

--- a/scripts/maint/rectify_include_paths.py
+++ b/scripts/maint/rectify_include_paths.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 
 # Future imports for Python 2.7, mandatory in 3.0
 from __future__ import division

--- a/scripts/maint/redox.py
+++ b/scripts/maint/redox.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 #
 #  Copyright (c) 2008-2019, The Tor Project, Inc.
 #  See LICENSE for licensing information.

--- a/scripts/maint/sortChanges.py
+++ b/scripts/maint/sortChanges.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # Copyright (c) 2014-2019, The Tor Project, Inc.
 # See LICENSE for licensing information
 


### PR DESCRIPTION
This proposed change will change all occasions of `/usr/bin/python` to the more agnostic `/usr/bin/env python`, similarly to the change [here](https://github.com/torproject/tor/commit/a10d4adc25500e160c71d0d3f32a6f3ebbf3c9fd).

[Relevant Trac ticket](https://trac.torproject.org/projects/tor/ticket/33192#ticket) (Fixes 33192)

This pull request is a follow up to #1712 and was made due to issues regarding the tree that was used to make the changes. More information about this can be found in the Trac ticket itself. Some of the changes were adapted accordingly, but they are identical for the most part.