### PR TITLE
[Tor Trac #33375]: Stop advertising an IPv6 exit policy when DNS is broken for IPv6

### DIFF
--- a/changes/bug33375
+++ b/changes/bug33375
@@ -1,0 +1,6 @@
+  o Minor bugfixes (coding best practices checks):
+    - Stop advertising an IPv6 exit policy when DNS is broken for IPv6 by
+      marking the relay descriptor dirty for 24 hours, not advertising an
+      IPv6 exit policy with a dirty descriptor, and then resetting the
+      IPv6 DNS broken count every 24 hours. Fixes bug 33375; bugfix on
+      0.2.9.14. Patch by Neel Chauhan.

--- a/changes/bug33375
+++ b/changes/bug33375
@@ -1,6 +1,4 @@
   o Minor bugfixes (coding best practices checks):
     - Stop advertising an IPv6 exit policy when DNS is broken for IPv6 by
-      marking the relay descriptor dirty for 24 hours, not advertising an
-      IPv6 exit policy with a dirty descriptor, and then resetting the
-      IPv6 DNS broken count every 24 hours. Fixes bug 33375; bugfix on
-      0.2.9.14. Patch by Neel Chauhan.
+      marking the relay descriptor dirty for 24 hours. Fixes bug 33375;
+      bugfix on 0.2.4.7-alpha. Patch by Neel Chauhan.

--- a/changes/bug33375
+++ b/changes/bug33375
@@ -1,4 +1,3 @@
-  o Minor bugfixes (coding best practices checks):
-    - Stop advertising an IPv6 exit policy when DNS is broken for IPv6 by
-      marking the relay descriptor dirty for 24 hours. Fixes bug 33375;
-      bugfix on 0.2.4.7-alpha. Patch by Neel Chauhan.
+  o Major bugfixes (ipv6):
+    - Stop advertising an IPv6 exit policy when DNS is broken for IPv6.
+      Fixes bug 33375; bugfix on 0.2.4.7-alpha. Patch by Neel Chauhan.

--- a/src/feature/relay/dns.c
+++ b/src/feature/relay/dns.c
@@ -2079,6 +2079,15 @@ dns_reset_ipv6_broken(evutil_socket_t fd, short event, void *args)
   dns_is_broken_for_ipv6 = 0;
 }
 
+#ifdef TOR_UNIT_TESTS
+/** Set dns_is_broken_for_ipv6 to the value in val for unit test. */
+void
+dns_set_is_broken_for_ipv6(int val) {
+  dns_is_broken_for_ipv6 = val;
+}
+#endif /* defined(TOR_UNIT_TESTS) */
+
+
 /** Forget what we've previously learned about our DNS servers' correctness. */
 void
 dns_reset_correctness_checks(void)

--- a/src/feature/relay/dns.c
+++ b/src/feature/relay/dns.c
@@ -1491,7 +1491,11 @@ configure_nameservers(int force)
   if (evdns_base_count_nameservers(the_evdns_base) == 1) {
     SET("max-timeouts:", "1000000");
   } else {
-    SET("max-timeouts:", "10");
+    if (options->TestingTorNetwork) {
+      SET("max-timeouts:", "1");
+    } else {
+      SET("max-timeouts:", "1000");
+    }
   }
 
   // Elongate the queue of maximum inflight dns requests, so if a bunch

--- a/src/feature/relay/dns.c
+++ b/src/feature/relay/dns.c
@@ -2082,11 +2082,11 @@ dns_reset_ipv6_broken(evutil_socket_t fd, short event, void *args)
 #ifdef TOR_UNIT_TESTS
 /** Set dns_is_broken_for_ipv6 to the value in val for unit test. */
 void
-dns_set_is_broken_for_ipv6(int val) {
+dns_set_is_broken_for_ipv6(int val)
+{
   dns_is_broken_for_ipv6 = val;
 }
 #endif /* defined(TOR_UNIT_TESTS) */
-
 
 /** Forget what we've previously learned about our DNS servers' correctness. */
 void

--- a/src/feature/relay/dns.h
+++ b/src/feature/relay/dns.h
@@ -32,6 +32,10 @@ size_t dns_cache_handle_oom(time_t now, size_t min_remove_bytes);
 void dns_free_all(void);
 void dns_launch_correctness_checks(void);
 
+#ifdef TOR_UNIT_TESTS
+void dns_set_is_broken_for_ipv6(int val);
+#endif /* defined(TOR_UNIT_TESTS) */
+
 #else /* !defined(HAVE_MODULE_RELAY) */
 
 #define dns_init() (0)

--- a/src/feature/relay/dns.h
+++ b/src/feature/relay/dns.h
@@ -42,6 +42,7 @@ void dns_set_is_broken_for_ipv6(int val);
 #define dns_seems_to_be_broken() (0)
 #define has_dns_init_failed() (0)
 #define dns_cache_total_allocation() (0)
+#define dns_seems_to_be_broken_for_ipv6() (0)
 
 #define dns_reset_correctness_checks() STMT_NIL
 

--- a/src/feature/relay/router.c
+++ b/src/feature/relay/router.c
@@ -1939,12 +1939,6 @@ get_my_declared_family(const or_options_t *options)
   return result;
 }
 
