### PR TITLE
practracker: Read unicode files when using Python 2

### DIFF
--- a/changes/bug33374
+++ b/changes/bug33374
@@ -1,0 +1,5 @@
+  o Minor bugfixes (coding best practices checks):
+    - Allow the "practracker" coding best practices checking script to read
+      unicode files, when using Python 2. We made the script use unicode
+      literals in 0.4.3.1-alpha, but didn't change the codec for opening files.
+      Fixes bug 33374; bugfix on 0.4.3.1-alpha.

--- a/scripts/maint/practracker/practracker.py
+++ b/scripts/maint/practracker/practracker.py
@@ -24,7 +24,7 @@ from __future__ import division
 from __future__ import print_function
 from __future__ import unicode_literals
 
-import os, sys
+import codecs, os, sys
 
 import metrics
 import util
@@ -63,12 +63,8 @@ TOR_TOPDIR = None
 
 #######################################################
 
-if sys.version_info[0] <= 2:
-    def open_file(fname):
-        return open(fname, 'r')
-else:
-    def open_file(fname):
-        return open(fname, 'r', encoding='utf-8')
+def open_file(fname):
+    return codecs.open(fname, 'r', encoding='utf-8')
 
 def consider_file_size(fname, f):
     """Consider the size of 'f' and yield an FileSizeItem for it.


### PR DESCRIPTION
Allow the "practracker" coding best practices checking script to read
unicode files, when using Python 2.

We made the script use unicode literals in 0.4.3.1-alpha, but didn't
change the codec for opening files.

Fixes bug 33374; bugfix on 0.4.3.1-alpha.