### PR TITLE
hs-v3: Don't close intro circuit for an encrypted descriptor

### DIFF
--- a/changes/ticket33458
+++ b/changes/ticket33458
@@ -1,0 +1,6 @@
+  o Minor bugfixes (onion service client):
+    - Don't attempt to close introduction circuits if we have an encrypted
+      descriptor waiting for a valid client authorization token. It lead to a
+      non fatal assert due to the missing descriptor. Fixes bug 33458; bugfix on
+      0.4.2.1-alpha.
+

--- a/src/feature/hs/hs_cache.c
+++ b/src/feature/hs/hs_cache.c
@@ -743,8 +743,11 @@ cache_clean_v3_as_client(time_t now)
     /* We just removed an old descriptor. We need to close all intro circuits
      * so we don't have leftovers that can be selected while lacking a
      * descriptor. We leave the rendezvous circuits opened because they could
-     * be in use. */
-    hs_client_close_intro_circuits_from_desc(entry->desc);
+     * be in use. It might be an encrypted descriptor and thus the decrypted
+     * version doesn't exists. */
+    if (entry->desc) {
+      hs_client_close_intro_circuits_from_desc(entry->desc);
+    }
     /* Entry is not in the cache anymore, destroy it. */
     cache_client_desc_free(entry);
     /* Update our OOM. We didn't use the remove() function because we are in


### PR DESCRIPTION
To close intro circuits, we need a valid decrypted descriptor in order to find
the circuit by authentication key. However, we can have encrypted descriptors
in the client cache that are waiting for a client authorization token.

This commit doesn't attempt to close intro circuits for that situation because
we are unable to access the authentication key for each intro circuit.

Signed-off-by: David Goulet <dgoulet@torproject.org>