### PR TITLE
Strip '\r' characters when reading text files on Unix.

### DIFF
--- a/changes/bug33781
+++ b/changes/bug33781
@@ -1,0 +1,7 @@
+  o Minor bugfixes (compatibility):
+    - Strip '\r' characters when reading text files on Unix platforms.
+      This should resolve an issue where a relay operator migrates a relay from
+      Windows to Unix, but does not change the line ending of Tor's various state
+      files to match the platform, the CRLF line endings from Windows ends up leaking
+      into other files such as the extra-info document. Fixes bug 33781; bugfix on
+      0.0.9pre5.

--- a/src/lib/fs/files.c
+++ b/src/lib/fs/files.c
@@ -685,7 +685,6 @@ read_file_to_str, (const char *filename, int flags, struct stat *stat_out))
   }
   string[r] = '\0'; /* NUL-terminate the result. */
 
-#if defined(_WIN32) || defined(__CYGWIN__)
   if (!bin && strchr(string, '\r')) {
     log_debug(LD_FS, "We didn't convert CRLF to LF as well as we hoped "
               "when reading %s. Coping.",
@@ -695,8 +694,7 @@ read_file_to_str, (const char *filename, int flags, struct stat *stat_out))
   }
   if (!bin) {
     statbuf.st_size = (size_t) r;
-  } else
-#endif /* defined(_WIN32) || defined(__CYGWIN__) */
+  } else {
     if (r != statbuf.st_size) {
       /* Unless we're using text mode on win32, we'd better have an exact
        * match for size. */
@@ -708,6 +706,7 @@ read_file_to_str, (const char *filename, int flags, struct stat *stat_out))
       errno = save_errno;
       return NULL;
     }
+  }
   close(fd);
   if (stat_out) {
     memcpy(stat_out, &statbuf, sizeof(struct stat));


### PR DESCRIPTION
This patch ensures that we strip "\r" characters on both Windows as well
as Unix when we read text files. This should prevent the issue where
some Tor state files have been moved from a Windows machine, and thus
contains CRLF line ending, to a Unix machine where only \n is needed.

We add a test-case to ensure that we handle this properly on all our
platforms.

See: https://bugs.torproject.org/tpo/core/tor/33781