### PR TITLE
Fix an enum comparison that was blowing up jenkins.

### DIFF
--- a/src/feature/hs/hs_service.c
+++ b/src/feature/hs/hs_service.c
@@ -3115,7 +3115,7 @@ log_cant_upload_desc(const hs_service_t *service,
    * control that value in the code flow but will be apparent during
    * development if a reason is added but LOG_DESC_UPLOAD_REASON_NUM_ is not
    * updated. */
-  if (BUG(reason > LOG_DESC_UPLOAD_REASON_MAX || reason < 0)) {
+  if (BUG(reason > LOG_DESC_UPLOAD_REASON_MAX)) {
     return;
   }
 


### PR DESCRIPTION
The warning was:
    11:23:10 ../tor/src/feature/hs/hs_service.c: In function 'log_cant_upload_desc':
    11:23:10 ../tor/src/feature/hs/hs_service.c:3118:3: error: comparison of unsigned expression < 0 is always false [-Werror=type-limits]
See #34254 for more info.

I guess this means that gcc assigned an unsigned type to the
`log_desc_upload_reason_t` enum and it warned if we compared it against 0...

For now I think it's simpler to remove that check instead of turning the enum
to a signed type, or trying to hack it some other way.

From what it seems, enum is up to the compiler on whether it's signed/unsigned:
     https://stackoverflow.com/questions/159034/are-c-enums-signed-or-unsigned