### PR TITLE
[Tor Trac #33555]: Space out the line.key/line.value in test_policy_summary_helper_family_flags()

### DIFF
--- a/src/test/test_policy.c
+++ b/src/test/test_policy.c
@@ -62,8 +62,8 @@ test_policy_summary_helper_family_flags(const char *policy_str,
   short_policy_t *short_policy = NULL;
   int success = 0;
 
-  line.key = (char*)"foo";
-  line.value = (char *)policy_str;
+  line.key = (char *) "foo";
+  line.value = (char *) policy_str;
   line.next = NULL;
 
   r = policies_parse_exit_policy(&line, &policy,


### PR DESCRIPTION
Ticket: https://trac.torproject.org/projects/tor/ticket/33555