### PR TITLE
[Tor Trac #34065]: Make routerset_contains_router() support IPv6

### DIFF
--- a/changes/bug34065
+++ b/changes/bug34065
@@ -1,0 +1,5 @@
+  o Minor features (IPv6, ExcludeNodes):
+    - Make routerset_contains_router() capable of handling IPv6
+      addresses. This makes ExcludeNodes capable of excluding an
+      IPv6 adddress. Previously, ExcludeNodes ignored IPv6
+      addresses. Closes ticket 34065. Patch by Neel Chauhan.

--- a/src/feature/nodelist/routerset.c
+++ b/src/feature/nodelist/routerset.c
@@ -306,14 +306,16 @@ int
 routerset_contains_router(const routerset_t *set, const routerinfo_t *ri,
                           country_t country)
 {
-  tor_addr_t addr;
-  tor_addr_from_ipv4h(&addr, ri->addr);
-  return routerset_contains(set,
-                            &addr,
-                            ri->or_port,
-                            ri->nickname,
-                            ri->cache_info.identity_digest,
-                            country);
+  tor_addr_t addr_v4;
+  tor_addr_from_ipv4h(&addr_v4, ri->addr);
+  int v4_ret =
+    routerset_contains(set, &addr_v4, ri->or_port, ri->nickname,
+                       ri->cache_info.identity_digest, country);
+  int v6_ret =
+    routerset_contains(set, &ri->ipv6_addr, ri->ipv6_orport, ri->nickname,
+                       ri->cache_info.identity_digest, country);
+
+  return MAX(v4_ret, v6_ret);
 }
 
 /** Return true iff <b>rs</b> is in <b>set</b>.  If country is <b>-1</b>, we

--- a/src/test/test_routerset.c
+++ b/src/test/test_routerset.c
@@ -1433,11 +1433,6 @@ test_rset_contains_router_ipv4(void *arg)
   const char *s;
   (void) arg;
 
-  MOCK(router_parse_addr_policy_item_from_string,
-       rset_parse_policy_ipv4_parse_item_from_string);
-  rset_parse_policy_ipv4_mock_addr_policy =
-    tor_malloc_zero(sizeof(addr_policy_t));
-
   /* IPv4 address test. */
   memset(&ri, 0, sizeof(ri));
   set = routerset_new();
@@ -1462,11 +1457,6 @@ test_rset_contains_router_ipv6(void *arg)
   int r;
   const char *s;
   (void) arg;
-
-  MOCK(router_parse_addr_policy_item_from_string,
-       rset_parse_policy_ipv6_parse_item_from_string);
-  rset_parse_policy_ipv6_mock_addr_policy =
-    tor_malloc_zero(sizeof(addr_policy_t));
 
   /* IPv6 address test. */
   memset(&ri, 0, sizeof(ri));

--- a/src/test/test_routerset.c
+++ b/src/test/test_routerset.c
@@ -1417,8 +1417,18 @@ test_rset_contains_router(void *arg)
   ri.nickname = (char *)nickname;
 
   r = routerset_contains_router(set, &ri, country);
-
   tt_int_op(r, OP_EQ, 4);
+
+  /* IP address test. */
+  ri.addr = htonl(0x0a000001); /* 10.0.0.1 */
+  ri.or_port = 1234;
+
+  tor_addr_parse(&ri.ipv6_addr, "2600::1");
+  ri.ipv6_orport = 12345;
+
+  r = routerset_contains_router(set, &ri, country);
+  tt_int_op(r, OP_EQ, 4);
+
   done:
     routerset_free(set);
 }

--- a/src/test/test_routerset.c
+++ b/src/test/test_routerset.c
@@ -1419,18 +1419,68 @@ test_rset_contains_router(void *arg)
   r = routerset_contains_router(set, &ri, country);
   tt_int_op(r, OP_EQ, 4);
 
-  /* IP address test. */
+  done:
+    routerset_free(set);
+}
+
+static void
+test_rset_contains_router_ipv4(void *arg)
+{
+  routerset_t *set;
+  routerinfo_t ri;
+  country_t country = 1;
+  int r;
+  const char *s;
+  (void) arg;
+
+  MOCK(router_parse_addr_policy_item_from_string,
+       rset_parse_policy_ipv4_parse_item_from_string);
+  rset_parse_policy_ipv4_mock_addr_policy =
+    tor_malloc_zero(sizeof(addr_policy_t));
+
+  /* IPv4 address test. */
+  memset(&ri, 0, sizeof(ri));
+  set = routerset_new();
+  s = "10.0.0.1";
+  r = routerset_parse(set, s, "");
   ri.addr = htonl(0x0a000001); /* 10.0.0.1 */
   ri.or_port = 1234;
 
+  r = routerset_contains_router(set, &ri, country);
+  tt_int_op(r, OP_EQ, 3);
+
+ done:
+  routerset_free(set);
+}
+
+static void
+test_rset_contains_router_ipv6(void *arg)
+{
+  routerset_t *set;
+  routerinfo_t ri;
+  country_t country = 1;
+  int r;
+  const char *s;
+  (void) arg;
+
+  MOCK(router_parse_addr_policy_item_from_string,
+       rset_parse_policy_ipv6_parse_item_from_string);
+  rset_parse_policy_ipv6_mock_addr_policy =
+    tor_malloc_zero(sizeof(addr_policy_t));
+
+  /* IPv6 address test. */
+  memset(&ri, 0, sizeof(ri));
+  set = routerset_new();
+  s = "2600::1";
+  r = routerset_parse(set, s, "");
   tor_addr_parse(&ri.ipv6_addr, "2600::1");
   ri.ipv6_orport = 12345;
 
   r = routerset_contains_router(set, &ri, country);
-  tt_int_op(r, OP_EQ, 4);
+  tt_int_op(r, OP_EQ, 3);
 
-  done:
-    routerset_free(set);
+ done:
+  routerset_free(set);
 }
 
 /*
@@ -2154,6 +2204,10 @@ struct testcase_t routerset_tests[] = {
   { "contains_extendinfo", test_rset_contains_extendinfo,
     TT_FORK, NULL, NULL },
   { "contains_router", test_rset_contains_router, TT_FORK, NULL, NULL },
+  { "contains_router_ipv4", test_rset_contains_router_ipv4,
+    TT_FORK, NULL, NULL },
+  { "contains_router_ipv6", test_rset_contains_router_ipv6,
+    TT_FORK, NULL, NULL },
   { "contains_routerstatus", test_rset_contains_routerstatus,
     TT_FORK, NULL, NULL },
   { "contains_none", test_rset_contains_none, TT_FORK, NULL, NULL },


### PR DESCRIPTION
PR: https://trac.torproject.org/projects/tor/ticket/34065