### PR TITLE
Revert "config: Make clients tell dual-stack exits they prefer IPv6"

### DIFF
--- a/changes/ticket33796
+++ b/changes/ticket33796
@@ -1,0 +1,7 @@
+  o Removed features (IPv6, revert):
+    - Revert the client port prefer IPv6 feature because it breaks the
+      torsocks use case. The SOCKS resolve command is lacking a mechanism to
+      ask for a specific address family (v4 or v6) thus prioritizing IPv6 when
+      an IPv4 address is asked on the resolve SOCKS interface resulting in a
+      failure. Tor Browser explicitly set PreferIPv6 so this should not affect
+      the majority of our users. Closes ticket 33796; bugfix on 0.4.4.1-alpha.

--- a/doc/tor.1.txt
+++ b/doc/tor.1.txt
@@ -1492,16 +1492,14 @@ The following options are useful only for clients (that is, if
     Other recognized __flags__ for a SocksPort are:
     **NoIPv4Traffic**;;
         Tell exits to not connect to IPv4 addresses in response to SOCKS
-        requests on this connection. (Allowing IPv4 is the default.)
-    **NoIPv6Traffic**;;
-        Tell exits to not connect to IPv6 addresses in response to SOCKS
-        requests on this connection. This option is only relevant when SOCKS5
-        is in use, because SOCKS4 can't handle IPv6.  (Allowing IPv6 is the
-        default.)
-    **NoPreferIPv6**;;
+        requests on this connection.
+    **IPv6Traffic**;;
+        Tell exits to allow IPv6 addresses in response to SOCKS requests on
+        this connection, so long as SOCKS5 is in use.  (SOCKS4 can't handle
+        IPv6.)
+    **PreferIPv6**;;
         Tells exits that, if a host has both an IPv4 and an IPv6 address,
-        we would prefer to connect to it via IPv4. (IPv6 is the default in
-        recent versions of Tor.)
+        we would prefer to connect to it via IPv6. (IPv4 is the default.)
     **NoDNSRequest**;;
         Do not ask exits to resolve DNS addresses in SOCKS5 requests. Tor will
         connect to IPv4 addresses, IPv6 addresses (if IPv6Traffic is set) and

--- a/src/app/config/config.c
+++ b/src/app/config/config.c
@@ -5610,7 +5610,7 @@ port_cfg_new(size_t namelen)
   /* entry_cfg flags */
   cfg->entry_cfg.ipv4_traffic = 1;
   cfg->entry_cfg.ipv6_traffic = 1;
-  cfg->entry_cfg.prefer_ipv6 = 1;
+  cfg->entry_cfg.prefer_ipv6 = 0;
   cfg->entry_cfg.dns_request = 1;
   cfg->entry_cfg.onion_traffic = 1;
   cfg->entry_cfg.prefer_ipv6_virtaddr = 1;

--- a/src/test/test_config.c
+++ b/src/test/test_config.c
@@ -4160,8 +4160,6 @@ test_config_parse_port_config__ports__ports_given(void *data)
   /* Test entry port defaults as initialised in port_parse_config */
   tt_int_op(port_cfg->entry_cfg.dns_request, OP_EQ, 1);
   tt_int_op(port_cfg->entry_cfg.ipv4_traffic, OP_EQ, 1);
-  tt_int_op(port_cfg->entry_cfg.ipv6_traffic, OP_EQ, 1);
-  tt_int_op(port_cfg->entry_cfg.prefer_ipv6, OP_EQ, 1);
   tt_int_op(port_cfg->entry_cfg.onion_traffic, OP_EQ, 1);
   tt_int_op(port_cfg->entry_cfg.cache_ipv4_answers, OP_EQ, 0);
   tt_int_op(port_cfg->entry_cfg.prefer_ipv6_virtaddr, OP_EQ, 1);


### PR DESCRIPTION
This reverts commit bf2a399fc0d90df76e091fa3259f7c1b8fb87781.