### PR TITLE
sandbox: Do not require M_SYSCALL.

### DIFF
--- a/changes/ticket34382
+++ b/changes/ticket34382
@@ -1,0 +1,6 @@
+  o Minor features (Linux seccomp2 sandbox, compilation):
+    - Allow Tor to build on platforms where it doesn't know how to
+      report which syscall had caused the linux seccomp2 sandbox
+      to fail. This change should make the sandbox code more portable
+      to less common Linux architectures.
+      Closes ticket 34382.


### PR DESCRIPTION
M_SYSCALL is used to report information about a sandbox violation,
but when we don't have a definition for it, it still makes sense to
compile.

Closes ticket 34382.