### PR TITLE
[Tor Trac #33375]: Stop advertising an IPv6 exit policy when DNS is broken for IPv6 (Revision 1)

### DIFF
--- a/changes/bug33375
+++ b/changes/bug33375
@@ -1,0 +1,4 @@
+  o Minor bugfixes (coding best practices checks):
+    - Stop advertising an IPv6 exit policy when DNS is broken for IPv6 by
+      marking the relay descriptor dirty for 24 hours. Fixes bug 33375;
+      bugfix on 0.2.4.7-alpha. Patch by Neel Chauhan.

--- a/src/feature/relay/dns.c
+++ b/src/feature/relay/dns.c
@@ -2079,6 +2079,15 @@ dns_reset_ipv6_broken(evutil_socket_t fd, short event, void *args)
   dns_is_broken_for_ipv6 = 0;
 }
 
+#ifdef TOR_UNIT_TESTS
+/** Set dns_is_broken_for_ipv6 to the value in val for unit test. */
+void
+dns_set_is_broken_for_ipv6(int val)
+{
+  dns_is_broken_for_ipv6 = val;
+}
+#endif /* defined(TOR_UNIT_TESTS) */
+
 /** Forget what we've previously learned about our DNS servers' correctness. */
 void
 dns_reset_correctness_checks(void)

--- a/src/feature/relay/dns.h
+++ b/src/feature/relay/dns.h
@@ -32,6 +32,10 @@ size_t dns_cache_handle_oom(time_t now, size_t min_remove_bytes);
 void dns_free_all(void);
 void dns_launch_correctness_checks(void);
 
+#ifdef TOR_UNIT_TESTS
+void dns_set_is_broken_for_ipv6(int val);
+#endif /* defined(TOR_UNIT_TESTS) */
+
 #else /* !defined(HAVE_MODULE_RELAY) */
 
 #define dns_init() (0)

--- a/src/feature/relay/router.c
+++ b/src/feature/relay/router.c
@@ -1939,6 +1939,12 @@ get_my_declared_family(const or_options_t *options)
   return result;
 }
 
+#ifdef HAVE_MODULE_RELAY
+#define IPV6_DNS_NOT_BROKEN !dns_seems_to_be_broken_for_ipv6()
+#else
+#define IPV6_DNS_NOT_BROKEN 1
+#endif
+
 /** Allocate a fresh, unsigned routerinfo for this OR, without any of the
  * fields that depend on the corresponding extrainfo.
  *
@@ -2053,7 +2059,7 @@ router_build_fresh_unsigned_routerinfo,(routerinfo_t **ri_out))
     policy_is_reject_star(ri->exit_policy, AF_INET, 1) &&
     policy_is_reject_star(ri->exit_policy, AF_INET6, 1);
 
-  if (options->IPv6Exit) {
+  if (options->IPv6Exit && IPV6_DNS_NOT_BROKEN) {
     char *p_tmp = policy_summarize(ri->exit_policy, AF_INET6);
     if (p_tmp)
       ri->ipv6_exit_policy = parse_short_policy(p_tmp);

--- a/src/feature/relay/router.c
+++ b/src/feature/relay/router.c
@@ -1941,9 +1941,9 @@ get_my_declared_family(const or_options_t *options)
 
 #ifdef HAVE_MODULE_RELAY
 #define IPV6_DNS_NOT_BROKEN !dns_seems_to_be_broken_for_ipv6()
-#else
+#else /* !defined(HAVE_MODULE_RELAY) */
 #define IPV6_DNS_NOT_BROKEN 1
-#endif
+#endif /* defined(HAVE_MODULE_RELAY) */
 
 /** Allocate a fresh, unsigned routerinfo for this OR, without any of the
  * fields that depend on the corresponding extrainfo.


### PR DESCRIPTION
Ticket: https://trac.torproject.org/projects/tor/ticket/33375