### PR TITLE
Ticket33617

### DIFF
--- a/changes/ticket33617
+++ b/changes/ticket33617
@@ -1,0 +1,3 @@
+  o Minor features (torrc option, consensus parameter):
+    - Added BandwidthStatistics torrc option and consensus parameter.
+      Closes ticket 33617. Patch by MrSquanchee.

--- a/doc/tor.1.txt
+++ b/doc/tor.1.txt
@@ -3780,6 +3780,10 @@ __DataDirectory__/**`stats/bridge-stats`**::
     Only used by servers. This file is used to collect incoming connection
     statistics by Tor bridges.
 
+__DataDirectory__/**`stats/bandwidth-stats`**::
+    Only used by relays and bridges. This file is used to collect information
+    about bandwidth used in OR and directory read and write operations.
+
 __DataDirectory__/**`stats/exit-stats`**::
     Only used by servers. This file is used to collect outgoing connection
     statistics by Tor exit routers.

--- a/doc/tor.1.txt
+++ b/doc/tor.1.txt
@@ -2616,6 +2616,17 @@ Relays publish most statistics in a document called the
 extra-info document. The following options affect the different
 types of statistics that Tor relays collect and publish:
 
+[[BandwidthStatistics]] **BandwidthStatistics** **0**|**1**|**auto**::
+    Relays and bridges only.
+    When this option is enabled, Tor collects statistics about bandwidth (i.e.
+    read and written bytes, and read and written directory bytes) and writes
+    them to disk every 24 hours. Relay and bridge operators may use the
+    statistics for performance monitoring. If this option is set to "auto",
+    use the value from the BandwidthStatistics consensus parameter, and
+    default to 1 if the consensus parameter isn't set. If ExtraInfoStatistics
+    is enabled, it will be published as part of the extra-info document.
+    (Default: auto)
+
 [[CellStatistics]] **CellStatistics** **0**|**1**::
     Relays only.
     When this option is enabled, Tor collects statistics about cell

--- a/src/app/config/config.c
+++ b/src/app/config/config.c
@@ -463,6 +463,7 @@ static const config_var_t option_vars_[] = {
   V(ExtORPortCookieAuthFile,     FILENAME,   NULL),
   V(ExtORPortCookieAuthFileGroupReadable, BOOL, "0"),
   V(ExtraInfoStatistics,         BOOL,     "1"),
+  V(BandwidthStatistics,         AUTOBOOL,     "auto"),
   V(ExtendByEd25519ID,           AUTOBOOL, "auto"),
   V(FallbackDir,                 LINELIST, NULL),
 

--- a/src/app/config/or_options_st.h
+++ b/src/app/config/or_options_st.h
@@ -634,6 +634,12 @@ struct or_options_t {
   /** If true, include statistics file contents in extra-info documents. */
   int ExtraInfoStatistics;
 
+  /** If true, write the bandwidth stats to disk and publish the stats
+   *  in extrainfo document. If set to auto, write the bandwidth stats
+   *  to disk and check the consesus parameter, BandwidthStatistics,
+   *  before publishing the stats in extrainfo document. */
+  int BandwidthStatistics;
+
   /** If true, do not believe anybody who tells us that a domain resolves
    * to an internal address, or that an internal address has a PTR mapping.
    * Helps avoid some cross-site attacks. */

--- a/src/app/main/main.c
+++ b/src/app/main/main.c
@@ -1030,6 +1030,7 @@ sandbox_init_filter(void)
     OPEN_DATADIR2_SUFFIX("stats", "buffer-stats", ".tmp");
     OPEN_DATADIR2_SUFFIX("stats", "conn-stats", ".tmp");
     OPEN_DATADIR2_SUFFIX("stats", "hidserv-stats", ".tmp");
+    OPEN_DATADIR2_SUFFIX("stats", "bandwidth-stats", ".tmp");
 
     OPEN_DATADIR("approved-routers");
     OPEN_DATADIR_SUFFIX("fingerprint", ".tmp");
@@ -1046,6 +1047,7 @@ sandbox_init_filter(void)
     RENAME_KEYDIR_SUFFIX("secret_onion_key", ".tmp");
     RENAME_KEYDIR_SUFFIX("secret_onion_key.old", ".tmp");
 
