### PR TITLE
Resolve a compiler warning from a 32-bit signed/unsigned comparison

### DIFF
--- a/changes/bug40028
+++ b/changes/bug40028
@@ -1,0 +1,3 @@
+  o Minor bugfixes (compiler warnings):
+    - Fix a compiler warning on platforms with 32-bit time_t values.
+      Fixes bug 40028; bugfix on 0.3.2.8-rc.

--- a/src/lib/tls/x509.c
+++ b/src/lib/tls/x509.c
@@ -23,6 +23,7 @@ tor_tls_pick_certificate_lifetime(time_t now,
                                   time_t *start_time_out,
                                   time_t *end_time_out)
 {
+  tor_assert(cert_lifetime < INT_MAX);
   time_t start_time, end_time;
   /* Make sure we're part-way through the certificate lifetime, rather
    * than having it start right now. Don't choose quite uniformly, since
@@ -36,7 +37,7 @@ tor_tls_pick_certificate_lifetime(time_t now,
   const time_t start_granularity = 24*3600;
   time_t earliest_start_time;
   /* Don't actually start in the future! */
-  if (cert_lifetime <= min_real_lifetime + start_granularity) {
+  if ((int)cert_lifetime <= min_real_lifetime + start_granularity) {
     earliest_start_time = now - 1;
   } else {
     earliest_start_time = now + min_real_lifetime + start_granularity


### PR DESCRIPTION
This warning only affects platforms (like win32) with 32-bit time_t.

Fixes bug 40028; bugfix on 0.3.2.8-rc.