### PR TITLE
log/util_bug: Make IF_BUG_ONCE() support ALL_BUGS_ARE_FATAL

### DIFF
--- a/changes/bug33917
+++ b/changes/bug33917
@@ -1,0 +1,5 @@
+  o Minor bugfixes (logging, testing):
+    - Make all of tor's assertion macros support the ALL_BUGS_ARE_FATAL and
+      DISABLE_ASSERTS_IN_UNIT_TESTS debugging modes. Implements these modes
+      for IF_BUG_ONCE(). (It used to log a non-fatal warning, regardless of
+      the debugging mode.) Fixes bug 33917; bugfix on 0.2.9.1-alpha.


### PR DESCRIPTION
... and DISABLE_ASSERTS_IN_UNIT_TESTS.

Make all of tor's assertion macros support the ALL_BUGS_ARE_FATAL and
DISABLE_ASSERTS_IN_UNIT_TESTS debugging modes.

Implements these modes for IF_BUG_ONCE(). (It used to log a non-fatal
warning, regardless of the debugging mode.)

Fixes bug 33917; bugfix on 0.2.9.1-alpha.