### PR TITLE
[Ticket #34400]: control: HSFETCH command fails to validate v2 addresses

### DIFF
--- a/changes/bug34400
+++ b/changes/bug34400
@@ -1,0 +1,5 @@
+  o Minor bugfixes (v2 onion services):
+    - For HSFETCH commands on v2 onion services addresses, check the length of
+      bytes decoded, not the base32 length. This takes the behavior introduced
+      in commit a517daa56f5848d25ba79617a1a7b82ed2b0a7c0 into consideration.
+      Fixes bug 34400; bugfix on 0.4.1.1-alpha. Patch by Neel Chauhan.

--- a/src/feature/control/control_cmd.c
+++ b/src/feature/control/control_cmd.c
@@ -1430,7 +1430,7 @@ handle_control_hsfetch(control_connection_t *conn,
              rend_valid_descriptor_id(arg1 + v2_str_len) &&
              base32_decode(digest, sizeof(digest), arg1 + v2_str_len,
                            REND_DESC_ID_V2_LEN_BASE32) ==
-                DIGEST_LEN) {
+                sizeof(digest)) {
     /* We have a well formed version 2 descriptor ID. Keep the decoded value
      * of the id. */
     desc_id = digest;

--- a/src/feature/control/control_cmd.c
+++ b/src/feature/control/control_cmd.c
@@ -1430,7 +1430,7 @@ handle_control_hsfetch(control_connection_t *conn,
              rend_valid_descriptor_id(arg1 + v2_str_len) &&
              base32_decode(digest, sizeof(digest), arg1 + v2_str_len,
                            REND_DESC_ID_V2_LEN_BASE32) ==
-                REND_DESC_ID_V2_LEN_BASE32) {
+                DIGEST_LEN) {
     /* We have a well formed version 2 descriptor ID. Keep the decoded value
      * of the id. */
     desc_id = digest;


### PR DESCRIPTION
Ticket: https://gitlab.torproject.org/tpo/core/tor/-/issues/34400