### PR TITLE
hs-v3: Remove a possible BUG() condition

### DIFF
--- a/changes/ticket34087
+++ b/changes/ticket34087
@@ -1,0 +1,3 @@
+  o Minor bugfix (onion service v3 client):
+    - Remove a BUG() warning that can occur naturally. Fixes bug 34087; bugfix
+      on 0.3.2.1-alpha.

--- a/src/feature/hs/hs_client.c
+++ b/src/feature/hs/hs_client.c
@@ -1065,8 +1065,10 @@ close_or_reextend_intro_circ(origin_circuit_t *intro_circ)
   tor_assert(intro_circ);
 
   desc = hs_cache_lookup_as_client(&intro_circ->hs_ident->identity_pk);
-  if (BUG(desc == NULL)) {
-    /* We can't continue without a descriptor. */
+  if (desc == NULL) {
+    /* We can't continue without a descriptor. This is possible if the cache
+     * was cleaned up between the intro point established and the reception of
+     * the introduce ack. */
     goto close;
   }
   /* We still have the descriptor, great! Let's try to see if we can


### PR DESCRIPTION
When receiving an introduction NACK, the client either decides to close or
re-extend the circuit to another intro point.

In order to do this, the service descriptor needs to exists but it is possible
that it gets removed from the cache between the establishement of the
introduction circuit and the reception of the (N)ACK.

For that reason, the BUG(desc == NULL) is removed because it is a possible
normal use case. Tor recovers gracefully already.

Fixes #34087

Signed-off-by: David Goulet <dgoulet@torproject.org>