### PR TITLE
Small changes to scheduler comments and state changes

### DIFF
--- a/changes/ticket33349
+++ b/changes/ticket33349
@@ -1,0 +1,4 @@
+  o Code simplifications and refactoring:
+    - Updated comments in 'scheduler.c' to reflect old code changes,
+      and simplified the scheduler channel state change code. Closes
+      ticket 33349.

--- a/changes/ticket33349
+++ b/changes/ticket33349
@@ -1,4 +1,4 @@
-  o Code simplifications and refactoring:
+  o Code simplification and refactoring:
     - Updated comments in 'scheduler.c' to reflect old code changes,
       and simplified the scheduler channel state change code. Closes
       ticket 33349.

--- a/src/core/or/scheduler_kist.c
+++ b/src/core/or/scheduler_kist.c
@@ -463,6 +463,13 @@ MOCK_IMPL(void, channel_write_to_kernel, (channel_t *chan))
   log_debug(LD_SCHED, "Writing %lu bytes to kernel for chan %" PRIu64,
             (unsigned long)channel_outbuf_length(chan),
             chan->global_identifier);
+  /* Note that 'connection_handle_write()' may change the scheduler state of
+   * the channel during the scheduling loop with
+   * 'connection_or_flushed_some()' -> 'scheduler_channel_wants_writes()'.
+   * This side-effect will only occur if the channel is currently in the
+   * 'SCHED_CHAN_WAITING_TO_WRITE' or 'SCHED_CHAN_IDLE' states, which KIST
+   * rarely uses, so it should be fine unless KIST begins using these states
+   * in the future. */
   connection_handle_write(TO_CONN(BASE_CHAN_TO_TLS(chan)->conn), 0);
 }
 


### PR DESCRIPTION
See ticket [#33349](https://trac.torproject.org/projects/tor/ticket/33349).

> I have attached a patch that tries to make some of the comments in scheduler.c easier to follow, such as the comments that reference the old channels_waiting_for_cells and channels_waiting_to_write lists that were removed in ​commit 3530825c5. It also simplifies a couple of the channel state changes.

Merged in: f0561861e3