### PR TITLE
coverity: Silence spurious unreachable warning

### DIFF
--- a/src/test/test_circuitbuild.c
+++ b/src/test/test_circuitbuild.c
@@ -115,7 +115,11 @@ test_new_route_len_unhandled_exit(void *arg)
 
   (void)arg;
 #ifdef ALL_BUGS_ARE_FATAL
+  /* Coverity (and maybe clang analyser) complain that the code following
+   * tt_skip() is unconditionally unreachable. */
+#if !defined(__COVERITY__) && !defined(__clang_analyzer__)
   tt_skip();
+#endif
 #endif
 
   MOCK(count_acceptable_nodes, mock_count_acceptable_nodes);

--- a/src/test/test_dir.c
+++ b/src/test/test_dir.c
@@ -4992,7 +4992,11 @@ test_dir_purpose_needs_anonymity_returns_true_by_default(void *arg)
   (void)arg;
 
 #ifdef ALL_BUGS_ARE_FATAL
+  /* Coverity (and maybe clang analyser) complain that the code following
+   * tt_skip() is unconditionally unreachable. */
+#if !defined(__COVERITY__) && !defined(__clang_analyzer__)
   tt_skip();
+#endif
 #endif
 
   tor_capture_bugs_(1);


### PR DESCRIPTION
Closes bug 33641; not in any released version of tor.