### PR TITLE
[GitLab #40029]: Remove duplicate #include control_events.h in control_cmd.c

### DIFF
--- a/src/feature/control/control_cmd.c
+++ b/src/feature/control/control_cmd.c
@@ -25,7 +25,6 @@
 #include "feature/client/addressmap.h"
 #include "feature/client/dnsserv.h"
 #include "feature/client/entrynodes.h"
-#include "feature/control/control_events.h"
 #include "feature/control/control.h"
 #include "feature/control/control_auth.h"
 #include "feature/control/control_cmd.h"


### PR DESCRIPTION
Ticket: https://gitlab.torproject.org/tpo/core/tor/-/issues/40029