### PR TITLE
addr: Prioritize interface lookup over local hostname

### DIFF
--- a/changes/ticket33238
+++ b/changes/ticket33238
@@ -1,0 +1,5 @@
+  o Minor feature (address discovery):
+    - If no Address statements are found, relays now prioritize guessing their
+      address by looking at the local interface instead of the local hostname.
+      If the interface address can't be found, the local hostname is used.
+      Closes ticket 33238.

--- a/src/app/config/resolve_addr.c
+++ b/src/app/config/resolve_addr.c
@@ -445,8 +445,8 @@ static fn_address_ret_t
 {
   /* These functions are in order for our find address algorithm. */
   get_address_from_config,
-  get_address_from_hostname,
   get_address_from_interface,
+  get_address_from_hostname,
 };
 /** Length of address table as in how many functions. */
 static const size_t fn_address_table_len = ARRAY_LENGTH(fn_address_table);
@@ -478,7 +478,17 @@ static const size_t fn_address_table_len = ARRAY_LENGTH(fn_address_table);
  *
  *     If no given Address, fallback to the local hostname (see section 2).
  *
- *  2. Look at the local hostname.
+ *  2. Look at the network interface.
+ *
+ *     Attempt to find the first public usable address from the list of
+ *     network interface returned by the OS.
+ *
+ *     On failure, we attempt to look at the local hostname (3).
+ *
+ *     On success, addr_out is set with it, method_out is set to "INTERFACE"
+ *     and hostname_out is set to NULL.
+ *
+ *  3. Look at the local hostname.
  *
  *     If the local hostname resolves to a non internal address, addr_out is
  *     set with it, method_out is set to "GETHOSTNAME" and hostname_out is set
@@ -489,20 +499,7 @@ static const size_t fn_address_table_len = ARRAY_LENGTH(fn_address_table);
  *     If the local hostname resolves to an internal address, an error is
  *     returned.
  *
- *     If the local hostname can NOT be resolved, fallback to the network
- *     interface (see section 3).
- *
- *  3. Look at the network interface.
- *
- *     Attempt to find the first public usable address from the list of
- *     network interface returned by the OS.
- *
- *     On failure, an error is returned. This error indicates that all
- *     attempts have failed and thus the address for the given family can not
- *     be found.
- *
- *     On success, addr_out is set with it, method_out is set to "INTERFACE"
- *     and hostname_out is set to NULL.
+ *     If the local hostname can NOT be resolved, an error is returned.
  *
  * @param options Global configuration options.
  * @param family IP address family. Only AF_INET and AF_INET6 are supported.

--- a/src/test/test_config.c
+++ b/src/test/test_config.c
@@ -6404,36 +6404,6 @@ test_config_getinfo_config_names(void *arg)
   tor_free(answer);
 }
 
-static int IPv4 = 1;
-static int IPv6 = 2;
-
-/** Setup function for the find_my_address() test. Return parameters for the
- * test are based on the passed string as setup data. */
-static void *
-find_my_addr_setup_fn(const struct testcase_t *tc)
-{
-  if (*(int *) tc->setup_data == IPv4) {
-    return &addr_param_v4;
-  }
-  if (*(int *) tc->setup_data == IPv6) {
-    return &addr_param_v6;
-  }
-  return NULL;
-}
-
-/** Cleanup function for the find_my_address() test. */
-static int
-find_my_addr_cleanup_fn(const struct testcase_t *tc, void *arg)
-{
-  (void) tc;
-  (void) arg;
-  return 1;
-}
-
-static struct testcase_setup_t test_find_my_addr_setup = {
-  find_my_addr_setup_fn, find_my_addr_cleanup_fn,
-};
-
 #define CONFIG_TEST(name, flags)                          \
   { #name, test_config_ ## name, flags, NULL, NULL }
 
@@ -6451,9 +6421,9 @@ struct testcase_t config_tests[] = {
   CONFIG_TEST(default_dir_servers, TT_FORK),
   CONFIG_TEST(default_fallback_dirs, 0),
   CONFIG_TEST_SETUP(_v4, find_my_address, TT_FORK,
-                    &test_find_my_addr_setup, &IPv4),
+                    &passthrough_setup, &addr_param_v4),
   CONFIG_TEST_SETUP(_v6, find_my_address, TT_FORK,
-                    &test_find_my_addr_setup, &IPv6),
+                    &passthrough_setup, &addr_param_v6),
   CONFIG_TEST(find_my_address_mixed, TT_FORK),
   CONFIG_TEST(addressmap, 0),
   CONFIG_TEST(parse_bridge_line, 0),

