### PR TITLE
Update and upgrade Pacman before installing dependencies in AppVeyor.

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -65,6 +65,8 @@ install:
      # All installed library dlls must be copied to the test and app
      # directories, before running tor's tests. (See below.)
      #>
+    Execute-Command "C:\msys64\usr\bin\pacman" -Syu --verbose --noconfirm pacman ;
+- ps: >-
     Execute-Command "C:\msys64\usr\bin\pacman" -Sy --verbose --needed --noconfirm ${env:mingw_prefix}-libevent ${env:mingw_prefix}-openssl ${env:mingw_prefix}-pkg-config ${env:mingw_prefix}-xz ${env:mingw_prefix}-zstd ;
 
 build_script:


### PR DESCRIPTION
This patch makes sures that AppVeyor upgrades its Pacman (the package
manager) before installing the Tor dependencies.

See: https://bugs.torproject.org/34384