### PR TITLE
Refactor reachability test logging: log exactly what we launch.

### DIFF
--- a/changes/ticket34137
+++ b/changes/ticket34137
@@ -1,0 +1,5 @@
+  o Minor features (relay):
+    - Log immediately when launching a relay self-check.  Previously
+      we would try to log before launching checks, or approximately
+      when we intended to launch checks, but this tended to be
+      error-prone.  Closes ticket 34137.

--- a/src/core/or/circuitbuild.c
+++ b/src/core/or/circuitbuild.c
@@ -1056,7 +1056,6 @@ circuit_build_no_more_hops(origin_circuit_t *circ)
     clear_broken_connection_map(1);
     if (server_mode(options) &&
         !router_all_orports_seem_reachable(options)) {
-      inform_testing_reachability();
       router_do_reachability_checks(1, 1);
     }
   }

--- a/src/feature/relay/relay_config.c
+++ b/src/feature/relay/relay_config.c
@@ -1114,8 +1114,6 @@ options_act_relay(const or_options_t *old_options)
 
       if (server_mode_turned_on) {
         ip_address_changed(0);
-        if (have_completed_a_circuit() || !any_predicted_circuits(time(NULL)))
-          inform_testing_reachability();
       }
       cpuworkers_rotate_keyinfo();
     }

--- a/src/feature/relay/selftest.h
+++ b/src/feature/relay/selftest.h
@@ -25,7 +25,6 @@ int router_dirport_seems_reachable(
 
 void router_do_reachability_checks(int test_or, int test_dir);
 void router_perform_bandwidth_test(int num_circs, time_t now);
-int inform_testing_reachability(void);
 
 void router_orport_found_reachable(int family);
 void router_dirport_found_reachable(void);


### PR DESCRIPTION
Previously we had two chains of logic for reachability tests: one
for launching them, and one for telling the user that we had
launched them.  Now, we simply have the launch code inform the user:
this way, we can't get out of sync.

Closes ticket 34137.