### PR TITLE
#40060: Add IPv6 ORPort config debug logging

### DIFF
--- a/src/feature/relay/router.c
+++ b/src/feature/relay/router.c
@@ -1475,6 +1475,9 @@ router_get_advertised_ipv6_or_ap(const or_options_t *options,
     return;
   }
 
+  log_debug(LD_CONFIG, "Found configured IPv6 ORPort '%s'.",
+            fmt_addrport(addr, port));
+
   /* If the relay is configured using the default authorities, disallow
    * internal IPs. Otherwise, allow them. For IPv4 ORPorts and DirPorts,
    * this check is done in resolve_my_address(). See #33681. */


### PR DESCRIPTION
Per [ticket #40060](https://gitlab.torproject.org/tpo/core/tor/-/issues/40060) this should log "the IPv6 address of the first IPv6
ORPort torrc option".