### PR TITLE
Set *have_low_ports_out from stub port_parse_ports_relay().

### DIFF
--- a/changes/bug33668
+++ b/changes/bug33668
@@ -1,0 +1,4 @@
+  o Minor bugfixes (--disable-module-relay):
+    - Fix an assertion failure when Tor is build without the relay module,
+      and then invoked with the "User" option. Fixes bug 33668; bugfix on
+      0.4.3.1-alpha.

--- a/src/feature/relay/relay_config.h
+++ b/src/feature/relay/relay_config.h
@@ -125,6 +125,21 @@ options_validate_relay_mode(const struct or_options_t *old_options,
   return 0;
 }
 
+static inline int
+port_parse_ports_relay(or_options_t *options,
+                       char **msg,
+                       smartlist_t *ports_out,
+                       int *have_low_ports_out)
+{
+  (void)options;
+  (void)msg;
+  (void)ports_out;
+  (void)msg;
+  if (*have_low_ports_out < 0)
+    *have_low_ports_out = 0;
+  return 0;
+}
+
 #define relay_get_dirportfrontpage() \
   (NULL)
 #define relay_config_free_all() \
@@ -138,9 +153,6 @@ options_validate_relay_mode(const struct or_options_t *old_options,
 #define port_warn_nonlocal_ext_orports(ports, portname) \
   (((void)(ports)),((void)(portname)))
 
-#define port_parse_ports_relay(options, msg, ports_out, have_low_ports_out) \
-  (((void)(options)),((void)(msg)),((void)(ports_out)), \
-   ((void)(have_low_ports_out)),0)
 #define port_update_port_set_relay(options, ports) \
   (((void)(options)),((void)(ports)))
 


### PR DESCRIPTION
Previously we just ignored this option, which would leave it unset,
and cause an assertion failure later on when running with the User
option.

Fixes bug 33668; bugfix on 0.4.3.1-alpha.