### PR TITLE
practracker: Disable practracker in git hooks

### DIFF
--- a/changes/ticket33678_043
+++ b/changes/ticket33678_043
@@ -1,0 +1,3 @@
+  o Code simplification and refactoring:
+    - Disable our coding standards best practices tracker in our git hooks.
+      (0.4.3 branches only.) Closes ticket 33678.

--- a/scripts/maint/practracker/.enable_practracker_in_hooks
+++ b/scripts/maint/practracker/.enable_practracker_in_hooks
@@ -1,1 +1,0 @@
-This file is present to tell our git hooks to run practracker on this branch.


### PR DESCRIPTION
Disable our coding standards best practices tracker in our git hooks.

0.4.3 branches only.

Closes ticket 33678.