### PR TITLE
Preemptive circs should work with UseEntryGuards 0

### DIFF
--- a/changes/bug34303
+++ b/changes/bug34303
@@ -1,0 +1,5 @@
+  o Minor bugfixes (client performance):
+    - Resume being willing to use preemptively-built circuits when
+      UseEntryGuards is set to 0. We accidentally disabled this feature
+      with that config setting, leading to slower load times. Fixes bug
+      34303; bugfix on 0.3.3.2-alpha.

--- a/src/core/or/circuitlist.c
+++ b/src/core/or/circuitlist.c
@@ -1883,7 +1883,7 @@ circuit_find_to_cannibalize(uint8_t purpose_to_produce, extend_info_t *info,
       }
 
       /* Ignore any circuits for which we can't use the Guard. It is possible
-       * that the Guard was removed from the samepled set after the circuit
+       * that the Guard was removed from the sampled set after the circuit
        * was created so avoid using it. */
       if (!entry_guard_could_succeed(circ->guard_state)) {
         goto next;

--- a/src/feature/client/entrynodes.c
+++ b/src/feature/client/entrynodes.c
@@ -3452,10 +3452,16 @@ entry_guards_update_state(or_state_t *state)
   entry_guards_dirty = 0;
 }
 
-/** Return true iff the circuit's guard can succeed that is can be used. */
+/** Return true iff the circuit's guard can succeed, that is, can be used. */
 int
 entry_guard_could_succeed(const circuit_guard_state_t *guard_state)
 {
+  if (get_options()->UseEntryGuards == 0) {
+    /* we're fine with this circuit's first hop, because we're not
+     * configured to use entry guards. */
+    return 1;
+  }
+
   if (!guard_state) {
     return 0;
   }


### PR DESCRIPTION
Resume being willing to use preemptively-built circuits when
UseEntryGuards is set to 0. We accidentally disabled this feature with
that config setting (in our fix for #24469), leading to slower load times.

Fixes bug 34303; bugfix on 0.3.3.2-alpha.