### PR TITLE
connection: Stop forcing some ports to prefer IPv6

### DIFF
--- a/changes/bug33608
+++ b/changes/bug33608
@@ -1,0 +1,5 @@
+  o Minor bugfixes (client IPv6):
+    - Stop forcing all non-SOCKSPorts to prefer IPv6 exit connections. Instead,
+      prefer IPv6 connections by default, but allow users to change their
+      configs using the "NoPreferIPv6" port flag.
+      Fixes bug 33608; bugfix on 0.4.3.1-alpha.

--- a/src/core/mainloop/connection.c
+++ b/src/core/mainloop/connection.c
@@ -1514,10 +1514,11 @@ connection_listener_new(const struct sockaddr *listensockaddr,
     }
   }
 
+  /* Force IPv4 and IPv6 traffic on for non-SOCKSPorts.
+   * Forcing options on isn't a good idea, see #32994 and #33607. */
   if (type != CONN_TYPE_AP_LISTENER) {
     lis_conn->entry_cfg.ipv4_traffic = 1;
     lis_conn->entry_cfg.ipv6_traffic = 1;
-    lis_conn->entry_cfg.prefer_ipv6 = 1;
   }
 
   if (connection_add(conn) < 0) { /* no space, forget it */


### PR DESCRIPTION
Stop forcing all non-SOCKSPorts to prefer IPv6 exit connections.
Instead, prefer IPv6 connections by default, but allow users to change
their configs using the "NoPreferIPv6" port flag.

Fixes bug 33608; bugfix on 0.4.3.1-alpha.