### PR TITLE
Consistently use 'address' in Invalid v3 address responses to ONION_CLIENT_AUTH commands

### DIFF
--- a/src/feature/control/control_hs.c
+++ b/src/feature/control/control_hs.c
@@ -291,7 +291,7 @@ handle_control_onion_client_auth_view(control_connection_t *conn,
   if (argc >= 1) {
     hsaddress = smartlist_get(args->args, 0);
     if (!hs_address_is_valid(hsaddress)) {
-      control_printf_endreply(conn, 512, "Invalid v3 addr \"%s\"", hsaddress);
+      control_printf_endreply(conn, 512, "Invalid v3 address \"%s\"", hsaddress);
       goto err;
     }
   }

--- a/src/test/test_hs_control.c
+++ b/src/test/test_hs_control.c
@@ -393,7 +393,7 @@ test_hs_control_good_onion_client_auth_add(void *arg)
   retval = handle_control_command(&conn, (uint32_t) strlen(args), args);
   tt_int_op(retval, OP_EQ, 0);
   cp1 = buf_get_contents(TO_CONN(&conn)->outbuf, &sz);
-  tt_str_op(cp1, OP_EQ, "512 Invalid v3 addr \"house\"\r\n");
+  tt_str_op(cp1, OP_EQ, "512 Invalid v3 address \"house\"\r\n");
 
  done:
   tor_free(args);


### PR DESCRIPTION
The response to ONION_CLIENT_AUTH_VIEW differed to the _ADD and _REMOVE commands in that it used 'Invalid v3 addr' rather than 'Invalid v3 address'. This makes it consistent.

Discovered whilst writing integration tests for the Stem implementation https://github.com/torproject/stem/pull/67

Thanks!
mig5 (from the OnionShare project)