### PR TITLE
Man page: MinUptimeHidServDirectoryV2 defaults to 96 hours

### DIFF
--- a/changes/bug34299
+++ b/changes/bug34299
@@ -1,0 +1,3 @@
+  o Minor bugfixes (man page):
+    - Update the man page to reflect that MinUptimeHidServDirectoryV2
+      defaults to 96 hours. Fixes bug 34299; bugfix on 0.2.6.3-alpha.

--- a/doc/tor.1.txt
+++ b/doc/tor.1.txt
@@ -2907,8 +2907,8 @@ on the public Tor network.
     networkstatus documents rather than generating its own. (Default: 0)
 
 [[MinUptimeHidServDirectoryV2]] **MinUptimeHidServDirectoryV2** __N__ **seconds**|**minutes**|**hours**|**days**|**weeks**::
-    Minimum uptime of a v2 hidden service directory to be accepted as such by
-    authoritative directories. (Default: 25 hours)
+    Minimum uptime of a relay to be accepted as a hidden service directory
+    by directory authorities. (Default: 96 hours)
 
 [[RecommendedServerVersions]] **RecommendedServerVersions** __STRING__::
     STRING is a comma-separated list of Tor versions currently believed to be


### PR DESCRIPTION
Bugfix on 0.2.6.3-alpha; fixes bug 34299.