### PR TITLE
addr: Look at /48 for IPv6 in is_local_addr()

### DIFF
--- a/src/app/config/resolve_addr.c
+++ b/src/app/config/resolve_addr.c
@@ -603,8 +603,10 @@ is_local_to_resolve_addr, (const tor_addr_t *addr))
     return tor_addr_compare_masked(addr, last_resolved_addr, 24,
                                    CMP_SEMANTIC) == 0;
   case AF_INET6:
-    /* Look at the /32 like addrs_in_same_network_family() does. */
-    return tor_addr_compare_masked(addr, last_resolved_addr, 32,
+    /* Look at /48 because it is typically the smallest network in the global
+     * IPv6 routing tables, and it was previously the recommended per-customer
+     * network block. (See [RFC 6177: IPv6 End Site Address Assignment].) */
+    return tor_addr_compare_masked(addr, last_resolved_addr, 48,
                                    CMP_SEMANTIC) == 0;
     break;
   default:


### PR DESCRIPTION
Closes #33618

Signed-off-by: David Goulet <dgoulet@torproject.org>