### PR TITLE
Downgrade "Bug: No entry found in extrainfo map" message.

### DIFF
--- a/changes/bug16016
+++ b/changes/bug16016
@@ -1,0 +1,4 @@
+  o Minor bugfixes (logging):
+    - Downgrade a noisy log message that could occur naturally when
+      receiving an extrainfo document that we no longer want.
+      Fixes bug 16016; bugfix on 0.2.6.3-alpha.

--- a/src/feature/nodelist/routerlist.c
+++ b/src/feature/nodelist/routerlist.c
@@ -1087,7 +1087,11 @@ extrainfo_insert,(routerlist_t *rl, extrainfo_t *ei, int warn_if_incompatible))
      * This just won't work. */;
     static ratelim_t no_sd_ratelim = RATELIM_INIT(1800);
     r = ROUTER_BAD_EI;
-    log_fn_ratelim(&no_sd_ratelim, severity, LD_BUG,
+    /* This is a DEBUG because it can happen naturally, if we tried
+     * to add an extrainfo for which we no longer have the
+     * corresponding routerinfo.
+     */
+    log_fn_ratelim(&no_sd_ratelim, LOG_DEBUG, LD_DIR,
                    "No entry found in extrainfo map.");
     goto done;
   }


### PR DESCRIPTION
This is not actually a bug!  It can happen for a bunch of reasons,
which all boil down to "trying to add an extrainfo for which we no
longer have the corresponding routerinfo".

Fixes #16016; bugfix on 0.2.6.3-alpha.