### PR TITLE
[GitLab #32190]: Send a control port event when a stream enters the controller_wait state

### DIFF
--- a/changes/ticket32190
+++ b/changes/ticket32190
@@ -1,0 +1,4 @@
+  o Minor features (control port):
+    - When a stream enters the AP_CONN_STATE_CONTROLLER_WAIT status,
+      send a control port event CONTROLLER_WAIT. Closes ticket 32190.
+      Patch by Neel Chauhan.

--- a/src/core/or/connection_edge.c
+++ b/src/core/or/connection_edge.c
@@ -1511,7 +1511,7 @@ connection_entry_set_controller_wait(entry_connection_t *conn)
 {
   CONNECTION_AP_EXPECT_NONPENDING(conn);
   ENTRY_TO_CONN(conn)->state = AP_CONN_STATE_CONTROLLER_WAIT;
-  control_event_enter_controller_wait();
+  control_event_stream_status(conn, STREAM_EVENT_CONTROLLER_WAIT, 0);
 }
 
 /** The AP connection <b>conn</b> has just failed while attaching or

--- a/src/core/or/connection_edge.h
+++ b/src/core/or/connection_edge.h
@@ -94,6 +94,8 @@ int connection_edge_flushed_some(edge_connection_t *conn);
 int connection_edge_finished_flushing(edge_connection_t *conn);
 int connection_edge_finished_connecting(edge_connection_t *conn);
 
+void connection_entry_set_controller_wait(entry_connection_t *conn);
+
 void connection_ap_about_to_close(entry_connection_t *edge_conn);
 void connection_exit_about_to_close(edge_connection_t *edge_conn);
 

--- a/src/feature/control/control_cmd.c
+++ b/src/feature/control/control_cmd.c
@@ -982,8 +982,7 @@ handle_control_attachstream(control_connection_t *conn,
     edge_conn->end_reason = 0;
     if (tmpcirc)
       circuit_detach_stream(tmpcirc, edge_conn);
-    CONNECTION_AP_EXPECT_NONPENDING(ap_conn);
-    TO_CONN(edge_conn)->state = AP_CONN_STATE_CONTROLLER_WAIT;
+    connection_entry_set_controller_wait(ap_conn);
   }
 
   if (circ && (circ->base_.state != CIRCUIT_STATE_OPEN)) {

--- a/src/feature/control/control_events.c
+++ b/src/feature/control/control_events.c
@@ -109,6 +109,7 @@ const struct control_event_t control_event_table[] = {
   { EVENT_HS_DESC, "HS_DESC" },
   { EVENT_HS_DESC_CONTENT, "HS_DESC_CONTENT" },
   { EVENT_NETWORK_LIVENESS, "NETWORK_LIVENESS" },
+  { EVENT_CONTROLLER_WAIT, "CONTROLLER_WAIT" },
   { 0, NULL },
 };
 
@@ -2361,6 +2362,15 @@ control_events_free_all(void)
   }
   global_event_mask = 0;
   disable_log_messages = 0;
+}
+
+/** Our own router descriptor has changed; tell any controllers that care.
+ */
+int
+control_event_enter_controller_wait(void)
+{
+  send_control_event(EVENT_CONTROLLER_WAIT, "650 CONTROLLER_WAIT\r\n");
+  return 0;
 }
 
 #ifdef TOR_UNIT_TESTS

--- a/src/feature/control/control_events.c
+++ b/src/feature/control/control_events.c
@@ -819,6 +819,7 @@ control_event_stream_status(entry_connection_t *conn, stream_status_event_t tp,
     case STREAM_EVENT_NEW_RESOLVE: status = "NEWRESOLVE"; break;
     case STREAM_EVENT_FAILED_RETRIABLE: status = "DETACHED"; break;
     case STREAM_EVENT_REMAP: status = "REMAP"; break;
+    case STREAM_EVENT_CONTROLLER_WAIT: status = "CONTROLLER_WAIT"; break;
     default:
       log_warn(LD_BUG, "Unrecognized status code %d", (int)tp);
       return 0;
@@ -2362,15 +2363,6 @@ control_events_free_all(void)
   }
   global_event_mask = 0;
   disable_log_messages = 0;
-}
-
-/** Our own router descriptor has changed; tell any controllers that care.
- */
-int
-control_event_enter_controller_wait(void)
-{
-  send_control_event(EVENT_CONTROLLER_WAIT, "650 CONTROLLER_WAIT\r\n");
-  return 0;
 }
 
 #ifdef TOR_UNIT_TESTS

--- a/src/feature/control/control_events.h
+++ b/src/feature/control/control_events.h
@@ -36,7 +36,8 @@ typedef enum stream_status_event_t {
   STREAM_EVENT_NEW          = 5,
   STREAM_EVENT_NEW_RESOLVE  = 6,
   STREAM_EVENT_FAILED_RETRIABLE = 7,
-  STREAM_EVENT_REMAP        = 8
+  STREAM_EVENT_REMAP        = 8,
+  STREAM_EVENT_CONTROLLER_WAIT = 9
 } stream_status_event_t;
 
 /** Used to indicate the type of a buildtime event */

--- a/src/feature/control/control_events.h
+++ b/src/feature/control/control_events.h
@@ -226,6 +226,8 @@ void control_event_hs_descriptor_content(const char *onion_address,
 void cbt_control_event_buildtimeout_set(const circuit_build_times_t *cbt,
                                         buildtimeout_set_event_t type);
 
+int control_event_enter_controller_wait(void);
+
 void control_events_free_all(void);
 
 #ifdef CONTROL_MODULE_PRIVATE
@@ -284,7 +286,8 @@ typedef uint64_t event_mask_t;
 #define EVENT_NETWORK_LIVENESS        0x0023
 #define EVENT_PT_LOG                  0x0024
 #define EVENT_PT_STATUS               0x0025
-#define EVENT_MAX_                    0x0025
+#define EVENT_CONTROLLER_WAIT         0x0026
+#define EVENT_MAX_                    0x0026
 
 /* sizeof(control_connection_t.event_mask) in bits, currently a uint64_t */
 #define EVENT_CAPACITY_               0x0040


### PR DESCRIPTION
Ticket: https://gitlab.torproject.org/tpo/core/tor/-/issues/32190