### PR TITLE
Travis: Produce detailed chutney diagnostics

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -262,7 +262,7 @@ after_failure:
   ## `make distcheck` puts it somewhere different.
   - if [[ "$DISTCHECK" != "" ]]; then make show-distdir-testlog || echo "make failed"; fi
   - if [[ "$DISTCHECK" != "" ]]; then make show-distdir-core || echo "make failed"; fi
-  - if [[ "$CHUTNEY" != "" ]]; then ls test_network_log || echo "ls failed"; cat test_network_log/* || echo "cat failed"; fi
+  - if [[ "$CHUTNEY" != "" ]]; then "$CHUTNEY_PATH/tools/diagnostics.sh" || echo "diagnostics failed"; ls test_network_log || echo "ls failed"; cat test_network_log/* || echo "cat failed"; fi
   - if [[ "$TEST_STEM" != "" ]]; then tail -1000 "$STEM_SOURCE_DIR"/test/data/tor_log || echo "tail failed"; fi
   - if [[ "$TEST_STEM" != "" ]]; then grep -v "SocketClosed" stem.log | tail -1000 || echo "grep | tail failed"; fi
 

--- a/changes/ticket32792
+++ b/changes/ticket32792
@@ -1,0 +1,3 @@
+  o Testing:
+    - When a Travis chutney job fails, use chutney's new "diagnostics.sh" tool
+      to produce detailed diagnostic output. Closes ticket 32792.


### PR DESCRIPTION
When a Travis chutney job fails, use chutney's new "diagnostics.sh" tool
to produce detailed diagnostic output.

Closes ticket 32792.