-#ifdef HAVE_MODULE_RELAY
-#define IPV6_DNS_NOT_BROKEN !dns_seems_to_be_broken_for_ipv6()
-#else /* !defined(HAVE_MODULE_RELAY) */
-#define IPV6_DNS_NOT_BROKEN 1
-#endif /* defined(HAVE_MODULE_RELAY) */
-
 /** Allocate a fresh, unsigned routerinfo for this OR, without any of the
  * fields that depend on the corresponding extrainfo.
  *
@@ -2059,7 +2053,7 @@ router_build_fresh_unsigned_routerinfo,(routerinfo_t **ri_out))
     policy_is_reject_star(ri->exit_policy, AF_INET, 1) &&
     policy_is_reject_star(ri->exit_policy, AF_INET6, 1);
 
-  if (options->IPv6Exit && IPV6_DNS_NOT_BROKEN) {
+  if (options->IPv6Exit && !dns_seems_to_be_broken_for_ipv6()) {
     char *p_tmp = policy_summarize(ri->exit_policy, AF_INET6);
     if (p_tmp)
       ri->ipv6_exit_policy = parse_short_policy(p_tmp);

--- a/src/feature/relay/router.c
+++ b/src/feature/relay/router.c
@@ -1939,6 +1939,12 @@ get_my_declared_family(const or_options_t *options)
   return result;
 }
 
+#ifdef HAVE_MODULE_RELAY
+#define IPV6_DNS_NOT_BROKEN !dns_seems_to_be_broken_for_ipv6()
+#else
+#define IPV6_DNS_NOT_BROKEN 1
+#endif
+
 /** Allocate a fresh, unsigned routerinfo for this OR, without any of the
  * fields that depend on the corresponding extrainfo.
  *
@@ -2053,7 +2059,7 @@ router_build_fresh_unsigned_routerinfo,(routerinfo_t **ri_out))
     policy_is_reject_star(ri->exit_policy, AF_INET, 1) &&
     policy_is_reject_star(ri->exit_policy, AF_INET6, 1);
 
-  if (options->IPv6Exit) {
+  if (options->IPv6Exit && IPV6_DNS_NOT_BROKEN) {
     char *p_tmp = policy_summarize(ri->exit_policy, AF_INET6);
     if (p_tmp)
       ri->ipv6_exit_policy = parse_short_policy(p_tmp);

--- a/src/feature/relay/router.c
+++ b/src/feature/relay/router.c
@@ -1941,9 +1941,9 @@ get_my_declared_family(const or_options_t *options)
 
 #ifdef HAVE_MODULE_RELAY
 #define IPV6_DNS_NOT_BROKEN !dns_seems_to_be_broken_for_ipv6()
-#else
+#else /* !defined(HAVE_MODULE_RELAY) */
 #define IPV6_DNS_NOT_BROKEN 1
-#endif
+#endif /* defined(HAVE_MODULE_RELAY) */
 
 /** Allocate a fresh, unsigned routerinfo for this OR, without any of the
  * fields that depend on the corresponding extrainfo.

--- a/src/test/test_policy.c
+++ b/src/test/test_policy.c
@@ -2753,7 +2753,7 @@ mock_tor_cert_dup_null(const tor_cert_t *cert)
 static void
 test_policies_reject_failed_ipv6_dns(void *arg)
 {
-  routerinfo_t *ri = tor_malloc(sizeof(routerinfo_t));
+  routerinfo_t *ri = NULL;
   config_line_t line;
   (void)arg;
 

--- a/src/test/test_policy.c
+++ b/src/test/test_policy.c
@@ -2782,6 +2782,7 @@ test_policies_reject_failed_ipv6_dns(void *arg)
   dns_set_is_broken_for_ipv6(0);
   router_build_fresh_unsigned_routerinfo(&ri);
   tt_assert(ri->ipv6_exit_policy != NULL);
+  routerinfo_free(ri);
 
   dns_set_is_broken_for_ipv6(1);
   router_build_fresh_unsigned_routerinfo(&ri);

--- a/src/test/test_policy.c
+++ b/src/test/test_policy.c
@@ -2,6 +2,7 @@
 /* See LICENSE for licensing information */
 
 #define CONFIG_PRIVATE
+#define ROUTER_PRIVATE
 #define POLICIES_PRIVATE
 
 #include "core/or/or.h"
@@ -11,6 +12,8 @@
 #include "feature/dirparse/policy_parse.h"
 #include "feature/hs/hs_common.h"
 #include "feature/hs/hs_descriptor.h"
+#include "feature/nodelist/routerlist.h"
+#include "feature/relay/dns.h"
 #include "feature/relay/router.h"
 #include "lib/encoding/confline.h"
 #include "test/test.h"
@@ -2711,6 +2714,89 @@ test_policies_fascist_firewall_choose_address(void *arg)
   UNMOCK(get_options);
 }
 
