### PR TITLE
Replace router_should_skip_*() identifiers.

### DIFF
--- a/src/feature/control/control_getinfo.c
+++ b/src/feature/control/control_getinfo.c
@@ -1283,13 +1283,13 @@ getinfo_helper_events(control_connection_t *control_conn,
                     "1" : "0");
     } else if (!strcmp(question, "status/reachability-succeeded/dir")) {
       *answer = tor_strdup(
-                    router_should_skip_dirport_reachability_check(options) ?
+                    router_dirport_seems_reachable(options) ?
                     "1" : "0");
     } else if (!strcmp(question, "status/reachability-succeeded")) {
       tor_asprintf(
           answer, "OR=%d DIR=%d",
           router_should_skip_orport_reachability_check(options) ? 1 : 0,
-          router_should_skip_dirport_reachability_check(options) ? 1 : 0);
+          router_dirport_seems_reachable(options) ? 1 : 0);
     } else if (!strcmp(question, "status/bootstrap-phase")) {
       *answer = control_event_boot_last_msg();
     } else if (!strcmpstart(question, "status/version/")) {

--- a/src/feature/relay/relay_periodic.c
+++ b/src/feature/relay/relay_periodic.c
@@ -202,9 +202,9 @@ reachability_warnings_callback(time_t now, const or_options_t *options)
     /* every 20 minutes, check and complain if necessary */
     const routerinfo_t *me = router_get_my_routerinfo();
     bool v4_ok =
-      router_should_skip_orport_reachability_check_family(options,AF_INET);
+      router_orport_seems_reachable(options,AF_INET);
     bool v6_ok =
-      router_should_skip_orport_reachability_check_family(options,AF_INET6);
+      router_orport_seems_reachable(options,AF_INET6);
     if (me && !(v4_ok && v6_ok)) {
       /* We need to warn that one or more of our ORPorts isn't reachable.
        * Determine which, and give a reasonable warning. */
@@ -243,7 +243,7 @@ reachability_warnings_callback(time_t now, const or_options_t *options)
       tor_free(address6);
     }
 
-    if (me && !router_should_skip_dirport_reachability_check(options)) {
+    if (me && !router_dirport_seems_reachable(options)) {
       char *address = tor_dup_ip(me->addr);
       if (address) {
         log_warn(LD_CONFIG,

--- a/src/feature/relay/router.c
+++ b/src/feature/relay/router.c
@@ -1370,7 +1370,7 @@ decide_if_publishable_server(void)
      * test network), so we can't check our DirPort reachability. */
     return 1;
   } else {
-    return router_should_skip_dirport_reachability_check(options);
+    return router_dirport_seems_reachable(options);
   }
 }
 

--- a/src/feature/relay/selftest.c
+++ b/src/feature/relay/selftest.c
@@ -86,7 +86,7 @@ router_reachability_checks_disabled(const or_options_t *options)
  * orport checks.
  */
 int
-router_should_skip_orport_reachability_check_family(
+router_orport_seems_reachable(
                                                 const or_options_t *options,
                                                 int family)
 {
@@ -124,7 +124,7 @@ router_should_skip_orport_reachability_check_family(
  *   - the network is disabled.
  */
 int
-router_should_skip_dirport_reachability_check(const or_options_t *options)
+router_dirport_seems_reachable(const or_options_t *options)
 {
   int reach_checks_disabled = router_reachability_checks_disabled(options) ||
                               !options->DirPort_set;
@@ -308,9 +308,9 @@ router_do_reachability_checks(int test_or, int test_dir)
   const routerinfo_t *me = router_get_my_routerinfo();
   const or_options_t *options = get_options();
   int orport_reachable_v4 =
-    router_should_skip_orport_reachability_check_family(options, AF_INET);
+    router_orport_seems_reachable(options, AF_INET);
   int orport_reachable_v6 =
-    router_should_skip_orport_reachability_check_family(options, AF_INET6);
+    router_orport_seems_reachable(options, AF_INET6);
 
   if (router_should_check_reachability(test_or, test_dir)) {
     bool need_testing = !circuit_enough_testing_circs();
@@ -325,7 +325,7 @@ router_do_reachability_checks(int test_or, int test_dir)
       router_do_orport_reachability_checks(me, AF_INET6, orport_reachable_v6);
     }
 
-    if (test_dir && !router_should_skip_dirport_reachability_check(options)) {
+    if (test_dir && !router_dirport_seems_reachable(options)) {
       router_do_dirport_reachability_checks(me);
     }
   }
@@ -407,7 +407,7 @@ static bool
 ready_to_publish(const or_options_t *options)
 {
   return options->PublishServerDescriptor_ != NO_DIRINFO &&
-    router_should_skip_dirport_reachability_check(options) &&
+    router_dirport_seems_reachable(options) &&
     router_should_skip_orport_reachability_check(options);
 }
 

--- a/src/feature/relay/selftest.h
+++ b/src/feature/relay/selftest.h
@@ -16,11 +16,11 @@
 
 struct or_options_t;
 #define router_should_skip_orport_reachability_check(opts) \
-  router_should_skip_orport_reachability_check_family((opts),0)
-int router_should_skip_orport_reachability_check_family(
+  router_orport_seems_reachable((opts),0)
+int router_orport_seems_reachable(
                                          const struct or_options_t *options,
                                          int family);
-int router_should_skip_dirport_reachability_check(
+int router_dirport_seems_reachable(
                                          const struct or_options_t *options);
 
 void router_do_reachability_checks(int test_or, int test_dir);
@@ -36,9 +36,9 @@ void router_reset_reachability(void);
 
 #define router_should_skip_orport_reachability_check(opts)     \
   ((void)(opts), 0)
-#define router_should_skip_orport_reachability_check_family(opts, fam)  \
+#define router_orport_seems_reachable(opts, fam)  \
   ((void)(opts), (void)(fam), 0)
-#define router_should_skip_dirport_reachability_check(opts) \
+#define router_dirport_seems_reachable(opts) \
   ((void)(opts), 0)
 
 static inline void

--- a/src/feature/stats/predict_ports.c
+++ b/src/feature/stats/predict_ports.c
@@ -273,7 +273,7 @@ rep_hist_circbuilding_dormant(time_t now)
       (!router_should_skip_orport_reachability_check(options) ||
        !circuit_enough_testing_circs()))
     return 0;
-  if (!router_should_skip_dirport_reachability_check(options))
+  if (!router_dirport_seems_reachable(options))
     return 0;
 
   return 1;


### PR DESCRIPTION
These identifiers are confusing and unreadable.  I think these
replacements should be better. Closes ticket #40012.

This is an automated commit, generated by this command:

./scripts/maint/rename_c_identifier.py \
        router_should_skip_orport_reachability_check_family router_orport_seems_reachable \
        router_should_skip_dirport_reachability_check router_dirport_seems_reachable \
        router_should_skip_dirport_reachability_check router_all_orports_seem_reachable