### PR TITLE
[Tor Trac #34232]: Make summarize_protover_flags() handle NULL and empty string the same

### DIFF
--- a/changes/ticket34232
+++ b/changes/ticket34232
@@ -1,0 +1,5 @@
+  o Minor bugfixes (string handling):
+    - In summarize_protover_flags(), treat empty strings the same as NULL.
+      This prevents protocols_known from being set. Previously, we treated
+      empty strings as normal strings, which led to protocols_known being
+      set. Fixes bug 34232; bugfix on 0.3.3.2-alpha. Patch by Neel Chauhan.

--- a/src/core/or/versions.c
+++ b/src/core/or/versions.c
@@ -504,10 +504,10 @@ summarize_protover_flags(protover_summary_flags_t *out,
 {
   tor_assert(out);
   memset(out, 0, sizeof(*out));
-  if (protocols) {
+  if (protocols && strcmp(protocols, "")) {
     memoize_protover_summary(out, protocols);
   }
-  if (version && !strcmpstart(version, "Tor ")) {
+  if (version && strcmp(version, "") && !strcmpstart(version, "Tor ")) {
     if (!out->protocols_known) {
       /* The version is a "Tor" version, and where there is no
        * list of protocol versions that we should be looking at instead. */

--- a/src/core/or/versions.c
+++ b/src/core/or/versions.c
@@ -490,8 +490,8 @@ memoize_protover_summary(protover_summary_flags_t *out,
 /** Summarize the protocols listed in <b>protocols</b> into <b>out</b>,
  * falling back or correcting them based on <b>version</b> as appropriate.
  *
- * If protocols and version are both NULL, returns a summary with no flags
- * set.
+ * If protocols and version are both NULL or "", returns a summary with no
+ * flags set.
  *
  * If the protover string does not contain any recognised protocols, and the
  * version is not recognised, sets protocols_known, but does not set any other

--- a/src/test/test_protover.c
+++ b/src/test/test_protover.c
@@ -789,13 +789,9 @@ test_protover_summarize_flags(void *args)
   DEBUG_PROTOVER(flags);
   tt_mem_op(&flags, OP_EQ, &zero_flags, sizeof(flags));
 
-  /* "" sets the protocols_known flag */
   memset(&flags, 0, sizeof(flags));
   summarize_protover_flags(&flags, "", "");
   DEBUG_PROTOVER(flags);
-  tt_int_op(flags.protocols_known, OP_EQ, 1);
-  /* Now clear that flag, and check the rest are zero */
-  flags.protocols_known = 0;
   tt_mem_op(&flags, OP_EQ, &zero_flags, sizeof(flags));
 
   /* Now check version exceptions */


### PR DESCRIPTION
Ticket: https://gitlab.torproject.org/tpo/core/tor/-/issues/34232