### PR TITLE
hs-v3: Move to log notice the registration of an OB instance

### DIFF
--- a/src/feature/hs/hs_ob.c
+++ b/src/feature/hs/hs_ob.c
@@ -159,8 +159,8 @@ ob_option_parse(hs_service_config_t *config, const ob_options_t *opts)
       goto end;
     }
     smartlist_add(config->ob_master_pubkeys, pubkey);
-    log_info(LD_REND, "OnionBalance: MasterOnionAddress %s registered",
-             line->value);
+    log_notice(LD_REND, "OnionBalance: MasterOnionAddress %s registered",
+               line->value);
   }
   /* Success. */
   ret = 1;


### PR DESCRIPTION
This is to allow a visual feedback in the logs for operators setting up Onion
Balance so they can confirm they properly configured the instances.

Signed-off-by: David Goulet <dgoulet@torproject.org>