### PR TITLE
addr: Remove a BUG() that can normally occur

### DIFF
--- a/src/feature/relay/relay_find_addr.c
+++ b/src/feature/relay/relay_find_addr.c
@@ -64,8 +64,9 @@ relay_address_new_suggestion(const tor_addr_t *suggested_addr,
   tor_assert(peer_addr);
   tor_assert(identity_digest);
 
-  /* This should never be called on a non Tor relay. */
-  if (BUG(!server_mode(options))) {
+  /* Non server should just ignore this suggestion. Clients don't need to
+   * learn their address let alone cache it. */
+  if (!server_mode(options)) {
     return;
   }
 


### PR DESCRIPTION
Fix on unreleased code.

The relay_new_address_suggestion() is called when a NETINFO cell is received
thus not only for relay or bridges.

Remove the BUG() that made sure only in server mode we could handle the
suggested address.

Fixes #40032

Signed-off-by: David Goulet <dgoulet@torproject.org>