### PR TITLE
Correct 'was not internal' to 'was internal' in test_external_ip()

### DIFF
--- a/src/test/test_addr.c
+++ b/src/test/test_addr.c
@@ -110,7 +110,7 @@ test_addr_basic(void *arg)
     tt_int_op(tor_inet_pton(AF_INET6, a, &t1.addr.in6_addr), OP_EQ, 1); \
     t1.family = AF_INET6;                                      \
     if (tor_addr_is_internal(&t1, for_listening))              \
-      TT_DIE(("%s was not internal", a));                      \
+      TT_DIE(("%s was internal", a));                      \
   STMT_END
 
 #ifndef COCCI


### PR DESCRIPTION
Fixing a typo.

Please tell me if I need to open a ticket or add a ticket file in the repo.