+    RENAME_SUFFIX2("stats", "bandwidth-stats", ".tmp");
     RENAME_SUFFIX2("stats", "bridge-stats", ".tmp");
     RENAME_SUFFIX2("stats", "dirreq-stats", ".tmp");
     RENAME_SUFFIX2("stats", "entry-stats", ".tmp");

--- a/src/core/mainloop/mainloop.c
+++ b/src/core/mainloop/mainloop.c
@@ -1959,6 +1959,15 @@ write_stats_file_callback(time_t now, const or_options_t *options)
     if (next_write && next_write < next_time_to_write_stats_files)
       next_time_to_write_stats_files = next_write;
   }
+  /* Writes bandwidth statistics to disk if BandwidthStatistics is set to 1
+   * or auto (-1). It doesn't check the consensus parameter here
+   * for it can change temporarily and we do not want to lose the stats.
+   * If BandwidthStatistics is set to 0 then don't write to disk. */
+  if ( !!options->BandwidthStatistics) {
+    time_t next_write = rep_hist_bw_stats_write(now);
+    if (next_write && next_write < next_time_to_write_stats_files)
+      next_time_to_write_stats_files = next_write;
+  }
 
   return safe_timer_diff(now, next_time_to_write_stats_files);
 }

--- a/src/feature/relay/router.c
+++ b/src/feature/relay/router.c
@@ -3225,9 +3225,9 @@ extrainfo_dump_to_string_stats_helper(smartlist_t *chunks,
 
   if (options->ExtraInfoStatistics && write_stats_to_extrainfo) {
     log_info(LD_GENERAL, "Adding stats to extra-info descriptor.");
-    /* Bandwidth usage stats don't have their own option */
-    {
-      contents = rep_hist_get_bandwidth_lines();
+    if (get_bandwidth_stats_param(NULL) &&
+      load_stats_file("stats"PATH_SEPARATOR"bandwidth-stats",
+                      "write-history",now,&contents) > 0) {
       smartlist_add(chunks, contents);
     }
     /* geoip hashes aren't useful unless we are publishing other stats */

--- a/src/feature/stats/rephist.c
+++ b/src/feature/stats/rephist.c
@@ -1558,6 +1558,23 @@ rep_hist_bw_stats_write(time_t now)
   return start_of_bw_stats_interval;
 }
 
+/** If the BandwidthStatistics option is "auto", checks the BandwidthStatistics
+ * consensus parameter, and returns its value. If the consensus parameter is
+ * not set, return a default value. If the BandwidthStatistics option is not
+ * auto, return the value of the BandwidthStatistics option. */
+bool
+get_bandwidth_stats_param(const networkstatus_t *ns)
+{
+  int bandwidth_stats = get_options()->BandwidthStatistics;
+  /* If bandwidth_stats is auto check the consensus parameter. */
+  if (bandwidth_stats == -1)
+    bandwidth_stats = networkstatus_get_param(ns, "BandwidthStatistics",
+                              BANDWIDTHSTATS_ENABLED_DEFAULT, 0, 1);
+  /** If BANDWIDTHSTATS_ENABLED_DEFAULT is set to -1 in future,
+   *  this should return true. */
+  return !!bandwidth_stats;
+}
+
 /*** Exit port statistics ***/
 
 /* Some constants */

--- a/src/feature/stats/rephist.h
+++ b/src/feature/stats/rephist.h
@@ -12,6 +12,10 @@
 #ifndef TOR_REPHIST_H
 #define TOR_REPHIST_H
 
+/** The default BandwidthStatistics setting, if the option is "auto"
+  * and the consensus parameter is not set. */
+#define BANDWIDTHSTATS_ENABLED_DEFAULT 1
+
 void rep_hist_init(void);
 void rep_hist_dump_stats(time_t now, int severity);
 void rep_hist_note_bytes_read(uint64_t num_bytes, time_t when);
@@ -32,6 +36,7 @@ void rep_hist_note_router_reachable(const char *id, const tor_addr_t *at_addr,
                                     const uint16_t at_port, time_t when);
 void rep_hist_note_router_unreachable(const char *id, time_t when);
 int rep_hist_record_mtbf_data(time_t now, int missing_means_down);
+bool get_bandwidth_stats_param(const networkstatus_t *ns);
 time_t rep_hist_bw_stats_write(time_t now);
 int rep_hist_load_mtbf_data(time_t now);
 

--- a/src/feature/stats/rephist.h
+++ b/src/feature/stats/rephist.h
@@ -32,6 +32,7 @@ void rep_hist_note_router_reachable(const char *id, const tor_addr_t *at_addr,
                                     const uint16_t at_port, time_t when);
 void rep_hist_note_router_unreachable(const char *id, time_t when);
 int rep_hist_record_mtbf_data(time_t now, int missing_means_down);
+time_t rep_hist_bw_stats_write(time_t now);
 int rep_hist_load_mtbf_data(time_t now);
 
 time_t rep_hist_downrate_old_runs(time_t now);

--- a/src/test/conf_examples/bandwidthstats_1/error_no_dirauth_relay
+++ b/src/test/conf_examples/bandwidthstats_1/error_no_dirauth_relay
@@ -1,0 +1,1 @@
+This tor was built with relay mode disabled.

--- a/src/test/conf_examples/bandwidthstats_1/expected
+++ b/src/test/conf_examples/bandwidthstats_1/expected
@@ -1,0 +1,4 @@
+BandwidthStatistics 0
+ContactInfo tor_parse_test@example.com
+Nickname Unnamed
+ORPort 1

--- a/src/test/conf_examples/bandwidthstats_1/expected_log
+++ b/src/test/conf_examples/bandwidthstats_1/expected_log
@@ -1,0 +1,1 @@
+Read configuration file .*bandwidthstats_1[./]*torrc

--- a/src/test/conf_examples/bandwidthstats_1/torrc
+++ b/src/test/conf_examples/bandwidthstats_1/torrc
@@ -1,0 +1,4 @@
+
+ORPort 1
+BandwidthStatistics 0
+ContactInfo tor_parse_test@example.com

--- a/src/test/conf_examples/bandwidthstats_2/error_no_dirauth_relay
+++ b/src/test/conf_examples/bandwidthstats_2/error_no_dirauth_relay
@@ -1,0 +1,1 @@
+This tor was built with relay mode disabled.

--- a/src/test/conf_examples/bandwidthstats_2/expected
+++ b/src/test/conf_examples/bandwidthstats_2/expected
@@ -1,0 +1,4 @@
+BandwidthStatistics 1
+ContactInfo tor_parse_test@example.com
+Nickname Unnamed
+ORPort 1

--- a/src/test/conf_examples/bandwidthstats_2/expected_log
+++ b/src/test/conf_examples/bandwidthstats_2/expected_log
@@ -1,0 +1,1 @@
+Read configuration file .*bandwidthstats_2[./]*torrc

--- a/src/test/conf_examples/bandwidthstats_2/torrc
+++ b/src/test/conf_examples/bandwidthstats_2/torrc
@@ -1,0 +1,4 @@
+
+ORPort 1
+BandwidthStatistics 1
+ContactInfo tor_parse_test@example.com

--- a/src/test/conf_examples/bandwidthstats_3/error_no_dirauth_relay
+++ b/src/test/conf_examples/bandwidthstats_3/error_no_dirauth_relay
@@ -1,0 +1,1 @@
+This tor was built with relay mode disabled.

--- a/src/test/conf_examples/bandwidthstats_3/expected
+++ b/src/test/conf_examples/bandwidthstats_3/expected
@@ -1,0 +1,3 @@
+ContactInfo tor_parse_test@example.com
+Nickname Unnamed
+ORPort 1

--- a/src/test/conf_examples/bandwidthstats_3/expected_log
+++ b/src/test/conf_examples/bandwidthstats_3/expected_log
@@ -1,0 +1,1 @@
+Read configuration file .*bandwidthstats_3[./]*torrc

--- a/src/test/conf_examples/bandwidthstats_3/torrc
+++ b/src/test/conf_examples/bandwidthstats_3/torrc
@@ -1,0 +1,4 @@
+
+ORPort 1
+BandwidthStatistics auto
+ContactInfo tor_parse_test@example.com


### PR DESCRIPTION
Trac : https://trac.torproject.org/projects/tor/ticket/33617

Torrc Option: Add BandwidthStatistics
Write bandwidth statistics to disk.
Add BandwidthStatistics consensus parameter.

Some tests are to be added as per [teor](https://trac.torproject.org/projects/tor/ticket/33617#comment:32).

The functions added and modified are :- 
1. `write_stats_file_callback()`
2. `extrainfo_dump_to_string_stats_helper()`
3. `bw_arrays_init()` (Tests would be unnecessary).
4. `rep_hist_bw_stats_write()`
5. `get_bandwidth_stats_param()` (Tests Added).