### PR TITLE
Remove special authority semantics for AssumeReachable.

### DIFF
--- a/changes/ticket34445
+++ b/changes/ticket34445
@@ -1,0 +1,5 @@
+  o Minor features (directory authority):
+    - The AssumeReachable option no longer stops directory authorities
+      from checking whether other relays are running. A new
+      AuthDirTestReachability option can be used to disable these checks.
+      Closes ticket 34445.

--- a/doc/tor.1.txt
+++ b/doc/tor.1.txt
@@ -2143,9 +2143,7 @@ is non-zero):
 [[AssumeReachable]] **AssumeReachable** **0**|**1**::
     This option is used when bootstrapping a new Tor network. If set to 1,
     don't do self-reachability testing; just upload your server descriptor
-    immediately. If **AuthoritativeDirectory** is also set, this option
-    instructs the dirserver to bypass remote reachability testing too and list
-    all connected servers as running. (Default: 0)
+    immediately. (Default: 0)
 
 [[AssumeReachableIPv6]] **AssumeReachableIPv6** **0**|**1**|**auto**::
     Like **AssumeReachable**, but affects only the relay's own IPv6 ORPort.
@@ -3009,6 +3007,12 @@ on the public Tor network.
     regardless of their Ed25519 key. We should only ever set this option to 0
     if there is some major bug in Ed25519 link authentication that causes us
     to label all the relays as not Running.  (Default: 1)
+
+[[AuthDirTestReachability]] **AuthDirTestReachability** **0**|**1**::
+    Authoritative directories only. If set to 1, then we periodically
+    check every relay we know about to see whether it is running.
+    If set to 0, we vote Running for every relay, and don't perform
+    these tests. (Default: 1)
 
 [[BridgePassword]] **BridgePassword** __Password__::
     If set, contains an HTTP authenticator that tells a bridge authority to

--- a/src/feature/dirauth/dirauth_options.inc
+++ b/src/feature/dirauth/dirauth_options.inc
@@ -44,6 +44,13 @@ CONF_VAR(AuthDirSharedRandomness, BOOL, 0, "1")
 /* NOTE: remove this option someday. */
 CONF_VAR(AuthDirTestEd25519LinkKeys, BOOL, 0, "1")
 
+/**
+ * Bool (default 1): As an authority, should we launch tests for
+ * reachability, and use those results to vote on "Running"?  If 0,
+ * we assume that every relay is Runnning.
+ **/
+CONF_VAR(AuthDirTestReachability, BOOL, 0, "1")
+
 /** Authority only: key=value pairs that we add to our networkstatus
  * consensus vote on the 'params' line. */
 CONF_VAR(ConsensusParams, STRING, 0, NULL)

--- a/src/feature/dirauth/reachability.c
+++ b/src/feature/dirauth/reachability.c
@@ -105,6 +105,8 @@ dirserv_should_launch_reachability_test(const routerinfo_t *ri,
 {
   if (!authdir_mode_handles_descs(get_options(), ri->purpose))
     return 0;
+  if (! dirauth_get_options()->AuthDirTestReachability)
+    return 0;
   if (!ri_old) {
     /* New router: Launch an immediate reachability test, so we will have an
      * opinion soon in case we're generating a consensus soon */
@@ -189,6 +191,9 @@ dirserv_test_reachability(time_t now)
    * the testing, and directory authorities are easy to upgrade. Let's
    * wait til 0.2.0. -RD */
 //  time_t cutoff = now - ROUTER_MAX_AGE_TO_PUBLISH;
+  if (! dirauth_get_options()->AuthDirTestReachability)
+    return;
+
   routerlist_t *rl = router_get_routerlist();
   static char ctr = 0;
   int bridge_auth = authdir_mode_bridge(get_options());

--- a/src/feature/dirauth/voteflags.c
+++ b/src/feature/dirauth/voteflags.c
@@ -487,7 +487,6 @@ dirserv_set_router_is_running(routerinfo_t *router, time_t now)
     unreachable.
    */
   int answer;
-  const or_options_t *options = get_options();
   const dirauth_options_t *dirauth_options = dirauth_get_options();
   node_t *node = node_get_mutable_by_id(router->cache_info.identity_digest);
   tor_assert(node);
@@ -501,8 +500,9 @@ dirserv_set_router_is_running(routerinfo_t *router, time_t now)
     /* A hibernating router is down unless we (somehow) had contact with it
      * since it declared itself to be hibernating. */
     answer = 0;
-  } else if (options->AssumeReachable) {
-    /* If AssumeReachable, everybody is up unless they say they are down! */
+  } else if (! dirauth_options->AuthDirTestReachability) {
+    /* If we aren't testing reachability, then everybody is up unless they say
+     * they are down. */
     answer = 1;
   } else {
     /* Otherwise, a router counts as up if we found all announced OR


### PR DESCRIPTION
AssumeReachable should only be about whether a relay thinks that it
is reachable itself.  But previously, we've had it also turn off
reachability checking of _other_ relays on authorities.
(Technically, reachability tests were still run, but we would ignore
the results.)

With this patch, there is a new AuthDirTestReachability option
(default 1) that controls whether authorities run reachability
tests.

Making this change allows us to have test networks where authorities
set AssumeReachable without disabling their reachability testing
entirely.

Closes ticket #34445.