### PR TITLE
[Tor GitLab #40015]: Tor triggers assert when run with "--key-expiration sign" but no ORPort

### DIFF
--- a/changes/bug40015
+++ b/changes/bug40015
@@ -1,0 +1,4 @@
+  o Major bugfixes (crash, relay, signing key):
+    - Avoid asserts when we run Tor from the command line with
+      `--key-expiration sign` when an ORPort is not set. Fixes
+      bug 40015; bugfix on 0.3.2.1-alpha. Patch by Neel Chauhan.

--- a/src/feature/relay/routermode.c
+++ b/src/feature/relay/routermode.c
@@ -34,6 +34,7 @@ MOCK_IMPL(int,
 server_mode,(const or_options_t *options))
 {
   if (options->ClientOnly) return 0;
+  if (options->command == CMD_KEY_EXPIRATION) return 1;
   return (options->ORPort_set);
 }
 


### PR DESCRIPTION
Ticket: https://gitlab.torproject.org/tpo/core/tor/-/issues/40015