### PR TITLE
Remove surprising empty line in info-level cbt log

### DIFF
--- a/changes/bug33531
+++ b/changes/bug33531
@@ -1,0 +1,3 @@
+  o Minor bugfixes (logs):
+    - Remove surprising empty line in info-level log about circuit build
+      timeout. Fixes bug 33531; bugfix on 0.3.3.1-alpha.

--- a/src/core/or/circuituse.c
+++ b/src/core/or/circuituse.c
@@ -732,7 +732,7 @@ circuit_expire_building(void)
           circuit_build_times_enough_to_compute(get_circuit_build_times())) {
 
         log_info(LD_CIRC,
-                 "Deciding to count the timeout for circuit %"PRIu32"\n",
+                 "Deciding to count the timeout for circuit %"PRIu32,
                  TO_ORIGIN_CIRCUIT(victim)->global_identifier);
 
         /* Circuits are allowed to last longer for measurement.


### PR DESCRIPTION
Fixes bug 33531; bugfix on 0.3.3.1-alpha.