### PR TITLE
Allow unlinkat() in the seccomp2 sandbox

### DIFF
--- a/changes/ticket33346
+++ b/changes/ticket33346
@@ -1,0 +1,3 @@
+  o Minor features (linux seccomp2 sandbox):
+    - Permit the unlinkat() syscall, which some Libc implementations
+      use to implement unlink(). Closes ticket 33346.

--- a/src/lib/sandbox/sandbox.c
+++ b/src/lib/sandbox/sandbox.c
@@ -269,6 +269,9 @@ static int filter_nopar_gen[] = {
     SCMP_SYS(recvfrom),
     SCMP_SYS(sendto),
     SCMP_SYS(unlink),
+#ifdef __NR_unlinkat
+    SCMP_SYS(unlinkat),
+#endif
     SCMP_SYS(poll)
 };
 


### PR DESCRIPTION
Closes ticket 33346.