### PR TITLE
#34381: Remove tor.sh from .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -79,11 +79,9 @@ uptime-*.json
 /callgraph/
 
 # /contrib/
-/contrib/dist/tor.sh
 /contrib/dist/torctl
 /contrib/dist/tor.service
 /contrib/operator-tools/tor.logrotate
-/contrib/dist/suse/tor.sh
 
 # /debian/
 /debian/files


### PR DESCRIPTION
The files contrib/dist/tor.sh and contrib/dist/suse/tor.sh should not
exist anymore, but when building in same repository for older versions
of Tor, these files may return and not be cleaned up properly. This
commit unignores those files from .gitignore, in order to make it clear
that these files are no longer auto-generated and should be cleaned up.

Part of [Trac ticket #34381](https://trac.torproject.org/projects/tor/ticket/34381)