### PR TITLE
Add support for console control signals in Windows

### DIFF
--- a/changes/ticket34211
+++ b/changes/ticket34211
@@ -1,0 +1,3 @@
+  o Minor features (windows):
+    - Add support for console control signals like Ctrl+C in Windows
+      Closes ticket 34211. Patch from Damon Harris (TheDcoder).

--- a/src/app/main/main.c
+++ b/src/app/main/main.c
@@ -294,6 +294,19 @@ process_signal(int sig)
   }
 }
 
+#ifdef _WIN32
+/** Activate SIGINT on reciving a control signal in console */
+static BOOL WINAPI
+process_win32_console_ctrl(DWORD ctrl_type)
+{
+  /* Ignore type of the ctrl signal */
+  (void) ctrl_type;
+
+  activate_signal(SIGINT);
+  return TRUE;
+}
+#endif
+
 /**
  * Write current memory usage information to the log.
  */
@@ -496,6 +509,13 @@ handle_signals(void)
                       &signal_handlers[i].signal_value);
     }
   }
+
+#ifdef _WIN32
+    /* Windows lacks traditional POSIX signals but WinAPI provides a function
+     * to handle control signals like Ctrl+C in the console, we can use this to
+     * simulate the SIGINT signal */
+    if (enabled) SetConsoleCtrlHandler(process_win32_console_ctrl, TRUE);
+#endif
 }
 
 /* Cause the signal handler for signal_num to be called in the event loop. */


### PR DESCRIPTION
This pull request is for Ticket [#34211](https://trac.torproject.org/projects/tor/ticket/34211):

> Hi everyone!
> 
> I am working on a [cross-platform Tor controller/wrapper](https://github.com/DcodingTheWeb/ProxAllium/tree/next-gen), and I encountered a minor inconvenience while writing code for stopping Tor in Windows.
> 
> Currently the only way to gracefully terminate Tor in Windows is to use the control port to issue the `SIGINT` signal, it would be beneficial for 3rd party programs which work with Tor to be able to invoke this procedure by using the native "control signals" provided to console programs in Windows.
> 
> I have made a patch which implements this functionality, I will post it soon, I am creating this ticket so that I can create a corresponding file in the `changes` directory :)
> 
> Thanks to nickm for some pointers about using the libevent `event_active` function to trigger the event, I decided to use the `activate_signal` function as it internally calls the suggested function and simplifies the code.