### PR TITLE
CI: Fix Appveyor printf format error

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -87,7 +87,7 @@ build_script:
              # mingw zstd doesn't come with a pkg-config file, so we manually
              # configure its flags. liblzma just works.
              #>
-            Execute-Bash "ZSTD_CFLAGS='-L/${env:compiler_path}/include' ZSTD_LIBS='-L/${env:compiler_path}/lib -lzstd' ../configure --prefix=/${env:compiler_path} --build=${env:target} --host=${env:target} --with-openssl-dir=/${env:compiler_path} --disable-asciidoc --enable-fatal-warnings ${env:hardening}"
+            Execute-Bash "ZSTD_CFLAGS='-L/${env:compiler_path}/include' ZSTD_LIBS='-L/${env:compiler_path}/lib -lzstd' ../configure --prefix=/${env:compiler_path} --build=${env:target} --host=${env:target} --with-openssl-dir=/${env:compiler_path} --disable-asciidoc --enable-fatal-warnings ${env:hardening} CFLAGS='-D__USE_MINGW_ANSI_STDIO=0'"
             Execute-Bash "V=1 make -k -j2"
             Execute-Bash "V=1 make -k -j2 install"
      }

--- a/changes/ticket40026
+++ b/changes/ticket40026
@@ -1,0 +1,3 @@
+  o Minor bugfix (CI, Windows):
+    - Don't use stdio 64 bit printf format when compiling with MINGW on
+      Appveyor. Fixes bug 40026; bugfix on 0.3.5.5-alpha.


### PR DESCRIPTION
For some reasons, Appveyor started to use the stdio printf format for 64 bit
values (PRIu64, ...). Mingw doesn't like that so force it to use the Windows
specific macros by setting D__USE_MINGW_ANSI_STDIO=0.

Fixes #40026