### PR TITLE
Fix a GCC 10.0.1 compilation warning.

### DIFF
--- a/changes/bug34077
+++ b/changes/bug34077
@@ -1,0 +1,3 @@
+  o Minor bugfixes (compiler warnings):
+    - Fix compilation warnings with GCC 10.0.1. Fixes bug 34077; bugfix on
+      0.4.0.3-alpha.

--- a/src/feature/dirauth/shared_random_state.c
+++ b/src/feature/dirauth/shared_random_state.c
@@ -1057,8 +1057,9 @@ sr_state_set_valid_after(time_t valid_after)
 sr_phase_t
 sr_state_get_phase(void)
 {
-  void *ptr;
+  void *ptr=NULL;
   state_query(SR_STATE_ACTION_GET, SR_STATE_OBJ_PHASE, NULL, &ptr);
+  tor_assert(ptr);
   return *(sr_phase_t *) ptr;
 }
 


### PR DESCRIPTION
Fixes 34077 for 0.4.1; bugfix on 0.4.0.3-alpha. (Specifically, GCC
first gives this warning for 9eeff921ae7b786d960ea4286d5bba56)