### PR TITLE
hs-v3: Fix typo in log info when PublishHidServDescriptors is set to 0

### DIFF
--- a/changes/ticket33779
+++ b/changes/ticket33779
@@ -1,0 +1,3 @@
+  o Minor bugfixes (onion service, logging):
+    - Typo in a log info level when PublishHidServDescriptors is set to 0.
+      Fixes bug 33779; bugfix on 0.3.2.1-alpha.

--- a/src/feature/hs/hs_service.c
+++ b/src/feature/hs/hs_service.c
@@ -2846,7 +2846,7 @@ upload_descriptor_to_hsdir(const hs_service_t *service,
   /* Let's avoid doing that if tor is configured to not publish. */
   if (!get_options()->PublishHidServDescriptors) {
     log_info(LD_REND, "Service %s not publishing descriptor. "
-                      "PublishHidServDescriptors is set to 1.",
+                      "PublishHidServDescriptors is set to 0.",
              safe_str_client(service->onion_address));
     goto end;
   }


### PR DESCRIPTION
Fixes #33779

Signed-off-by: David Goulet <dgoulet@torproject.org>