### PR TITLE
client: Revert setting PreferIPv6 on by default

### DIFF
--- a/changes/ticket33804
+++ b/changes/ticket33804
@@ -1,0 +1,7 @@
+  o Minor bugfixes (client, SocksPort, IPv6):
+    - Revert PreferIPv6 set by default on the SocksPort because it brokes the
+      torsocks use case. Tor doesn't have a way for an application to request
+      the hostname to be resolved for a specific IP version but torsocks
+      requires that. Up until now, IPv4 was used by default so it is expecting
+      that, and can't handle a possible IPv6 being returned. Fixes bug 33804;
+      bugfix on 0.4.3.1-alpha.

--- a/doc/tor.1.txt
+++ b/doc/tor.1.txt
@@ -1492,7 +1492,7 @@ The following options are useful only for clients (that is, if
         requests on this connection. This option is only relevant when SOCKS5
         is in use, because SOCKS4 can't handle IPv6.  (Allowing IPv6 is the
         default.)
-    **NoPreferIPv6**;;
+    **PreferIPv6**;;
         Tells exits that, if a host has both an IPv4 and an IPv6 address,
         we would prefer to connect to it via IPv4. (IPv4 is the default.)
     **NoDNSRequest**;;

--- a/doc/tor.1.txt
+++ b/doc/tor.1.txt
@@ -1494,8 +1494,7 @@ The following options are useful only for clients (that is, if
         default.)
     **NoPreferIPv6**;;
         Tells exits that, if a host has both an IPv4 and an IPv6 address,
-        we would prefer to connect to it via IPv4. (IPv6 is the default in
-        recent versions of Tor.)
+        we would prefer to connect to it via IPv4. (IPv4 is the default.)
     **NoDNSRequest**;;
         Do not ask exits to resolve DNS addresses in SOCKS5 requests. Tor will
         connect to IPv4 addresses, IPv6 addresses (if IPv6Traffic is set) and
@@ -1537,7 +1536,7 @@ The following options are useful only for clients (that is, if
         When serving a hostname lookup request on this port that
         should get automapped (according to AutomapHostsOnResolve),
         if we could return either an IPv4 or an IPv6 answer, prefer
-        an IPv4 answer. (Tor prefers IPv6 by default.)
+        an IPv4 answer. (Tor prefers IPv4 by default.)
     **PreferSOCKSNoAuth**;;
         Ordinarily, when an application offers both "username/password
         authentication" and "no authentication" to Tor via SOCKS5, Tor

--- a/src/app/config/config.c
+++ b/src/app/config/config.c
@@ -5886,7 +5886,7 @@ port_cfg_new(size_t namelen)
   port_cfg_t *cfg = tor_malloc_zero(sizeof(port_cfg_t) + namelen + 1);
   cfg->entry_cfg.ipv4_traffic = 1;
   cfg->entry_cfg.ipv6_traffic = 1;
-  cfg->entry_cfg.prefer_ipv6 = 1;
+  cfg->entry_cfg.prefer_ipv6 = 0;
   cfg->entry_cfg.dns_request = 1;
   cfg->entry_cfg.onion_traffic = 1;
   cfg->entry_cfg.prefer_ipv6_virtaddr = 1;
@@ -6134,7 +6134,7 @@ port_parse_config(smartlist_t *out,
     /* This must be kept in sync with port_cfg_new's defaults */
     int no_listen = 0, no_advertise = 0, all_addrs = 0,
       bind_ipv4_only = 0, bind_ipv6_only = 0,
-      ipv4_traffic = 1, ipv6_traffic = 1, prefer_ipv6 = 1, dns_request = 1,
+      ipv4_traffic = 1, ipv6_traffic = 1, prefer_ipv6 = 0, dns_request = 1,
       onion_traffic = 1,
       cache_ipv4 = 0, use_cached_ipv4 = 0,
       cache_ipv6 = 0, use_cached_ipv6 = 0,

--- a/src/test/test_config.c
+++ b/src/test/test_config.c
@@ -4159,7 +4159,7 @@ test_config_parse_port_config__ports__ports_given(void *data)
   tt_int_op(port_cfg->entry_cfg.dns_request, OP_EQ, 1);
   tt_int_op(port_cfg->entry_cfg.ipv4_traffic, OP_EQ, 1);
   tt_int_op(port_cfg->entry_cfg.ipv6_traffic, OP_EQ, 1);
-  tt_int_op(port_cfg->entry_cfg.prefer_ipv6, OP_EQ, 1);
+  tt_int_op(port_cfg->entry_cfg.prefer_ipv6, OP_EQ, 0);
   tt_int_op(port_cfg->entry_cfg.onion_traffic, OP_EQ, 1);
   tt_int_op(port_cfg->entry_cfg.cache_ipv4_answers, OP_EQ, 0);
   tt_int_op(port_cfg->entry_cfg.prefer_ipv6_virtaddr, OP_EQ, 1);


### PR DESCRIPTION
This change broke torsocks that by default is expecting an IPv4 for hostname
resolution because it can't ask tor for a specific IP version with the SOCKS5
extension.

PreferIPv6 made it that sometimes the IPv6 could be returned to torsocks that
was expecting an IPv4.

Torsocks is probably a very unique case because the runtime flow is that it
hijacks DNS resolution (ex: getaddrinfo()), gets an IP and then sends it back
for the connect() to happen.

The libc has DNS resolution functions that allows the caller to request a
specific INET family but torsocks can't tell tor to resolve the hostname only
to an IPv4 or IPv6 and thus by default fallsback to IPv4.

Reverting this change into 0.4.3.x series but we'll keep it in the 0.4.4.x
series in the hope that we add this SOCKS5 extension to tor for DNS resolution
and then change torsocks to use that.

Fixes #33804

Signed-off-by: David Goulet <dgoulet@torproject.org>