+static crypto_pk_t *mocked_onionkey = NULL;
+
+/* Returns mocked_onionkey with no checks. */
+static crypto_pk_t *
+mock_get_onion_key(void)
+{
+  return mocked_onionkey;
+}
+
+static curve25519_keypair_t mocked_curve25519_onion_key;
+
+/* Returns mocked_curve25519_onion_key with no checks. */
+static const curve25519_keypair_t *
+mock_get_current_curve25519_keypair(void)
+{
+  return &mocked_curve25519_onion_key;
+}
+
+static crypto_pk_t *mocked_server_identitykey = NULL;
+
+/* Returns mocked_server_identitykey with no checks. */
+static crypto_pk_t *
+mock_get_server_identity_key(void)
+{
+  return mocked_server_identitykey;
+}
+
+static tor_cert_t *
+mock_tor_cert_dup_null(const tor_cert_t *cert)
+{
+  (void)cert;
+  return NULL;
+}
+
+/** Run unit tests on an exit's failed IPv6 DNS resolver. */
+static void
+test_policies_reject_failed_ipv6_dns(void *arg)
+{
+  routerinfo_t *ri = tor_malloc(sizeof(routerinfo_t));
+  config_line_t line;
+  (void)arg;
+
+  memset(&mock_options, 0, sizeof(or_options_t));
+  MOCK(get_options, mock_get_options);
+  MOCK(get_onion_key, mock_get_onion_key);
+  MOCK(get_current_curve25519_keypair, mock_get_current_curve25519_keypair);
+  MOCK(get_server_identity_key, mock_get_server_identity_key);
+  MOCK(tor_cert_dup, mock_tor_cert_dup_null);
+
+  line.key = (char *) "ExitPolicy";
+  line.value = (char *) "accept *:*";
+  line.next = NULL;
+  mock_options.ExitPolicy = &line;
+
+  mocked_server_identitykey = pk_generate(0);
+
+  mock_options.ORPort_set = 1;
+  mock_options.Nickname = tor_strdup("Marina");
+  mock_options.ExitRelay = 1;
+  mock_options.IPv6Exit = 1;
+
+  mocked_onionkey = pk_generate(1);
+  curve25519_keypair_generate(&mocked_curve25519_onion_key, 0);
+
+  dns_set_is_broken_for_ipv6(0);
+  router_build_fresh_unsigned_routerinfo(&ri);
+  tt_assert(ri->ipv6_exit_policy);
+
+  dns_set_is_broken_for_ipv6(1);
+  router_build_fresh_unsigned_routerinfo(&ri);
+  tt_assert(!ri->ipv6_exit_policy);
+ done:
+  dns_set_is_broken_for_ipv6(0);
+  crypto_pk_free(mocked_onionkey);
+  crypto_pk_free(mocked_server_identitykey);
+  routerinfo_free(ri);
+  UNMOCK(get_options);
+  UNMOCK(get_onion_key);
+  UNMOCK(get_current_curve25519_keypair);
+  UNMOCK(get_server_identity_key);
+  UNMOCK(tor_cert_dup);
+}
+
 #undef TEST_IPV4_ADDR_STR
 #undef TEST_IPV6_ADDR_STR
 #undef TEST_IPV4_OR_PORT
@@ -2736,5 +2822,7 @@ struct testcase_t policy_tests[] = {
     test_policies_fascist_firewall_allows_address, 0, NULL, NULL },
   { "fascist_firewall_choose_address",
     test_policies_fascist_firewall_choose_address, 0, NULL, NULL },
+  { "reject_failed_ipv6_dns", test_policies_reject_failed_ipv6_dns,
+    0, NULL, NULL },
   END_OF_TESTCASES
 };

--- a/src/test/test_policy.c
+++ b/src/test/test_policy.c
@@ -2753,10 +2753,6 @@ mock_tor_cert_dup_null(const tor_cert_t *cert)
 static void
 test_policies_reject_failed_ipv6_dns(void *arg)
 {
-#ifndef HAVE_MODULE_RELAY
-  tt_skip();
- done:
-#else /* defined(HAVE_MODULE_RELAY) */
   routerinfo_t *ri = tor_malloc(sizeof(routerinfo_t));
   config_line_t line;
   (void)arg;
@@ -2777,6 +2773,7 @@ test_policies_reject_failed_ipv6_dns(void *arg)
   mock_options.Nickname = tor_strdup("Marina");
   mock_options.ExitRelay = 1;
   mock_options.IPv6Exit = 1;
+  mock_options.Address = tor_strdup("1.1.1.1");
 
   mocked_server_identitykey = pk_generate(0);
   mocked_onionkey = pk_generate(1);
@@ -2799,7 +2796,6 @@ test_policies_reject_failed_ipv6_dns(void *arg)
   UNMOCK(get_current_curve25519_keypair);
   UNMOCK(get_server_identity_key);
   UNMOCK(tor_cert_dup);
-#endif /* !defined(HAVE_MODULE_RELAY) */
 }
 
 #undef TEST_IPV4_ADDR_STR


### PR DESCRIPTION
For the bug [here](https://trac.torproject.org/projects/tor/ticket/33375).