--- a/src/test/test_config.c
+++ b/src/test/test_config.c
@@ -1404,7 +1404,14 @@ test_config_find_my_address_mixed(void *arg)
  * AF_INET6 but we have one interface to do so thus we run the same exact unit
  * tests for both without copying them. */
 typedef struct find_my_address_params_t {
-  /* Index where the mock function results are located. */
+  /* Index where the mock function results are located. For intance,
+   * tor_addr_lookup_01010101() will have its returned value depending on the
+   * family in ret_addr_lookup_01010101[].
+   *
+   * Values that can be found:
+   *    AF_INET : index 0.
+   *    AF_INET6: index 1.
+   */
   int idx;
   int family;
   const char *public_ip;

--- a/src/test/test_config.c
+++ b/src/test/test_config.c
@@ -1449,7 +1449,7 @@ test_config_find_my_address(void *arg)
 
   /*
    * Case 1:
-   *    1. Address is a valid IPv4.
+   *    1. Address is a valid address.
    *
    * Expected to succeed.
    */
@@ -1463,7 +1463,7 @@ test_config_find_my_address(void *arg)
   CLEANUP_FOUND_ADDRESS;
 
   /*
-   * Case 2: Address is a resolvable IPv4. Expected to succeed.
+   * Case 2: Address is a resolvable address. Expected to succeed.
    */
   MOCK(tor_addr_lookup, tor_addr_lookup_01010101);
 
@@ -1482,7 +1482,7 @@ test_config_find_my_address(void *arg)
   UNMOCK(tor_addr_lookup);
 
   /*
-   * Case 3: Address is a local IPv4. Expected to fail.
+   * Case 3: Address is a local addressi (internal). Expected to fail.
    */
   config_line_append(&options->Address, "Address", p->internal_ip);
 
@@ -1500,7 +1500,7 @@ test_config_find_my_address(void *arg)
   CLEANUP_FOUND_ADDRESS;
 
   /*
-   * Case 4: Address is a local IPv4 but custom authorities. Expected to
+   * Case 4: Address is a local address but custom authorities. Expected to
    * succeed.
    */
   config_line_append(&options->Address, "Address", p->internal_ip);
@@ -1514,7 +1514,7 @@ test_config_find_my_address(void *arg)
   CLEANUP_FOUND_ADDRESS;
 
   /*
-   * Case 5: Multiple IPv4 Address. Expected to fail.
+   * Case 5: Multiple address in Address. Expected to fail.
    */
   config_line_append(&options->Address, "Address", p->public_ip);
   config_line_append(&options->Address, "Address", p->public_ip);
@@ -1576,7 +1576,7 @@ test_config_find_my_address(void *arg)
   /*
    * Case 8:
    *    1. Address is NULL
-   *    2. Interface address is a valid IPv4.
+   *    2. Interface address is a valid address.
    *
    * Expected to succeed.
    */
@@ -1600,7 +1600,7 @@ test_config_find_my_address(void *arg)
    * Case 9:
    *    1. Address is NULL
    *    2. Interface address fails to be found.
-   *    3. Local hostname resolves to a valid IPv4.
+   *    3. Local hostname resolves to a valid address.
    *
    * Expected to succeed.
    */
@@ -1635,7 +1635,7 @@ test_config_find_my_address(void *arg)
    * Case 10:
    *    1. Address is NULL
    *    2. Interface address fails to be found.
-   *    3. Local hostname resolves to an internal IPv4.
+   *    3. Local hostname resolves to an internal address.
    *
    * Expected to fail.
    */


### PR DESCRIPTION
The find_my_address() function now prioritize the local interface over the
local hostname when guessing the IP address.

See proposal 312, section 3.2.1, general case:
https://gitweb.torproject.org/torspec.git/tree/proposals/312-relay-auto-ipv6-addr.txt#n359

The entire unit tests had to be refactored to make this possible. Instead of
hot patching it, it has been rewritten to cover all possible cases and the
test interface has been changed to accomodate both IPv4 and IPv6 in order for
them to be tested identically.

Closes #33238

Signed-off-by: David Goulet <dgoulet@torproject.org>