### PR TITLE
hs-v3: Relax severity of a log message when decoding descriptors.

### DIFF
--- a/changes/bug31669
+++ b/changes/bug31669
@@ -1,0 +1,5 @@
+  o Minor bugfixes (onion services v3):
+    - Relax severity of a log message that can appear naturally when decoding
+      onion service descriptors as a relay. Also add some diagnostics to debug
+      any future bugs in that area. Fixes ticket 31669; bugfix on
+      0.3.0.1-alpha.

--- a/src/feature/hs/hs_descriptor.c
+++ b/src/feature/hs/hs_descriptor.c
@@ -56,6 +56,7 @@
 #define HS_DESCRIPTOR_PRIVATE
 
 #include "core/or/or.h"
+#include "app/config/config.h"
 #include "trunnel/ed25519_cert.h" /* Trunnel interface. */
 #include "feature/hs/hs_descriptor.h"
 #include "core/or/circuitbuild.h"
@@ -1283,11 +1284,20 @@ cert_is_valid(tor_cert_t *cert, uint8_t type, const char *log_obj_type)
     log_warn(LD_REND, "Signing key is NOT included for %s.", log_obj_type);
     goto err;
   }
+
   /* The following will not only check if the signature matches but also the
    * expiration date and overall validity. */
   if (tor_cert_checksig(cert, &cert->signing_key, approx_time()) < 0) {
-    log_warn(LD_REND, "Invalid signature for %s: %s", log_obj_type,
-             tor_cert_describe_signature_status(cert));
+    if (cert->cert_expired) {
+      char expiration_str[ISO_TIME_LEN+1];
+      format_iso_time(expiration_str, cert->valid_until);
+      log_fn(LOG_PROTOCOL_WARN, LD_REND, "Invalid signature for %s: %s (%s)",
+             log_obj_type, tor_cert_describe_signature_status(cert),
+             expiration_str);
+    } else {
+      log_warn(LD_REND, "Invalid signature for %s: %s",
+               log_obj_type, tor_cert_describe_signature_status(cert));
+    }
     goto err;
   }
 

--- a/src/test/test_hs_descriptor.c
+++ b/src/test/test_hs_descriptor.c
@@ -99,9 +99,11 @@ test_cert_encoding(void *arg)
     pos += strlen("-----END ED25519 CERT-----");
     tt_str_op(pos, OP_EQ, "");
 
-    /* Check that certificate expiry works properly and emits the right log message */
+    /* Check that certificate expiry works properly and emits the right log
+       message */
     const char *msg = "fire";
-    /* Move us forward 4 hours so that the the certificate is definitely expired */
+    /* Move us forward 4 hours so that the the certificate is definitely
+       expired */
     update_approx_time(approx_time() + 3600*4);
     setup_full_capture_of_logs(LOG_PROTOCOL_WARN);
     ret = cert_is_valid(parsed_cert, CERT_TYPE_SIGNING_AUTH, msg);
@@ -110,7 +112,8 @@ test_cert_encoding(void *arg)
      * 20:08", and the expiration date of the cert was two hours, the Tor code
      * will ceiling that and make it 23:00. Make sure that the right log
      * message is emitted */
-    expect_log_msg_containing("Invalid signature for fire: expired (2290-02-01 23:00:00)");
+    expect_log_msg_containing("Invalid signature for fire: expired"
+                              " (2290-02-01 23:00:00)");
     teardown_capture_of_logs();
 
     tor_cert_free(parsed_cert);

--- a/src/test/test_hs_descriptor.c
+++ b/src/test/test_hs_descriptor.c
@@ -14,6 +14,7 @@
 #include "lib/crypt_ops/crypto_rand.h"
 #include "trunnel/ed25519_cert.h"
 #include "core/or/or.h"
+#include "app/config/config.h"
 #include "feature/hs/hs_descriptor.h"
 #include "test/test.h"
 #include "feature/nodelist/torcert.h"
@@ -37,13 +38,16 @@ test_cert_encoding(void *arg)
 {
   int ret;
   char *encoded = NULL;
-  time_t now = time(NULL);
   ed25519_keypair_t kp;
   ed25519_public_key_t signed_key;
   ed25519_secret_key_t secret_key;
   tor_cert_t *cert = NULL;
 
   (void) arg;
+
+  /* Change time to 2290-02-01 20:08 UTC */
+  update_approx_time(10101010101);
+  time_t now = approx_time();
 
   ret = ed25519_keypair_generate(&kp, 0);
   tt_int_op(ret, == , 0);
@@ -88,13 +92,28 @@ test_cert_encoding(void *arg)
     /* The cert did have the signing key? */
     ret= ed25519_pubkey_eq(&parsed_cert->signing_key, &kp.pubkey);
     tt_int_op(ret, OP_EQ, 1);
-    tor_cert_free(parsed_cert);
 
     /* Get to the end part of the certificate. */
     pos += b64_cert_len;
     tt_int_op(strcmpstart(pos, "-----END ED25519 CERT-----"), OP_EQ, 0);
     pos += strlen("-----END ED25519 CERT-----");
     tt_str_op(pos, OP_EQ, "");
+
+    /* Check that certificate expiry works properly and emits the right log message */
+    const char *msg = "fire";
+    /* Move us forward 4 hours so that the the certificate is definitely expired */
+    update_approx_time(approx_time() + 3600*4);
+    setup_full_capture_of_logs(LOG_PROTOCOL_WARN);
+    ret = cert_is_valid(parsed_cert, CERT_TYPE_SIGNING_AUTH, msg);
+    tt_int_op(ret, OP_EQ, 0);
+    /* Since the current time at the creation of the cert was "2290-02-01
+     * 20:08", and the expiration date of the cert was two hours, the Tor code
+     * will ceiling that and make it 23:00. Make sure that the right log
+     * message is emitted */
+    expect_log_msg_containing("Invalid signature for fire: expired (2290-02-01 23:00:00)");
+    teardown_capture_of_logs();
+
+    tor_cert_free(parsed_cert);
   }
 
  done:


### PR DESCRIPTION
Make it LOG_PROTOCOL_WARN and also add the expiration timestamp in there to
ease debugging in the future.