### PR TITLE
addr: Attempt to learn our address with ORPort

### DIFF
--- a/changes/ticket33236
+++ b/changes/ticket33236
@@ -1,0 +1,4 @@
+  o Minor feature (relay, address discovery):
+    - If Address is not found in torrc, attempt to learn our address with the
+      configured ORPort address if any. Closes ticket 33236.
+

--- a/src/app/config/resolve_addr.h
+++ b/src/app/config/resolve_addr.h
@@ -9,7 +9,13 @@
 #ifndef TOR_CONFIG_RESOLVE_ADDR_H
 #define TOR_CONFIG_RESOLVE_ADDR_H
 
+#include "app/config/config.h"
+#include "core/mainloop/connection.h"
+
 #include "app/config/or_options_st.h"
+
+#define get_orport_addr(family) \
+  (get_first_advertised_addr_by_type_af(CONN_TYPE_OR_LISTENER, family))
 
 bool find_my_address(const or_options_t *options, int family,
                      int warn_severity, tor_addr_t *addr_out,


### PR DESCRIPTION
If no Address statement are found in the configuration file, attempt to learn
our address by looking at the ORPort address if any. Specifying an address is
optional so if we can't find one, it is fine, we move on to the next discovery
mechanism.

Note that specifying a hostname on the ORPort is not yet supported at this
commit.

Closes #33236

Signed-off-by: David Goulet <dgoulet@torproject.org>