### PR TITLE
addr: Use tor_addr_t instead of uint32_t for IPv4

### DIFF
--- a/changes/ticket40043
+++ b/changes/ticket40043
@@ -1,0 +1,5 @@
+  o Code simplification and refactoring (relay address):
+    - Most of IPv4 representation was using "uint32_t". It has now been moved to
+      use the internal "tor_addr_t" interface instead. This is so we can
+      properly integrate IPv6 along IPv4 with common interfaces. Closes ticket
+      40043.

--- a/src/core/or/channeltls.c
+++ b/src/core/or/channeltls.c
@@ -1863,7 +1863,7 @@ channel_tls_process_netinfo_cell(cell_t *cell, channel_tls_t *chan)
 
   if (my_addr_type == NETINFO_ADDR_TYPE_IPV4 && my_addr_len == 4) {
     if (!get_options()->BridgeRelay && me &&
-        tor_addr_eq_ipv4h(&my_apparent_addr, me->addr)) {
+        tor_addr_eq(&my_apparent_addr, &me->ipv4_addr)) {
       TLS_CHAN_TO_BASE(chan)->is_canonical_to_peer = 1;
     }
   } else if (my_addr_type == NETINFO_ADDR_TYPE_IPV6 &&
@@ -1917,7 +1917,7 @@ channel_tls_process_netinfo_cell(cell_t *cell, channel_tls_t *chan)
              safe_str(hex_str(identity_digest, DIGEST_LEN)),
              safe_str(tor_addr_is_null(&my_apparent_addr) ?
              "<none>" : fmt_and_decorate_addr(&my_apparent_addr)),
-             safe_str(fmt_addr32(me->addr)));
+             safe_str(fmt_addr(&me->ipv4_addr)));
   }
 
   /* Act on apparent skew. */

--- a/src/core/or/connection_or.c
+++ b/src/core/or/connection_or.c
@@ -2507,14 +2507,11 @@ connection_or_send_netinfo,(or_connection_t *conn))
    * is an outgoing connection, act like a normal client and omit it. */
   if ((public_server_mode(get_options()) || !conn->is_outgoing) &&
       (me = router_get_my_routerinfo())) {
-    tor_addr_t my_addr;
-    tor_addr_from_ipv4h(&my_addr, me->addr);
-
     uint8_t n_my_addrs = 1 + !tor_addr_is_null(&me->ipv6_addr);
     netinfo_cell_set_n_my_addrs(netinfo_cell, n_my_addrs);
 
     netinfo_cell_add_my_addrs(netinfo_cell,
-                              netinfo_addr_from_tor_addr(&my_addr));
+                              netinfo_addr_from_tor_addr(&me->ipv4_addr));
 
     if (!tor_addr_is_null(&me->ipv6_addr)) {
       netinfo_cell_add_my_addrs(netinfo_cell,

--- a/src/core/or/policies.h
+++ b/src/core/or/policies.h
@@ -102,9 +102,9 @@ void fascist_firewall_choose_address_dir_server(const dir_server_t *ds,
 
 int dir_policy_permits_address(const tor_addr_t *addr);
 int socks_policy_permits_address(const tor_addr_t *addr);
-int authdir_policy_permits_address(uint32_t addr, uint16_t port);
-int authdir_policy_valid_address(uint32_t addr, uint16_t port);
-int authdir_policy_badexit_address(uint32_t addr, uint16_t port);
+int authdir_policy_permits_address(const tor_addr_t *addr, uint16_t port);
+int authdir_policy_valid_address(const tor_addr_t *addr, uint16_t port);
+int authdir_policy_badexit_address(const tor_addr_t *addr, uint16_t port);
 
 int validate_addr_policies(const or_options_t *options, char **msg);
 void policy_expand_private(smartlist_t **policy);
@@ -120,7 +120,7 @@ addr_policy_result_t compare_tor_addr_to_node_policy(const tor_addr_t *addr,
 
 int policies_parse_exit_policy_from_options(
                                           const or_options_t *or_options,
-                                          uint32_t local_address,
+                                          const tor_addr_t *ipv4_local_address,
                                           const tor_addr_t *ipv6_local_address,
                                           smartlist_t **result);
 struct config_line_t;

--- a/src/feature/dirauth/dirvote.c
+++ b/src/feature/dirauth/dirvote.c
@@ -225,7 +225,6 @@ format_networkstatus_vote(crypto_pk_t *private_signing_key,
   smartlist_t *chunks = smartlist_new();
   char fingerprint[FINGERPRINT_LEN+1];
   char digest[DIGEST_LEN];
-  uint32_t addr;
   char *protocols_lines = NULL;
   char *client_versions_line = NULL, *server_versions_line = NULL;
   char *shared_random_vote_str = NULL;
@@ -236,8 +235,6 @@ format_networkstatus_vote(crypto_pk_t *private_signing_key,
   tor_assert(v3_ns->type == NS_TYPE_VOTE || v3_ns->type == NS_TYPE_OPINION);
 
   voter = smartlist_get(v3_ns->voters, 0);
-
-  addr = voter->addr;
 
   base16_encode(fingerprint, sizeof(fingerprint),
                 v3_ns->cert->cache_info.identity_digest, DIGEST_LEN);
@@ -322,7 +319,7 @@ format_networkstatus_vote(crypto_pk_t *private_signing_key,
       tor_free(digest_algo_b64_digest_bw_file);
     }
 
-    const char *ip_str = fmt_addr32(addr);
+    const char *ip_str = fmt_addr(&voter->ipv4_addr);
 
     if (ip_str[0]) {
       smartlist_add_asprintf(chunks,
@@ -358,7 +355,7 @@ format_networkstatus_vote(crypto_pk_t *private_signing_key,
                    bw_headers_line ? bw_headers_line : "",
                    bw_file_digest ? bw_file_digest: "",
                    voter->nickname, fingerprint, voter->address,
-                   ip_str, voter->dir_port, voter->or_port,
+                   ip_str, voter->ipv4_dirport, voter->ipv4_orport,
                    voter->contact,
                    shared_random_vote_str ?
                              shared_random_vote_str : "");
@@ -636,9 +633,12 @@ compare_vote_rs(const vote_routerstatus_t *a, const vote_routerstatus_t *b)
   if ((r = strcmp(b->status.nickname, a->status.nickname)))
     return r;
 
-  CMP_FIELD(unsigned, int, addr);
-  CMP_FIELD(unsigned, int, or_port);
-  CMP_FIELD(unsigned, int, dir_port);
+  if ((r = tor_addr_compare(&a->status.ipv4_addr, &b->status.ipv4_addr,
+                            CMP_EXACT))) {
+    return r;
+  }
+  CMP_FIELD(unsigned, int, ipv4_orport);
+  CMP_FIELD(unsigned, int, ipv4_dirport);
 
   return 0;
 }
@@ -1740,9 +1740,9 @@ networkstatus_compute_consensus(smartlist_t *votes,
       smartlist_add_asprintf(chunks,
                    "dir-source %s%s %s %s %s %d %d\n",
                    voter->nickname, e->is_legacy ? "-legacy" : "",
-                   fingerprint, voter->address, fmt_addr32(voter->addr),
-                   voter->dir_port,
-                   voter->or_port);
+                   fingerprint, voter->address, fmt_addr(&voter->ipv4_addr),
+                   voter->ipv4_dirport,
+                   voter->ipv4_orport);
       if (! e->is_legacy) {
         smartlist_add_asprintf(chunks,
                      "contact %s\n"
@@ -2039,10 +2039,10 @@ networkstatus_compute_consensus(smartlist_t *votes,
       memcpy(rs_out.identity_digest, current_rsa_id, DIGEST_LEN);
       memcpy(rs_out.descriptor_digest, rs->status.descriptor_digest,
              DIGEST_LEN);
-      rs_out.addr = rs->status.addr;
+      tor_addr_copy(&rs_out.ipv4_addr, &rs->status.ipv4_addr);
       rs_out.published_on = rs->status.published_on;
-      rs_out.dir_port = rs->status.dir_port;
-      rs_out.or_port = rs->status.or_port;
+      rs_out.ipv4_dirport = rs->status.ipv4_dirport;
+      rs_out.ipv4_orport = rs->status.ipv4_orport;
       tor_addr_copy(&rs_out.ipv6_addr, &alt_orport.addr);
       rs_out.ipv6_orport = alt_orport.port;
       rs_out.has_bandwidth = 0;
@@ -4222,10 +4222,14 @@ compare_routerinfo_by_ip_and_bw_(const void **a, const void **b)
 
   /* we return -1 if first should appear before second... that is,
    * if first is a better router. */
+  /* XXX: MUST FOLLOW NEW tor_addr_t INTERFACE. Requires #7193 to be merged
+   * first. */
+#if 0
   if (first->addr < second->addr)
     return -1;
   else if (first->addr > second->addr)
     return 1;
+#endif
 
   /* Potentially, this next bit could cause k n lg n memeq calls.  But in
    * reality, we will almost never get here, since addresses will usually be
@@ -4286,6 +4290,10 @@ get_possible_sybil_list(const smartlist_t *routers)
   smartlist_sort(routers_by_ip, compare_routerinfo_by_ip_and_bw_);
   omit_as_sybil = digestmap_new();
 
+  /* XXX: Fixed once #7193 is merged. */
+  (void) last_addr;
+  (void) addr_count;
+#if 0
   last_addr = 0;
   addr_count = 0;
   SMARTLIST_FOREACH_BEGIN(routers_by_ip, routerinfo_t *, ri) {
@@ -4296,6 +4304,7 @@ get_possible_sybil_list(const smartlist_t *routers)
       digestmap_set(omit_as_sybil, ri->cache_info.identity_digest, ri);
     }
   } SMARTLIST_FOREACH_END(ri);
+#endif
 
   smartlist_free(routers_by_ip);
   return omit_as_sybil;
@@ -4722,9 +4731,9 @@ dirserv_generate_networkstatus_vote_obj(crypto_pk_t *private_key,
   memcpy(voter->identity_digest, identity_digest, DIGEST_LEN);
   voter->sigs = smartlist_new();
   voter->address = hostname;
-  voter->addr = tor_addr_to_ipv4h(&addr);
-  voter->dir_port = router_get_advertised_dir_port(options, 0);
-  voter->or_port = router_get_advertised_or_port(options);
+  tor_addr_copy(&voter->ipv4_addr, &addr);
+  voter->ipv4_dirport = router_get_advertised_dir_port(options, 0);
+  voter->ipv4_orport = router_get_advertised_or_port(options);
   voter->contact = tor_strdup(contact);
   if (options->V3AuthUseLegacyKey) {
     authority_cert_t *c = get_my_v3_legacy_cert();

--- a/src/feature/dirauth/reachability.c
+++ b/src/feature/dirauth/reachability.c
@@ -84,7 +84,7 @@ dirserv_orconn_tls_done(const tor_addr_t *addr,
       log_info(LD_DIRSERV, "Found router %s to be reachable at %s:%d. Yay.",
                router_describe(ri),
                tor_addr_to_str(addrstr, addr, sizeof(addrstr), 1),
-               ri->or_port);
+               ri->ipv4_orport);
       if (tor_addr_family(addr) == AF_INET) {
         rep_hist_note_router_reachable(digest_rcvd, addr, or_port, now);
         node->last_reachable = now;
@@ -132,7 +132,6 @@ dirserv_single_reachability_test(time_t now, routerinfo_t *router)
   const dirauth_options_t *dirauth_options = dirauth_get_options();
   channel_t *chan = NULL;
   const node_t *node = NULL;
-  tor_addr_t router_addr;
   const ed25519_public_key_t *ed_id_key;
   (void) now;
 
@@ -150,9 +149,9 @@ dirserv_single_reachability_test(time_t now, routerinfo_t *router)
 
   /* IPv4. */
   log_debug(LD_OR,"Testing reachability of %s at %s:%u.",
-            router->nickname, fmt_addr32(router->addr), router->or_port);
-  tor_addr_from_ipv4h(&router_addr, router->addr);
-  chan = channel_tls_connect(&router_addr, router->or_port,
+            router->nickname, fmt_addr(&router->ipv4_addr),
+            router->ipv4_orport);
+  chan = channel_tls_connect(&router->ipv4_addr, router->ipv4_orport,
                              router->cache_info.identity_digest,
                              ed_id_key);
   if (chan) command_setup_channel(chan);

--- a/src/feature/dirclient/dir_server_st.h
+++ b/src/feature/dirclient/dir_server_st.h
@@ -24,10 +24,10 @@ struct dir_server_t {
   char *address; /**< Hostname. */
   /* XX/teor - why do we duplicate the address and port fields here and in
    *           fake_status? Surely we could just use fake_status (#17867). */
+  tor_addr_t ipv4_addr;
+  uint16_t ipv4_dirport; /**< Directory port. */
+  uint16_t ipv4_orport; /**< OR port: Used for tunneling connections. */
   tor_addr_t ipv6_addr; /**< IPv6 address if present; AF_UNSPEC if not */
-  uint32_t addr; /**< IPv4 address. */
-  uint16_t dir_port; /**< Directory port. */
-  uint16_t or_port; /**< OR port: Used for tunneling connections. */
   uint16_t ipv6_orport; /**< OR port corresponding to ipv6_addr. */
   double weight; /** Weight used when selecting this node at random */
   char digest[DIGEST_LEN]; /**< Digest of identity key. */

--- a/src/feature/dirparse/authcert_parse.c
+++ b/src/feature/dirparse/authcert_parse.c
@@ -130,13 +130,13 @@ authority_cert_parse_from_string(const char *s, size_t maxlen,
     tor_assert(tok->n_args);
     /* XXX++ use some tor_addr parse function below instead. -RD */
     if (tor_addr_port_split(LOG_WARN, tok->args[0], &address,
-                            &cert->dir_port) < 0 ||
+                            &cert->ipv4_dirport) < 0 ||
         tor_inet_aton(address, &in) == 0) {
       log_warn(LD_DIR, "Couldn't parse dir-address in certificate");
       tor_free(address);
       goto err;
     }
-    cert->addr = ntohl(in.s_addr);
+    tor_addr_from_in(&cert->ipv4_addr, &in);
     tor_free(address);
   }
 

--- a/src/feature/dirparse/ns_parse.c
+++ b/src/feature/dirparse/ns_parse.c
@@ -384,12 +384,12 @@ routerstatus_parse_entry_from_string(memarea_t *area,
              escaped(tok->args[5+offset]));
     goto err;
   }
-  rs->addr = ntohl(in.s_addr);
+  tor_addr_from_in(&rs->ipv4_addr, &in);
 
-  rs->or_port = (uint16_t) tor_parse_long(tok->args[6+offset],
-                                         10,0,65535,NULL,NULL);
-  rs->dir_port = (uint16_t) tor_parse_long(tok->args[7+offset],
-                                           10,0,65535,NULL,NULL);
+  rs->ipv4_orport = (uint16_t) tor_parse_long(tok->args[6+offset],
+                                              10,0,65535,NULL,NULL);
+  rs->ipv4_dirport = (uint16_t) tor_parse_long(tok->args[7+offset],
+                                               10,0,65535,NULL,NULL);
 
   {
     smartlist_t *a_lines = find_all_by_keyword(tokens, K_A);
@@ -563,7 +563,7 @@ routerstatus_parse_entry_from_string(memarea_t *area,
       log_info(LD_BUG, "Found an entry in networkstatus with no "
                "microdescriptor digest. (Router %s ($%s) at %s:%d.)",
                rs->nickname, hex_str(rs->identity_digest, DIGEST_LEN),
-               fmt_addr32(rs->addr), rs->or_port);
+               fmt_addr(&rs->ipv4_addr), rs->ipv4_orport);
     }
   }
 
@@ -1367,13 +1367,13 @@ networkstatus_parse_vote_from_string(const char *s,
                  escaped(tok->args[3]));
         goto err;
       }
-      voter->addr = ntohl(in.s_addr);
+      tor_addr_from_in(&voter->ipv4_addr, &in);
       int ok;
-      voter->dir_port = (uint16_t)
+      voter->ipv4_dirport = (uint16_t)
         tor_parse_long(tok->args[4], 10, 0, 65535, &ok, NULL);
       if (!ok)
         goto err;
-      voter->or_port = (uint16_t)
+      voter->ipv4_orport = (uint16_t)
         tor_parse_long(tok->args[5], 10, 0, 65535, &ok, NULL);
       if (!ok)
         goto err;

--- a/src/feature/dirparse/routerparse.c
+++ b/src/feature/dirparse/routerparse.c
@@ -519,15 +519,15 @@ router_parse_entry_from_string(const char *s, const char *end,
     log_warn(LD_DIR,"Router address is not an IP address.");
     goto err;
   }
-  router->addr = ntohl(in.s_addr);
+  tor_addr_from_in(&router->ipv4_addr, &in);
 
-  router->or_port =
+  router->ipv4_orport =
     (uint16_t) tor_parse_long(tok->args[2],10,0,65535,&ok,NULL);
   if (!ok) {
     log_warn(LD_DIR,"Invalid OR port %s", escaped(tok->args[2]));
     goto err;
   }
-  router->dir_port =
+  router->ipv4_dirport =
     (uint16_t) tor_parse_long(tok->args[4],10,0,65535,&ok,NULL);
   if (!ok) {
     log_warn(LD_DIR,"Invalid dir port %s", escaped(tok->args[4]));
@@ -907,13 +907,14 @@ router_parse_entry_from_string(const char *s, const char *end,
 
   /* This router accepts tunnelled directory requests via begindir if it has
    * an open dirport or it included "tunnelled-dir-server". */
-  if (find_opt_by_keyword(tokens, K_DIR_TUNNELLED) || router->dir_port > 0) {
+  if (find_opt_by_keyword(tokens, K_DIR_TUNNELLED) ||
+      router->ipv4_dirport > 0) {
     router->supports_tunnelled_dir_requests = 1;
   }
 
   tok = find_by_keyword(tokens, K_ROUTER_SIGNATURE);
 
-  if (!router->or_port) {
+  if (!router->ipv4_orport) {
     log_warn(LD_DIR,"or_port unreadable or 0. Failing.");
     goto err;
   }

--- a/src/feature/nodelist/authcert.c
+++ b/src/feature/nodelist/authcert.c
@@ -460,19 +460,15 @@ trusted_dirs_load_certs_from_string(const char *contents, int source,
     if (ds && cert->cache_info.published_on > ds->addr_current_at) {
       /* Check to see whether we should update our view of the authority's
        * address. */
-      if (cert->addr && cert->dir_port &&
-          (ds->addr != cert->addr ||
-           ds->dir_port != cert->dir_port)) {
-        char *a = tor_dup_ip(cert->addr);
-        if (a) {
-          log_notice(LD_DIR, "Updating address for directory authority %s "
-                     "from %s:%d to %s:%d based on certificate.",
-                     ds->nickname, ds->address, (int)ds->dir_port,
-                     a, cert->dir_port);
-          tor_free(a);
-        }
-        ds->addr = cert->addr;
-        ds->dir_port = cert->dir_port;
+      if (!tor_addr_is_null(&cert->ipv4_addr) && cert->ipv4_dirport &&
+          (!tor_addr_eq(&ds->ipv4_addr, &cert->ipv4_addr) ||
+           ds->ipv4_dirport != cert->ipv4_dirport)) {
+        log_notice(LD_DIR, "Updating address for directory authority %s "
+                   "from %s:%"PRIu16" to %s:%"PRIu16" based on certificate.",
+                   ds->nickname, ds->address, ds->ipv4_dirport,
+                   fmt_addr(&cert->ipv4_addr), cert->ipv4_dirport);
+        tor_addr_copy(&ds->ipv4_addr, &cert->ipv4_addr);
+        ds->ipv4_dirport = cert->ipv4_dirport;
       }
       ds->addr_current_at = cert->cache_info.published_on;
     }

--- a/src/feature/nodelist/authority_cert_st.h
+++ b/src/feature/nodelist/authority_cert_st.h
@@ -27,10 +27,10 @@ struct authority_cert_t {
   char signing_key_digest[DIGEST_LEN];
   /** The listed expiration time of this certificate. */
   time_t expires;
-  /** This authority's IPv4 address, in host order. */
-  uint32_t addr;
+  /** This authority's IPv4 address. */
+  tor_addr_t ipv4_addr;
   /** This authority's directory port. */
-  uint16_t dir_port;
+  uint16_t ipv4_dirport;
 };
 
 #endif /* !defined(AUTHORITY_CERT_ST_H) */

--- a/src/feature/nodelist/describe.h
+++ b/src/feature/nodelist/describe.h
@@ -49,8 +49,8 @@ void router_get_verbose_nickname(char *buf, const routerinfo_t *router);
 STATIC const char *format_node_description(char *buf,
                                            const char *id_digest,
                                            const char *nickname,
-                                           const tor_addr_t *addr,
-                                           uint32_t addr32h);
+                                           const tor_addr_t *ipv6_addr,
+                                           const tor_addr_t *ipv4_addr);
 
 #endif /* defined(TOR_UNIT_TESTS) */
 

--- a/src/feature/nodelist/fmt_routerstatus.c
+++ b/src/feature/nodelist/fmt_routerstatus.c
@@ -53,7 +53,7 @@ routerstatus_format_entry(const routerstatus_t *rs, const char *version,
   char digest64[BASE64_DIGEST_LEN+1];
   smartlist_t *chunks = smartlist_new();
 
-  const char *ip_str = fmt_addr32(rs->addr);
+  const char *ip_str = fmt_addr(&rs->ipv4_addr);
   if (ip_str[0] == '\0')
     goto err;
 
@@ -62,15 +62,15 @@ routerstatus_format_entry(const routerstatus_t *rs, const char *version,
   digest_to_base64(digest64, rs->descriptor_digest);
 
   smartlist_add_asprintf(chunks,
-                   "r %s %s %s%s%s %s %d %d\n",
+                   "r %s %s %s%s%s %s %" PRIu16 " %" PRIu16 "\n",
                    rs->nickname,
                    identity64,
                    (format==NS_V3_CONSENSUS_MICRODESC)?"":digest64,
                    (format==NS_V3_CONSENSUS_MICRODESC)?"":" ",
                    published,
                    ip_str,
-                   (int)rs->or_port,
-                   (int)rs->dir_port);
+                   rs->ipv4_orport,
+                   rs->ipv4_dirport);
 
   /* TODO: Maybe we want to pass in what we need to build the rest of
    * this here, instead of in the caller. Then we could use the

--- a/src/feature/nodelist/networkstatus.c
+++ b/src/feature/nodelist/networkstatus.c
@@ -608,25 +608,25 @@ networkstatus_check_consensus_signature(networkstatus_t *consensus,
     SMARTLIST_FOREACH(unrecognized, networkstatus_voter_info_t *, voter,
       {
         tor_log(severity, LD_DIR, "Consensus includes unrecognized authority "
-                 "'%s' at %s:%d (contact %s; identity %s)",
-                 voter->nickname, voter->address, (int)voter->dir_port,
+                 "'%s' at %s:%" PRIu16 " (contact %s; identity %s)",
+                 voter->nickname, voter->address, voter->ipv4_dirport,
                  voter->contact?voter->contact:"n/a",
                  hex_str(voter->identity_digest, DIGEST_LEN));
       });
     SMARTLIST_FOREACH(need_certs_from, networkstatus_voter_info_t *, voter,
       {
         tor_log(severity, LD_DIR, "Looks like we need to download a new "
-                 "certificate from authority '%s' at %s:%d (contact %s; "
-                 "identity %s)",
-                 voter->nickname, voter->address, (int)voter->dir_port,
+                 "certificate from authority '%s' at %s:%" PRIu16
+                 " (contact %s; identity %s)",
+                 voter->nickname, voter->address, voter->ipv4_dirport,
                  voter->contact?voter->contact:"n/a",
                  hex_str(voter->identity_digest, DIGEST_LEN));
       });
     SMARTLIST_FOREACH(missing_authorities, dir_server_t *, ds,
       {
         tor_log(severity, LD_DIR, "Consensus does not include configured "
-                 "authority '%s' at %s:%d (identity %s)",
-                 ds->nickname, ds->address, (int)ds->dir_port,
+                 "authority '%s' at %s:%" PRIu16 " (identity %s)",
+                 ds->nickname, ds->address, ds->ipv4_dirport,
                  hex_str(ds->v3_identity_digest, DIGEST_LEN));
       });
     {
@@ -1594,9 +1594,9 @@ routerstatus_has_visibly_changed(const routerstatus_t *a,
 
   return strcmp(a->nickname, b->nickname) ||
          fast_memneq(a->descriptor_digest, b->descriptor_digest, DIGEST_LEN) ||
-         a->addr != b->addr ||
-         a->or_port != b->or_port ||
-         a->dir_port != b->dir_port ||
+         !tor_addr_eq(&a->ipv4_addr, &b->ipv4_addr) ||
+         a->ipv4_orport != b->ipv4_orport ||
+         a->ipv4_dirport != b->ipv4_dirport ||
          a->is_authority != b->is_authority ||
          a->is_exit != b->is_exit ||
          a->is_stable != b->is_stable ||
@@ -2392,10 +2392,10 @@ set_routerstatus_from_routerinfo(routerstatus_t *rs,
   memcpy(rs->identity_digest, node->identity, DIGEST_LEN);
   memcpy(rs->descriptor_digest, ri->cache_info.signed_descriptor_digest,
          DIGEST_LEN);
-  rs->addr = ri->addr;
+  tor_addr_copy(&rs->ipv4_addr, &ri->ipv4_addr);
   strlcpy(rs->nickname, ri->nickname, sizeof(rs->nickname));
-  rs->or_port = ri->or_port;
-  rs->dir_port = ri->dir_port;
+  rs->ipv4_orport = ri->ipv4_orport;
+  rs->ipv4_dirport = ri->ipv4_dirport;
   rs->is_v2_dir = ri->supports_tunnelled_dir_requests;
 
   tor_addr_copy(&rs->ipv6_addr, &ri->ipv6_addr);

--- a/src/feature/nodelist/networkstatus_voter_info_st.h
+++ b/src/feature/nodelist/networkstatus_voter_info_st.h
@@ -21,9 +21,9 @@ struct networkstatus_voter_info_t {
    * consensuses, we treat legacy keys as additional signers. */
   char legacy_id_digest[DIGEST_LEN];
   char *address; /**< Address of this voter, in string format. */
-  uint32_t addr; /**< Address of this voter, in IPv4, in host order. */
-  uint16_t dir_port; /**< Directory port of this voter */
-  uint16_t or_port; /**< OR port of this voter */
+  tor_addr_t ipv4_addr;
+  uint16_t ipv4_dirport; /**< Directory port of this voter */
+  uint16_t ipv4_orport; /**< OR port of this voter */
   char *contact; /**< Contact information for this voter. */
   char vote_digest[DIGEST_LEN]; /**< Digest of this voter's vote, as signed. */
 

--- a/src/feature/nodelist/node_select.c
+++ b/src/feature/nodelist/node_select.c
@@ -217,13 +217,15 @@ router_picked_poor_directory_log(const routerstatus_t *rs)
              ) {
     /* This is rare, and might be interesting to users trying to diagnose
      * connection issues on dual-stack machines. */
+    char *ipv4_str = tor_addr_to_str_dup(&rs->ipv4_addr);
     log_info(LD_DIR, "Selected a directory %s with non-preferred OR and Dir "
              "addresses for launching an outgoing connection: "
              "IPv4 %s OR %d Dir %d IPv6 %s OR %d Dir %d",
              routerstatus_describe(rs),
-             fmt_addr32(rs->addr), rs->or_port,
-             rs->dir_port, fmt_addr(&rs->ipv6_addr),
-             rs->ipv6_orport, rs->dir_port);
+             (ipv4_str) ? ipv4_str : "???", rs->ipv4_orport,
+             rs->ipv4_dirport, fmt_addr(&rs->ipv6_addr),
+             rs->ipv6_orport, rs->ipv4_dirport);
+    tor_free(ipv4_str);
   }
 }
 
@@ -266,7 +268,7 @@ router_is_already_dir_fetching(const tor_addr_port_t *ap, int serverdesc,
  * If so, return 1, if not, return 0.
  */
 static int
-router_is_already_dir_fetching_(uint32_t ipv4_addr,
+router_is_already_dir_fetching_(const tor_addr_t *ipv4_addr,
                                 const tor_addr_t *ipv6_addr,
                                 uint16_t dir_port,
                                 int serverdesc,
@@ -275,7 +277,7 @@ router_is_already_dir_fetching_(uint32_t ipv4_addr,
   tor_addr_port_t ipv4_dir_ap, ipv6_dir_ap;
 
   /* Assume IPv6 DirPort is the same as IPv4 DirPort */
-  tor_addr_from_ipv4h(&ipv4_dir_ap.addr, ipv4_addr);
+  tor_addr_copy(&ipv4_dir_ap.addr, ipv4_addr);
   ipv4_dir_ap.port = dir_port;
   tor_addr_copy(&ipv6_dir_ap.addr, ipv6_addr);
   ipv6_dir_ap.port = dir_port;
@@ -352,9 +354,9 @@ router_pick_directory_server_impl(dirinfo_type_t type, int flags,
       continue;
     }
 
-    if (router_is_already_dir_fetching_(status->addr,
+    if (router_is_already_dir_fetching_(&status->ipv4_addr,
                                         &status->ipv6_addr,
-                                        status->dir_port,
+                                        status->ipv4_dirport,
                                         no_serverdesc_fetching,
                                         no_microdesc_fetching)) {
       ++n_busy;
@@ -1143,9 +1145,9 @@ router_pick_trusteddirserver_impl(const smartlist_t *sourcelist,
         continue;
       }
 
-      if (router_is_already_dir_fetching_(d->addr,
+      if (router_is_already_dir_fetching_(&d->ipv4_addr,
                                           &d->ipv6_addr,
-                                          d->dir_port,
+                                          d->ipv4_dirport,
                                           no_serverdesc_fetching,
                                           no_microdesc_fetching)) {
         ++n_busy;

--- a/src/feature/nodelist/nodelist.h
+++ b/src/feature/nodelist/nodelist.h
@@ -35,8 +35,7 @@ node_t *nodelist_add_microdesc(microdesc_t *md);
 void nodelist_set_consensus(const networkstatus_t *ns);
 void nodelist_ensure_freshness(const networkstatus_t *ns);
 int nodelist_probably_contains_address(const tor_addr_t *addr);
-void nodelist_add_addr4_to_address_set(const uint32_t addr);
-void nodelist_add_addr6_to_address_set(const tor_addr_t *addr);
+void nodelist_add_addr_to_address_set(const tor_addr_t *addr);
 
 void nodelist_remove_microdesc(const char *identity_digest, microdesc_t *md);
 void nodelist_remove_routerinfo(routerinfo_t *ri);
@@ -67,7 +66,6 @@ smartlist_t *node_get_all_orports(const node_t *node);
 int node_allows_single_hop_exits(const node_t *node);
 const char *node_get_nickname(const node_t *node);
 const char *node_get_platform(const node_t *node);
-uint32_t node_get_prim_addr_ipv4h(const node_t *node);
 void node_get_address_string(const node_t *node, char *cp, size_t len);
 long node_get_declared_uptime(const node_t *node);
 MOCK_DECL(const struct ed25519_public_key_t *,node_get_ed25519_id,
@@ -114,7 +112,6 @@ MOCK_DECL(const smartlist_t *, nodelist_get_list, (void));
 
 /* Temporary during transition to multiple addresses.  */
 void node_get_addr(const node_t *node, tor_addr_t *addr_out);
-#define node_get_addr_ipv4h(n) node_get_prim_addr_ipv4h((n))
 
 void nodelist_refresh_countries(void);
 void node_set_country(node_t *node);

--- a/src/feature/nodelist/routerinfo.c
+++ b/src/feature/nodelist/routerinfo.c
@@ -29,8 +29,8 @@ router_get_orport(const routerinfo_t *router,
 {
   tor_assert(ap_out != NULL);
   if (family == AF_INET) {
-    tor_addr_from_ipv4h(&ap_out->addr, router->addr);
-    ap_out->port = router->or_port;
+    tor_addr_copy(&ap_out->addr, &router->ipv4_addr);
+    ap_out->port = router->ipv4_orport;
     return 0;
   } else if (family == AF_INET6) {
     /* IPv6 addresses are optional, so check if it is valid. */
@@ -54,8 +54,8 @@ int
 router_has_orport(const routerinfo_t *router, const tor_addr_port_t *orport)
 {
   return
-    (tor_addr_eq_ipv4h(&orport->addr, router->addr) &&
-     orport->port == router->or_port) ||
+    (tor_addr_eq(&orport->addr, &router->ipv4_addr) &&
+     orport->port == router->ipv4_orport) ||
     (tor_addr_eq(&orport->addr, &router->ipv6_addr) &&
      orport->port == router->ipv6_orport);
 }

--- a/src/feature/nodelist/routerinfo_st.h
+++ b/src/feature/nodelist/routerinfo_st.h
@@ -21,9 +21,10 @@ struct routerinfo_t {
   signed_descriptor_t cache_info;
   char *nickname; /**< Human-readable OR name. */
 
-  uint32_t addr; /**< IPv4 address of OR, in host order. */
-  uint16_t or_port; /**< Port for TLS connections. */
-  uint16_t dir_port; /**< Port for HTTP directory connections. */
+  /** A router's IPv4 address. */
+  tor_addr_t ipv4_addr;
+  uint16_t ipv4_orport;
+  uint16_t ipv4_dirport;
 
   /** A router's IPv6 address, if it has one. */
   tor_addr_t ipv6_addr;

--- a/src/feature/nodelist/routerlist.c
+++ b/src/feature/nodelist/routerlist.c
@@ -506,7 +506,8 @@ router_dir_conn_should_skip_reachable_address_check(
 int
 routers_have_same_or_addrs(const routerinfo_t *r1, const routerinfo_t *r2)
 {
-  return r1->addr == r2->addr && r1->or_port == r2->or_port &&
+  return tor_addr_eq(&r1->ipv4_addr, &r2->ipv4_addr) &&
+    r1->ipv4_orport == r2->ipv4_orport &&
     tor_addr_eq(&r1->ipv6_addr, &r2->ipv6_addr) &&
     r1->ipv6_orport == r2->ipv6_orport;
 }
@@ -2964,12 +2965,12 @@ router_differences_are_cosmetic(const routerinfo_t *r1, const routerinfo_t *r2)
   }
 
   /* If any key fields differ, they're different. */
-  if (r1->addr != r2->addr ||
+  if (!tor_addr_eq(&r1->ipv4_addr, &r2->ipv4_addr) ||
       strcasecmp(r1->nickname, r2->nickname) ||
-      r1->or_port != r2->or_port ||
+      r1->ipv4_orport != r2->ipv4_orport ||
       !tor_addr_eq(&r1->ipv6_addr, &r2->ipv6_addr) ||
       r1->ipv6_orport != r2->ipv6_orport ||
-      r1->dir_port != r2->dir_port ||
+      r1->ipv4_dirport != r2->ipv4_dirport ||
       r1->purpose != r2->purpose ||
       r1->onion_pkey_len != r2->onion_pkey_len ||
       !tor_memeq(r1->onion_pkey, r2->onion_pkey, r1->onion_pkey_len) ||

--- a/src/feature/nodelist/routerset.c
+++ b/src/feature/nodelist/routerset.c
@@ -327,10 +327,8 @@ int
 routerset_contains_router(const routerset_t *set, const routerinfo_t *ri,
                           country_t country)
 {
-  tor_addr_t addr_v4;
-  tor_addr_from_ipv4h(&addr_v4, ri->addr);
-  return routerset_contains2(set, &addr_v4, ri->or_port, &ri->ipv6_addr,
-                             ri->ipv6_orport, ri->nickname,
+  return routerset_contains2(set, &ri->ipv4_addr, ri->ipv4_orport,
+                             &ri->ipv6_addr, ri->ipv6_orport, ri->nickname,
                              ri->cache_info.identity_digest, country);
 }
 
@@ -341,11 +339,9 @@ routerset_contains_routerstatus(const routerset_t *set,
                                 const routerstatus_t *rs,
                                 country_t country)
 {
-  tor_addr_t addr;
-  tor_addr_from_ipv4h(&addr, rs->addr);
   return routerset_contains(set,
-                            &addr,
-                            rs->or_port,
+                            &rs->ipv4_addr,
+                            rs->ipv4_orport,
                             rs->nickname,
                             rs->identity_digest,
                             country);

--- a/src/feature/nodelist/routerstatus_st.h
+++ b/src/feature/nodelist/routerstatus_st.h
@@ -29,9 +29,9 @@ struct routerstatus_t {
   /** Digest of the router's most recent descriptor or microdescriptor.
    * If it's a descriptor, we only use the first DIGEST_LEN bytes. */
   char descriptor_digest[DIGEST256_LEN];
-  uint32_t addr; /**< IPv4 address for this router, in host order. */
-  uint16_t or_port; /**< IPv4 OR port for this router. */
-  uint16_t dir_port; /**< Directory port for this router. */
+  tor_addr_t ipv4_addr;
+  uint16_t ipv4_orport; /**< IPv4 OR port for this router. */
+  uint16_t ipv4_dirport; /**< Directory port for this router. */
   tor_addr_t ipv6_addr; /**< IPv6 address for this router. */
   uint16_t ipv6_orport; /**< IPv6 OR port for this router. */
   unsigned int is_authority:1; /**< True iff this router is an authority. */

--- a/src/feature/relay/relay_periodic.c
+++ b/src/feature/relay/relay_periodic.c
@@ -208,14 +208,14 @@ reachability_warnings_callback(time_t now, const or_options_t *options)
     if (me && !(v4_ok && v6_ok)) {
       /* We need to warn that one or more of our ORPorts isn't reachable.
        * Determine which, and give a reasonable warning. */
-      char *address4 = tor_dup_ip(me->addr);
+      char *address4 = tor_addr_to_str_dup(&me->ipv4_addr);
       char *address6 = tor_addr_to_str_dup(&me->ipv6_addr);
       if (address4 || address6) {
         char *where4=NULL, *where6=NULL;
         if (!v4_ok)
-          tor_asprintf(&where4, "%s:%d", address4, me->or_port);
+          tor_asprintf(&where4, "%s:%d", address4, me->ipv4_orport);
         if (!v6_ok)
-          tor_asprintf(&where6, "[%s]:%d", address6, me->or_port);
+          tor_asprintf(&where6, "[%s]:%d", address6, me->ipv6_orport);
         const char *opt_and = (!v4_ok && !v6_ok) ? "and" : "";
 
         log_warn(LD_CONFIG,
@@ -231,7 +231,7 @@ reachability_warnings_callback(time_t now, const or_options_t *options)
         if (!v4_ok) {
           control_event_server_status(LOG_WARN,
                                       "REACHABILITY_FAILED ORADDRESS=%s:%d",
-                                      address4, me->or_port);
+                                      address4, me->ipv4_orport);
         }
         if (!v6_ok) {
           control_event_server_status(LOG_WARN,
@@ -244,18 +244,18 @@ reachability_warnings_callback(time_t now, const or_options_t *options)
     }
 
     if (me && !router_dirport_seems_reachable(options)) {
-      char *address = tor_dup_ip(me->addr);
-      if (address) {
+      char *address4 = tor_addr_to_str_dup(&me->ipv4_addr);
+      if (address4) {
         log_warn(LD_CONFIG,
                  "Your server (%s:%d) has not managed to confirm that its "
                  "DirPort is reachable. Relays do not publish descriptors "
                  "until their ORPort and DirPort are reachable. Please check "
                  "your firewalls, ports, address, /etc/hosts file, etc.",
-                 address, me->dir_port);
+                 address4, me->ipv4_dirport);
         control_event_server_status(LOG_WARN,
                                     "REACHABILITY_FAILED DIRADDRESS=%s:%d",
-                                    address, me->dir_port);
-        tor_free(address);
+                                    address4, me->ipv4_dirport);
+        tor_free(address4);
       }
     }
   }

--- a/src/feature/relay/selftest.c
+++ b/src/feature/relay/selftest.c
@@ -284,8 +284,8 @@ static void
 router_do_dirport_reachability_checks(const routerinfo_t *me)
 {
   tor_addr_port_t my_dirport;
-  tor_addr_from_ipv4h(&my_dirport.addr, me->addr);
-  my_dirport.port = me->dir_port;
+  tor_addr_copy(&my_dirport.addr, &me->ipv4_addr);
+  my_dirport.port = me->ipv4_dirport;
 
   /* If there is already a pending connection, don't open another one. */
   if (!connection_get_by_type_addr_port_purpose(
@@ -443,7 +443,7 @@ router_dirport_found_reachable(void)
   const or_options_t *options = get_options();
 
   if (!can_reach_dir_port && me) {
-    char *address = tor_dup_ip(me->addr);
+    char *address = tor_addr_to_str_dup(&me->ipv4_addr);
 
     if (!address)
       return;
@@ -454,7 +454,7 @@ router_dirport_found_reachable(void)
                ready_to_publish(options) ?
                " Publishing server descriptor." : "");
 
-    if (router_should_advertise_dirport(options, me->dir_port)) {
+    if (router_should_advertise_dirport(options, me->ipv4_dirport)) {
       mark_my_descriptor_dirty("DirPort found reachable");
       /* This is a significant enough change to upload immediately,
        * at least in a test network */
@@ -464,7 +464,7 @@ router_dirport_found_reachable(void)
     }
     control_event_server_status(LOG_NOTICE,
                                 "REACHABILITY_SUCCEEDED DIRADDRESS=%s:%d",
-                                address, me->dir_port);
+                                address, me->ipv4_dirport);
     tor_free(address);
   }
 }

--- a/src/feature/rend/rendservice.c
+++ b/src/feature/rend/rendservice.c
@@ -3740,7 +3740,7 @@ directory_post_to_hs_dir(rend_service_descriptor_t *renddesc,
       rend_data_free(rend_data);
       base32_encode(desc_id_base32, sizeof(desc_id_base32),
                     desc->desc_id, DIGEST_LEN);
-      hs_dir_ip = tor_dup_ip(hs_dir->addr);
+      hs_dir_ip = tor_addr_to_str_dup(&hs_dir->ipv4_addr);
       if (hs_dir_ip) {
         log_info(LD_REND, "Launching upload for v2 descriptor for "
                           "service '%s' with descriptor ID '%s' with validity "
@@ -3751,7 +3751,7 @@ directory_post_to_hs_dir(rend_service_descriptor_t *renddesc,
                  seconds_valid,
                  hs_dir->nickname,
                  hs_dir_ip,
-                 hs_dir->or_port);
+                 hs_dir->ipv4_orport);
         tor_free(hs_dir_ip);
       }
 

--- a/src/lib/net/address.c
+++ b/src/lib/net/address.c
@@ -764,6 +764,15 @@ tor_addr_is_v4(const tor_addr_t *addr)
   return 0; /* Not IPv4 - unknown family or a full-blood IPv6 address */
 }
 
+/** Determine whether an address <b>addr</b> is an IPv6 (AF_INET6). Return
+ * true if so else false. */
+int
+tor_addr_is_v6(const tor_addr_t *addr)
+{
+  tor_assert(addr);
+  return (tor_addr_family(addr) == AF_INET6);
+}
+
 /** Determine whether an address <b>addr</b> is null, either all zeroes or
  *  belonging to family AF_UNSPEC.
  */

--- a/src/lib/net/address.h
+++ b/src/lib/net/address.h
@@ -284,6 +284,7 @@ struct sipkey;
 uint64_t tor_addr_keyed_hash(const struct sipkey *key, const tor_addr_t *addr);
 
 int tor_addr_is_v4(const tor_addr_t *addr);
+int tor_addr_is_v6(const tor_addr_t *addr);
 int tor_addr_is_internal_(const tor_addr_t *ip, int for_listening,
                           const char *filename, int lineno);
 #define tor_addr_is_internal(addr, for_listening) \

--- a/src/test/test_address.c
+++ b/src/test/test_address.c
@@ -1194,16 +1194,14 @@ helper_free_mock_node(node_t *node)
   tor_free(node);
 }
 
-#define NODE_SET_IPV4(node, ipv4_addr, ipv4_port) { \
-    tor_addr_t addr; \
-    tor_addr_parse(&addr, ipv4_addr); \
-    node->ri->addr = tor_addr_to_ipv4h(&addr); \
-    node->ri->or_port = ipv4_port; \
+#define NODE_SET_IPV4(node, ipv4_addr_str, ipv4_port) { \
+    tor_addr_parse(&(node)->ri->ipv4_addr, ipv4_addr_str); \
+    node->ri->ipv4_orport = ipv4_port; \
   }
 
 #define NODE_CLEAR_IPV4(node) { \
-    node->ri->addr = 0; \
-    node->ri->or_port = 0; \
+    tor_addr_make_unspec(&node->ri->ipv4_addr); \
+    node->ri->ipv4_orport = 0; \
   }
 
 #define NODE_SET_IPV6(node, ipv6_addr_str, ipv6_port) { \
@@ -1260,9 +1258,7 @@ mock_get_options(void)
 #define TEST_ROUTER_VALID_ADDRESS_HELPER(ipv4_addr_str, ipv6_addr_str, rv) \
   STMT_BEGIN \
     ri = tor_malloc_zero(sizeof(routerinfo_t)); \
-    tor_addr_t addr; \
-    tor_addr_parse(&addr, (ipv4_addr_str));   \
-    ri->addr = tor_addr_to_ipv4h(&addr); \
+    tor_addr_parse(&ri->ipv4_addr, (ipv4_addr_str));   \
     tor_addr_parse(&ri->ipv6_addr, (ipv6_addr_str)); \
     tt_int_op(dirserv_router_has_valid_address(ri), OP_EQ, (rv)); \
     tor_free(ri); \
@@ -1320,7 +1316,7 @@ test_address_dirserv_router_addr_private(void *opt_dir_allow_private)
   /* IPv6 null succeeds, because IPv4 is not internal */
   {
     ri = tor_malloc_zero(sizeof(routerinfo_t));
-    ri->addr = 16777217; /* 1.0.0.1 */
+    tor_addr_parse(&ri->ipv4_addr, "1.0.0.1");
     tt_int_op(dirserv_router_has_valid_address(ri), OP_EQ, 0);
     tor_free(ri);
   }

--- a/src/test/test_address_set.c
+++ b/src/test/test_address_set.c
@@ -114,7 +114,6 @@ test_nodelist(void *arg)
 
   tor_addr_t addr_v4, addr_v6, dummy_addr;
   tor_addr_parse(&addr_v4, "42.42.42.42");
-  uint32_t ipv4h = tor_addr_to_ipv4h(&addr_v4);
   tor_addr_parse(&addr_v6, "1:2:3:4::");
   memset(&dummy_addr, 'A', sizeof(dummy_addr));
 
@@ -148,9 +147,9 @@ test_nodelist(void *arg)
   memcpy(rs->descriptor_digest, md->digest, DIGEST256_LEN);
 
   /* Setup the rs, ri and md addresses. */
-  rs->addr = ipv4h;
+  tor_addr_copy(&rs->ipv4_addr, &addr_v4);
   tor_addr_parse(&rs->ipv6_addr, "1:2:3:4::");
-  ri->addr = ipv4h;
+  tor_addr_copy(&ri->ipv4_addr, &addr_v4);
   tor_addr_parse(&ri->ipv6_addr, "1:2:3:4::");
   tor_addr_parse(&md->ipv6_addr, "1:2:3:4::");
 

--- a/src/test/test_bridges.c
+++ b/src/test/test_bridges.c
@@ -592,8 +592,12 @@ test_bridges_get_transport_by_bridge_addrport(void *arg)
 static void
 test_bridges_node_is_a_configured_bridge(void *arg)
 {
-  routerinfo_t ri_ipv4 = { .addr = 0x06060606, .or_port = 6666 };
-  routerstatus_t rs_ipv4 = { .addr = 0x06060606, .or_port = 6666 };
+
+  routerinfo_t ri_ipv4 = { .ipv4_orport = 6666 };
+  tor_addr_parse(&ri_ipv4.ipv4_addr, "6.6.6.6");
+
+  routerstatus_t rs_ipv4 = { .ipv4_orport = 6666 };
+  tor_addr_parse(&rs_ipv4.ipv4_addr, "6.6.6.6");
 
   routerinfo_t ri_ipv6 = { .ipv6_orport = 6666 };
   tor_addr_parse(&(ri_ipv6.ipv6_addr),
@@ -632,8 +636,8 @@ test_bridges_node_is_a_configured_bridge(void *arg)
 
   /* It won't match bridge1, though, since bridge1 has a digest, and this
      isn't it! */
-  node_ri_ipv4.ri->addr = 0x06060607;
-  node_ri_ipv4.ri->or_port = 6667;
+  tor_addr_parse(&node_ri_ipv4.ri->ipv4_addr, "6.6.6.7");
+  node_ri_ipv4.ri->ipv4_orport = 6667;
   tt_assert(! node_is_a_configured_bridge(&node_ri_ipv4));
   /* If we set the fingerprint right, though, it will match. */
   base16_decode(node_ri_ipv4.identity, DIGEST_LEN,

--- a/src/test/test_bwmgt.c
+++ b/src/test/test_bwmgt.c
@@ -317,8 +317,8 @@ test_bwmgt_dir_conn_global_write_low(void *arg)
   memcpy(rs->descriptor_digest, md->digest, DIGEST256_LEN);
 
   /* Set IP address. */
-  rs->addr = tor_addr_to_ipv4h(&relay_addr);
-  ri->addr = rs->addr;
+  tor_addr_copy(&rs->ipv4_addr, &relay_addr);
+  tor_addr_copy(&ri->ipv4_addr, &rs->ipv4_addr);
   /* Add the rs to the consensus becoming a node_t. */
   smartlist_add(dummy_ns->routerstatus_list, rs);
 

--- a/src/test/test_circuitbuild.c
+++ b/src/test/test_circuitbuild.c
@@ -824,16 +824,14 @@ test_circuit_extend_lspec_valid(void *arg)
   tor_free(p_chan);
 }
 
-#define NODE_SET_IPV4(node, ipv4_addr, ipv4_port) { \
-    tor_addr_t addr; \
-    tor_addr_parse(&addr, ipv4_addr); \
-    node->ri->addr = tor_addr_to_ipv4h(&addr); \
-    node->ri->or_port = ipv4_port; \
+#define NODE_SET_IPV4(node, ipv4_addr_str, ipv4_port) { \
+    tor_addr_parse(&node->ri->ipv4_addr, ipv4_addr_str); \
+    node->ri->ipv4_orport = ipv4_port; \
   }
 
 #define NODE_CLEAR_IPV4(node) { \
-    node->ri->addr = 0; \
-    node->ri->or_port = 0; \
+    tor_addr_make_unspec(&node->ri->ipv4_addr); \
+    node->ri->ipv4_orport = 0; \
   }
 
 #define NODE_SET_IPV6(node, ipv6_addr_str, ipv6_port) { \
@@ -864,7 +862,7 @@ test_circuit_extend_add_ip(void *arg)
 
   /* Do the IPv4 test */
   tt_int_op(circuit_extend_add_ipv4_helper(ec), OP_EQ, 0);
-  tor_addr_from_ipv4h(&ipv4_tmp, fake_node->ri->addr);
+  tor_addr_copy(&ipv4_tmp, &fake_node->ri->ipv4_addr);
   /* The IPv4 should match */
   tt_int_op(tor_addr_compare(&ec->orport_ipv4.addr, &ipv4_tmp, CMP_SEMANTIC),
             OP_EQ, 0);

--- a/src/test/test_config.c
+++ b/src/test/test_config.c
@@ -2313,7 +2313,7 @@ test_config_adding_dir_servers(void *arg)
                         ds,
                         /* increment the found counter if dir_port matches */
                         found_D0 +=
-                        (ds->dir_port == 60090 ?
+                        (ds->ipv4_dirport == 60090 ?
                          1 : 0)
                         );
       tt_int_op(found_D0, OP_EQ, 1);
@@ -2325,7 +2325,7 @@ test_config_adding_dir_servers(void *arg)
                         ds,
                         /* increment the found counter if dir_port matches */
                         found_B1 +=
-                        (ds->dir_port == 60091 ?
+                        (ds->ipv4_dirport == 60091 ?
                          1 : 0)
                         );
       tt_int_op(found_B1, OP_EQ, 0);
@@ -2337,7 +2337,7 @@ test_config_adding_dir_servers(void *arg)
                         ds,
                         /* increment the found counter if dir_port matches */
                         found_A2 +=
-                        (ds->dir_port == 60092 ?
+                        (ds->ipv4_dirport == 60092 ?
                          1 : 0)
                         );
       tt_int_op(found_A2, OP_EQ, 0);
@@ -2356,7 +2356,7 @@ test_config_adding_dir_servers(void *arg)
                         ds,
                         /* increment the found counter if dir_port matches */
                         found_D0 +=
-                        (ds->dir_port == 60090 ?
+                        (ds->ipv4_dirport == 60090 ?
                          1 : 0)
                         );
       tt_int_op(found_D0, OP_EQ, 1);
@@ -2368,7 +2368,7 @@ test_config_adding_dir_servers(void *arg)
                         ds,
                         /* increment the found counter if dir_port matches */
                         found_B1 +=
-                        (ds->dir_port == 60091 ?
+                        (ds->ipv4_dirport == 60091 ?
                          1 : 0)
                         );
       tt_int_op(found_B1, OP_EQ, 0);
@@ -2380,7 +2380,7 @@ test_config_adding_dir_servers(void *arg)
                         ds,
                         /* increment the found counter if dir_port matches */
                         found_A2 +=
-                        (ds->dir_port == 60092 ?
+                        (ds->ipv4_dirport == 60092 ?
                          1 : 0)
                         );
       tt_int_op(found_A2, OP_EQ, 0);
@@ -2392,7 +2392,7 @@ test_config_adding_dir_servers(void *arg)
                         ds,
                         /* increment the found counter if dir_port matches */
                         found_non_default_fallback +=
-                        (ds->dir_port == 60093 ?
+                        (ds->ipv4_dirport == 60093 ?
                          1 : 0)
                         );
       tt_int_op(found_non_default_fallback, OP_EQ, 1);
@@ -2404,7 +2404,7 @@ test_config_adding_dir_servers(void *arg)
                         ds,
                         /* increment the found counter if dir_port matches */
                         found_default_fallback +=
-                        (ds->dir_port == 60099 ?
+                        (ds->ipv4_dirport == 60099 ?
                          1 : 0)
                         );
       tt_int_op(found_default_fallback, OP_EQ, 0);
@@ -2456,7 +2456,7 @@ test_config_adding_dir_servers(void *arg)
                         ds,
                         /* increment the found counter if dir_port matches */
                         found_D0 +=
-                        (ds->dir_port == 60090 ?
+                        (ds->ipv4_dirport == 60090 ?
                          1 : 0)
                         );
       tt_int_op(found_D0, OP_EQ, 1);
@@ -2468,7 +2468,7 @@ test_config_adding_dir_servers(void *arg)
                         ds,
                         /* increment the found counter if dir_port matches */
                         found_B1 +=
-                        (ds->dir_port == 60091 ?
+                        (ds->ipv4_dirport == 60091 ?
                          1 : 0)
                         );
       tt_int_op(found_B1, OP_EQ, 0);
@@ -2480,7 +2480,7 @@ test_config_adding_dir_servers(void *arg)
                         ds,
                         /* increment the found counter if dir_port matches */
                         found_A2 +=
-                        (ds->dir_port == 60092 ?
+                        (ds->ipv4_dirport == 60092 ?
                          1 : 0)
                         );
       tt_int_op(found_A2, OP_EQ, 0);
@@ -2499,7 +2499,7 @@ test_config_adding_dir_servers(void *arg)
                         ds,
                         /* increment the found counter if dir_port matches */
                         found_D0 +=
-                        (ds->dir_port == 60090 ?
+                        (ds->ipv4_dirport == 60090 ?
                          1 : 0)
                         );
       tt_int_op(found_D0, OP_EQ, 1);
@@ -2511,7 +2511,7 @@ test_config_adding_dir_servers(void *arg)
                         ds,
                         /* increment the found counter if dir_port matches */
                         found_B1 +=
-                        (ds->dir_port == 60091 ?
+                        (ds->ipv4_dirport == 60091 ?
                          1 : 0)
                         );
       tt_int_op(found_B1, OP_EQ, 0);
@@ -2523,7 +2523,7 @@ test_config_adding_dir_servers(void *arg)
                         ds,
                         /* increment the found counter if dir_port matches */
                         found_A2 +=
-                        (ds->dir_port == 60092 ?
+                        (ds->ipv4_dirport == 60092 ?
                          1 : 0)
                         );
       tt_int_op(found_A2, OP_EQ, 0);
@@ -2535,7 +2535,7 @@ test_config_adding_dir_servers(void *arg)
                         ds,
                         /* increment the found counter if dir_port matches */
                         found_non_default_fallback +=
-                        (ds->dir_port == 60093 ?
+                        (ds->ipv4_dirport == 60093 ?
                          1 : 0)
                         );
       tt_int_op(found_non_default_fallback, OP_EQ, 0);
@@ -2547,7 +2547,7 @@ test_config_adding_dir_servers(void *arg)
                         ds,
                         /* increment the found counter if dir_port matches */
                         found_default_fallback +=
-                        (ds->dir_port == 60099 ?
+                        (ds->ipv4_dirport == 60099 ?
                          1 : 0)
                         );
       tt_int_op(found_default_fallback, OP_EQ, 0);
@@ -2599,7 +2599,7 @@ test_config_adding_dir_servers(void *arg)
                         ds,
                         /* increment the found counter if dir_port matches */
                         found_D0 +=
-                        (ds->dir_port == 60090 ?
+                        (ds->ipv4_dirport == 60090 ?
                          1 : 0)
                         );
       tt_int_op(found_D0, OP_EQ, 0);
@@ -2611,7 +2611,7 @@ test_config_adding_dir_servers(void *arg)
                         ds,
                         /* increment the found counter if dir_port matches */
                         found_B1 +=
-                        (ds->dir_port == 60091 ?
+                        (ds->ipv4_dirport == 60091 ?
                          1 : 0)
                         );
       tt_int_op(found_B1, OP_EQ, 1);
@@ -2623,7 +2623,7 @@ test_config_adding_dir_servers(void *arg)
                         ds,
                         /* increment the found counter if dir_port matches */
                         found_A2 +=
-                        (ds->dir_port == 60092 ?
+                        (ds->ipv4_dirport == 60092 ?
                          1 : 0)
                         );
       tt_int_op(found_A2, OP_EQ, 1);
@@ -2642,7 +2642,7 @@ test_config_adding_dir_servers(void *arg)
                         ds,
                         /* increment the found counter if dir_port matches */
                         found_D0 +=
-                        (ds->dir_port == 60090 ?
+                        (ds->ipv4_dirport == 60090 ?
                          1 : 0)
                         );
       tt_int_op(found_D0, OP_EQ, 0);
@@ -2654,7 +2654,7 @@ test_config_adding_dir_servers(void *arg)
                         ds,
                         /* increment the found counter if dir_port matches */
                         found_B1 +=
-                        (ds->dir_port == 60091 ?
+                        (ds->ipv4_dirport == 60091 ?
                          1 : 0)
                         );
       tt_int_op(found_B1, OP_EQ, 1);
@@ -2666,7 +2666,7 @@ test_config_adding_dir_servers(void *arg)
                         ds,
                         /* increment the found counter if dir_port matches */
                         found_A2 +=
-                        (ds->dir_port == 60092 ?
+                        (ds->ipv4_dirport == 60092 ?
                          1 : 0)
                         );
       tt_int_op(found_A2, OP_EQ, 1);
@@ -2678,7 +2678,7 @@ test_config_adding_dir_servers(void *arg)
                         ds,
                         /* increment the found counter if dir_port matches */
                         found_non_default_fallback +=
-                        (ds->dir_port == 60093 ?
+                        (ds->ipv4_dirport == 60093 ?
                          1 : 0)
                         );
       tt_int_op(found_non_default_fallback, OP_EQ, 1);
@@ -2690,7 +2690,7 @@ test_config_adding_dir_servers(void *arg)
                         ds,
                         /* increment the found counter if dir_port matches */
                         found_default_fallback +=
-                        (ds->dir_port == 60099 ?
+                        (ds->ipv4_dirport == 60099 ?
                          1 : 0)
                         );
       tt_int_op(found_default_fallback, OP_EQ, 0);
@@ -2743,7 +2743,7 @@ test_config_adding_dir_servers(void *arg)
                         ds,
                         /* increment the found counter if dir_port matches */
                         found_D0 +=
-                        (ds->dir_port == 60090 ?
+                        (ds->ipv4_dirport == 60090 ?
                          1 : 0)
                         );
       tt_int_op(found_D0, OP_EQ, 0);
@@ -2755,7 +2755,7 @@ test_config_adding_dir_servers(void *arg)
                         ds,
                         /* increment the found counter if dir_port matches */
                         found_B1 +=
-                        (ds->dir_port == 60091 ?
+                        (ds->ipv4_dirport == 60091 ?
                          1 : 0)
                         );
       tt_int_op(found_B1, OP_EQ, 1);
@@ -2767,7 +2767,7 @@ test_config_adding_dir_servers(void *arg)
                         ds,
                         /* increment the found counter if dir_port matches */
                         found_A2 +=
-                        (ds->dir_port == 60092 ?
+                        (ds->ipv4_dirport == 60092 ?
                          1 : 0)
                         );
       tt_int_op(found_A2, OP_EQ, 1);
@@ -2786,7 +2786,7 @@ test_config_adding_dir_servers(void *arg)
                         ds,
                         /* increment the found counter if dir_port matches */
                         found_D0 +=
-                        (ds->dir_port == 60090 ?
+                        (ds->ipv4_dirport == 60090 ?
                          1 : 0)
                         );
       tt_int_op(found_D0, OP_EQ, 0);
@@ -2798,7 +2798,7 @@ test_config_adding_dir_servers(void *arg)
                         ds,
                         /* increment the found counter if dir_port matches */
                         found_B1 +=
-                        (ds->dir_port == 60091 ?
+                        (ds->ipv4_dirport == 60091 ?
                          1 : 0)
                         );
       tt_int_op(found_B1, OP_EQ, 1);
@@ -2810,7 +2810,7 @@ test_config_adding_dir_servers(void *arg)
                         ds,
                         /* increment the found counter if dir_port matches */
                         found_A2 +=
-                        (ds->dir_port == 60092 ?
+                        (ds->ipv4_dirport == 60092 ?
                          1 : 0)
                         );
       tt_int_op(found_A2, OP_EQ, 1);
@@ -2822,7 +2822,7 @@ test_config_adding_dir_servers(void *arg)
                         ds,
                         /* increment the found counter if dir_port matches */
                         found_non_default_fallback +=
-                        (ds->dir_port == 60093 ?
+                        (ds->ipv4_dirport == 60093 ?
                          1 : 0)
                         );
       tt_int_op(found_non_default_fallback, OP_EQ, 0);
@@ -2834,7 +2834,7 @@ test_config_adding_dir_servers(void *arg)
                         ds,
                         /* increment the found counter if dir_port matches */
                         found_default_fallback +=
-                        (ds->dir_port == 60099 ?
+                        (ds->ipv4_dirport == 60099 ?
                          1 : 0)
                         );
       tt_int_op(found_default_fallback, OP_EQ, 0);
@@ -2897,7 +2897,7 @@ test_config_adding_dir_servers(void *arg)
                         ds,
                         /* increment the found counter if dir_port matches */
                         found_D0 +=
-                        (ds->dir_port == 60090 ?
+                        (ds->ipv4_dirport == 60090 ?
                          1 : 0)
                         );
       tt_int_op(found_D0, OP_EQ, 0);
@@ -2909,7 +2909,7 @@ test_config_adding_dir_servers(void *arg)
                         ds,
                         /* increment the found counter if dir_port matches */
                         found_B1 +=
-                        (ds->dir_port == 60091 ?
+                        (ds->ipv4_dirport == 60091 ?
                          1 : 0)
                         );
       tt_int_op(found_B1, OP_EQ, 1);
@@ -2921,7 +2921,7 @@ test_config_adding_dir_servers(void *arg)
                         ds,
                         /* increment the found counter if dir_port matches */
                         found_A2 +=
-                        (ds->dir_port == 60092 ?
+                        (ds->ipv4_dirport == 60092 ?
                          1 : 0)
                         );
       tt_int_op(found_A2, OP_EQ, 0);
@@ -2947,7 +2947,7 @@ test_config_adding_dir_servers(void *arg)
                         ds,
                         /* increment the found counter if dir_port matches */
                         found_D0 +=
-                        (ds->dir_port == 60090 ?
+                        (ds->ipv4_dirport == 60090 ?
                          1 : 0)
                         );
       tt_int_op(found_D0, OP_EQ, 0);
@@ -2959,7 +2959,7 @@ test_config_adding_dir_servers(void *arg)
                         ds,
                         /* increment the found counter if dir_port matches */
                         found_B1 +=
-                        (ds->dir_port == 60091 ?
+                        (ds->ipv4_dirport == 60091 ?
                          1 : 0)
                         );
       tt_int_op(found_B1, OP_EQ, 1);
@@ -2971,7 +2971,7 @@ test_config_adding_dir_servers(void *arg)
                         ds,
                         /* increment the found counter if dir_port matches */
                         found_A2 +=
-                        (ds->dir_port == 60092 ?
+                        (ds->ipv4_dirport == 60092 ?
                          1 : 0)
                         );
       tt_int_op(found_A2, OP_EQ, 0);
@@ -2983,7 +2983,7 @@ test_config_adding_dir_servers(void *arg)
                         ds,
                         /* increment the found counter if dir_port matches */
                         found_non_default_fallback +=
-                        (ds->dir_port == 60093 ?
+                        (ds->ipv4_dirport == 60093 ?
                          1 : 0)
                         );
       tt_int_op(found_non_default_fallback, OP_EQ, 1);
@@ -2995,7 +2995,7 @@ test_config_adding_dir_servers(void *arg)
                         ds,
                         /* increment the found counter if dir_port matches */
                         found_default_fallback +=
-                        (ds->dir_port == 60099 ?
+                        (ds->ipv4_dirport == 60099 ?
                          1 : 0)
                         );
       tt_int_op(found_default_fallback, OP_EQ, 0);
@@ -3053,7 +3053,7 @@ test_config_adding_dir_servers(void *arg)
                         ds,
                         /* increment the found counter if dir_port matches */
                         found_D0 +=
-                        (ds->dir_port == 60090 ?
+                        (ds->ipv4_dirport == 60090 ?
                          1 : 0)
                         );
       tt_int_op(found_D0, OP_EQ, 0);
@@ -3065,7 +3065,7 @@ test_config_adding_dir_servers(void *arg)
                         ds,
                         /* increment the found counter if dir_port matches */
                         found_B1 +=
-                        (ds->dir_port == 60091 ?
+                        (ds->ipv4_dirport == 60091 ?
                          1 : 0)
                         );
       tt_int_op(found_B1, OP_EQ, 1);
@@ -3077,7 +3077,7 @@ test_config_adding_dir_servers(void *arg)
                         ds,
                         /* increment the found counter if dir_port matches */
                         found_A2 +=
-                        (ds->dir_port == 60092 ?
+                        (ds->ipv4_dirport == 60092 ?
                          1 : 0)
                         );
       tt_int_op(found_A2, OP_EQ, 0);
@@ -3103,7 +3103,7 @@ test_config_adding_dir_servers(void *arg)
                         ds,
                         /* increment the found counter if dir_port matches */
                         found_D0 +=
-                        (ds->dir_port == 60090 ?
+                        (ds->ipv4_dirport == 60090 ?
                          1 : 0)
                         );
       tt_int_op(found_D0, OP_EQ, 0);
@@ -3115,7 +3115,7 @@ test_config_adding_dir_servers(void *arg)
                         ds,
                         /* increment the found counter if dir_port matches */
                         found_B1 +=
-                        (ds->dir_port == 60091 ?
+                        (ds->ipv4_dirport == 60091 ?
                          1 : 0)
                         );
       tt_int_op(found_B1, OP_EQ, 1);
@@ -3127,7 +3127,7 @@ test_config_adding_dir_servers(void *arg)
                         ds,
                         /* increment the found counter if dir_port matches */
                         found_A2 +=
-                        (ds->dir_port == 60092 ?
+                        (ds->ipv4_dirport == 60092 ?
                          1 : 0)
                         );
       tt_int_op(found_A2, OP_EQ, 0);
@@ -3139,7 +3139,7 @@ test_config_adding_dir_servers(void *arg)
                         ds,
                         /* increment the found counter if dir_port matches */
                         found_non_default_fallback +=
-                        (ds->dir_port == 60093 ?
+                        (ds->ipv4_dirport == 60093 ?
                          1 : 0)
                         );
       tt_int_op(found_non_default_fallback, OP_EQ, 0);
@@ -3151,7 +3151,7 @@ test_config_adding_dir_servers(void *arg)
                         ds,
                         /* increment the found counter if dir_port matches */
                         found_default_fallback +=
-                        (ds->dir_port == 60099 ?
+                        (ds->ipv4_dirport == 60099 ?
                          1 : 0)
                         );
       tt_int_op(found_default_fallback, OP_EQ, 1);
@@ -3219,7 +3219,7 @@ test_config_adding_dir_servers(void *arg)
                         ds,
                         /* increment the found counter if dir_port matches */
                         found_D0 +=
-                        (ds->dir_port == 60090 ?
+                        (ds->ipv4_dirport == 60090 ?
                          1 : 0)
                         );
       tt_int_op(found_D0, OP_EQ, 0);
@@ -3231,7 +3231,7 @@ test_config_adding_dir_servers(void *arg)
                         ds,
                         /* increment the found counter if dir_port matches */
                         found_B1 +=
-                        (ds->dir_port == 60091 ?
+                        (ds->ipv4_dirport == 60091 ?
                          1 : 0)
                         );
       tt_int_op(found_B1, OP_EQ, 0);
@@ -3243,7 +3243,7 @@ test_config_adding_dir_servers(void *arg)
                         ds,
                         /* increment the found counter if dir_port matches */
                         found_A2 +=
-                        (ds->dir_port == 60092 ?
+                        (ds->ipv4_dirport == 60092 ?
                          1 : 0)
                         );
       tt_int_op(found_A2, OP_EQ, 1);
@@ -3270,7 +3270,7 @@ test_config_adding_dir_servers(void *arg)
                         ds,
                         /* increment the found counter if dir_port matches */
                         found_D0 +=
-                        (ds->dir_port == 60090 ?
+                        (ds->ipv4_dirport == 60090 ?
                          1 : 0)
                         );
       tt_int_op(found_D0, OP_EQ, 0);
@@ -3282,7 +3282,7 @@ test_config_adding_dir_servers(void *arg)
                         ds,
                         /* increment the found counter if dir_port matches */
                         found_B1 +=
-                        (ds->dir_port == 60091 ?
+                        (ds->ipv4_dirport == 60091 ?
                          1 : 0)
                         );
       tt_int_op(found_B1, OP_EQ, 0);
@@ -3294,7 +3294,7 @@ test_config_adding_dir_servers(void *arg)
                         ds,
                         /* increment the found counter if dir_port matches */
                         found_A2 +=
-                        (ds->dir_port == 60092 ?
+                        (ds->ipv4_dirport == 60092 ?
                          1 : 0)
                         );
       tt_int_op(found_A2, OP_EQ, 1);
@@ -3306,7 +3306,7 @@ test_config_adding_dir_servers(void *arg)
                         ds,
                         /* increment the found counter if dir_port matches */
                         found_non_default_fallback +=
-                        (ds->dir_port == 60093 ?
+                        (ds->ipv4_dirport == 60093 ?
                          1 : 0)
                         );
       tt_int_op(found_non_default_fallback, OP_EQ, 1);
@@ -3318,7 +3318,7 @@ test_config_adding_dir_servers(void *arg)
                         ds,
                         /* increment the found counter if dir_port matches */
                         found_default_fallback +=
-                        (ds->dir_port == 60099 ?
+                        (ds->ipv4_dirport == 60099 ?
                          1 : 0)
                         );
       tt_int_op(found_default_fallback, OP_EQ, 0);
@@ -3379,7 +3379,7 @@ test_config_adding_dir_servers(void *arg)
                         ds,
                         /* increment the found counter if dir_port matches */
                         found_D0 +=
-                        (ds->dir_port == 60090 ?
+                        (ds->ipv4_dirport == 60090 ?
                          1 : 0)
                         );
       tt_int_op(found_D0, OP_EQ, 0);
@@ -3391,7 +3391,7 @@ test_config_adding_dir_servers(void *arg)
                         ds,
                         /* increment the found counter if dir_port matches */
                         found_B1 +=
-                        (ds->dir_port == 60091 ?
+                        (ds->ipv4_dirport == 60091 ?
                          1 : 0)
                         );
       tt_int_op(found_B1, OP_EQ, 0);
@@ -3403,7 +3403,7 @@ test_config_adding_dir_servers(void *arg)
                         ds,
                         /* increment the found counter if dir_port matches */
                         found_A2 +=
-                        (ds->dir_port == 60092 ?
+                        (ds->ipv4_dirport == 60092 ?
                          1 : 0)
                         );
       tt_int_op(found_A2, OP_EQ, 1);
@@ -3430,7 +3430,7 @@ test_config_adding_dir_servers(void *arg)
                         ds,
                         /* increment the found counter if dir_port matches */
                         found_D0 +=
-                        (ds->dir_port == 60090 ?
+                        (ds->ipv4_dirport == 60090 ?
                          1 : 0)
                         );
       tt_int_op(found_D0, OP_EQ, 0);
@@ -3442,7 +3442,7 @@ test_config_adding_dir_servers(void *arg)
                         ds,
                         /* increment the found counter if dir_port matches */
                         found_B1 +=
-                        (ds->dir_port == 60091 ?
+                        (ds->ipv4_dirport == 60091 ?
                          1 : 0)
                         );
       tt_int_op(found_B1, OP_EQ, 0);
@@ -3454,7 +3454,7 @@ test_config_adding_dir_servers(void *arg)
                         ds,
                         /* increment the found counter if dir_port matches */
                         found_A2 +=
-                        (ds->dir_port == 60092 ?
+                        (ds->ipv4_dirport == 60092 ?
                          1 : 0)
                         );
       tt_int_op(found_A2, OP_EQ, 1);
@@ -3466,7 +3466,7 @@ test_config_adding_dir_servers(void *arg)
                         ds,
                         /* increment the found counter if dir_port matches */
                         found_non_default_fallback +=
-                        (ds->dir_port == 60093 ?
+                        (ds->ipv4_dirport == 60093 ?
                          1 : 0)
                         );
       tt_int_op(found_non_default_fallback, OP_EQ, 0);
@@ -3478,7 +3478,7 @@ test_config_adding_dir_servers(void *arg)
                         ds,
                         /* increment the found counter if dir_port matches */
                         found_default_fallback +=
-                        (ds->dir_port == 60099 ?
+                        (ds->ipv4_dirport == 60099 ?
                          1 : 0)
                         );
       tt_int_op(found_default_fallback, OP_EQ, 0);
@@ -3546,7 +3546,7 @@ test_config_adding_dir_servers(void *arg)
                         ds,
                         /* increment the found counter if dir_port matches */
                         found_D0 +=
-                        (ds->dir_port == 60090 ?
+                        (ds->ipv4_dirport == 60090 ?
                          1 : 0)
                         );
       tt_int_op(found_D0, OP_EQ, 0);
@@ -3558,7 +3558,7 @@ test_config_adding_dir_servers(void *arg)
                         ds,
                         /* increment the found counter if dir_port matches */
                         found_B1 +=
-                        (ds->dir_port == 60091 ?
+                        (ds->ipv4_dirport == 60091 ?
                          1 : 0)
                         );
       tt_int_op(found_B1, OP_EQ, 0);
@@ -3570,7 +3570,7 @@ test_config_adding_dir_servers(void *arg)
                         ds,
                         /* increment the found counter if dir_port matches */
                         found_A2 +=
-                        (ds->dir_port == 60092 ?
+                        (ds->ipv4_dirport == 60092 ?
                          1 : 0)
                         );
       tt_int_op(found_A2, OP_EQ, 0);
@@ -3597,7 +3597,7 @@ test_config_adding_dir_servers(void *arg)
                         ds,
                         /* increment the found counter if dir_port matches */
                         found_D0 +=
-                        (ds->dir_port == 60090 ?
+                        (ds->ipv4_dirport == 60090 ?
                          1 : 0)
                         );
       tt_int_op(found_D0, OP_EQ, 0);
@@ -3609,7 +3609,7 @@ test_config_adding_dir_servers(void *arg)
                         ds,
                         /* increment the found counter if dir_port matches */
                         found_B1 +=
-                        (ds->dir_port == 60091 ?
+                        (ds->ipv4_dirport == 60091 ?
                          1 : 0)
                         );
       tt_int_op(found_B1, OP_EQ, 0);
@@ -3621,7 +3621,7 @@ test_config_adding_dir_servers(void *arg)
                         ds,
                         /* increment the found counter if dir_port matches */
                         found_A2 +=
-                        (ds->dir_port == 60092 ?
+                        (ds->ipv4_dirport == 60092 ?
                          1 : 0)
                         );
       tt_int_op(found_A2, OP_EQ, 0);
@@ -3633,7 +3633,7 @@ test_config_adding_dir_servers(void *arg)
                         ds,
                         /* increment the found counter if dir_port matches */
                         found_non_default_fallback +=
-                        (ds->dir_port == 60093 ?
+                        (ds->ipv4_dirport == 60093 ?
                          1 : 0)
                         );
       tt_int_op(found_non_default_fallback, OP_EQ, 1);
@@ -3645,7 +3645,7 @@ test_config_adding_dir_servers(void *arg)
                         ds,
                         /* increment the found counter if dir_port matches */
                         found_default_fallback +=
-                        (ds->dir_port == 60099 ?
+                        (ds->ipv4_dirport == 60099 ?
                          1 : 0)
                         );
       tt_int_op(found_default_fallback, OP_EQ, 0);
@@ -3711,7 +3711,7 @@ test_config_adding_dir_servers(void *arg)
                         ds,
                         /* increment the found counter if dir_port matches */
                         found_D0 +=
-                        (ds->dir_port == 60090 ?
+                        (ds->ipv4_dirport == 60090 ?
                          1 : 0)
                         );
       tt_int_op(found_D0, OP_EQ, 0);
@@ -3723,7 +3723,7 @@ test_config_adding_dir_servers(void *arg)
                         ds,
                         /* increment the found counter if dir_port matches */
                         found_B1 +=
-                        (ds->dir_port == 60091 ?
+                        (ds->ipv4_dirport == 60091 ?
                          1 : 0)
                         );
       tt_int_op(found_B1, OP_EQ, 0);
@@ -3735,7 +3735,7 @@ test_config_adding_dir_servers(void *arg)
                         ds,
                         /* increment the found counter if dir_port matches */
                         found_A2 +=
-                        (ds->dir_port == 60092 ?
+                        (ds->ipv4_dirport == 60092 ?
                          1 : 0)
                         );
       tt_int_op(found_A2, OP_EQ, 0);
@@ -3762,7 +3762,7 @@ test_config_adding_dir_servers(void *arg)
                         ds,
                         /* increment the found counter if dir_port matches */
                         found_D0 +=
-                        (ds->dir_port == 60090 ?
+                        (ds->ipv4_dirport == 60090 ?
                          1 : 0)
                         );
       tt_int_op(found_D0, OP_EQ, 0);
@@ -3774,7 +3774,7 @@ test_config_adding_dir_servers(void *arg)
                         ds,
                         /* increment the found counter if dir_port matches */
                         found_B1 +=
-                        (ds->dir_port == 60091 ?
+                        (ds->ipv4_dirport == 60091 ?
                          1 : 0)
                         );
       tt_int_op(found_B1, OP_EQ, 0);
@@ -3786,7 +3786,7 @@ test_config_adding_dir_servers(void *arg)
                         ds,
                         /* increment the found counter if dir_port matches */
                         found_A2 +=
-                        (ds->dir_port == 60092 ?
+                        (ds->ipv4_dirport == 60092 ?
                          1 : 0)
                         );
       tt_int_op(found_A2, OP_EQ, 0);
@@ -3798,7 +3798,7 @@ test_config_adding_dir_servers(void *arg)
                         ds,
                         /* increment the found counter if dir_port matches */
                         found_non_default_fallback +=
-                        (ds->dir_port == 60093 ?
+                        (ds->ipv4_dirport == 60093 ?
                          1 : 0)
                         );
       tt_int_op(found_non_default_fallback, OP_EQ, 0);
@@ -3810,7 +3810,7 @@ test_config_adding_dir_servers(void *arg)
                         ds,
                         /* increment the found counter if dir_port matches */
                         found_default_fallback +=
-                        (ds->dir_port == 60099 ?
+                        (ds->ipv4_dirport == 60099 ?
                          1 : 0)
                         );
       tt_int_op(found_default_fallback, OP_EQ, 1);
@@ -4051,7 +4051,7 @@ test_config_directory_fetch(void *arg)
   mock_router_my_exit_policy_is_reject_star_result = 1;
 
   mock_advertised_server_mode_result = 1;
-  routerinfo.dir_port = 1;
+  routerinfo.ipv4_dirport =  1;
   mock_router_get_my_routerinfo_result = &routerinfo;
   tt_assert(server_mode(options) == 1);
   tt_assert(public_server_mode(options) == 1);
@@ -4060,7 +4060,7 @@ test_config_directory_fetch(void *arg)
             OP_EQ, 0);
 
   mock_advertised_server_mode_result = 0;
-  routerinfo.dir_port = 1;
+  routerinfo.ipv4_dirport =  1;
   mock_router_get_my_routerinfo_result = &routerinfo;
   tt_assert(server_mode(options) == 1);
   tt_assert(public_server_mode(options) == 1);
@@ -4077,7 +4077,7 @@ test_config_directory_fetch(void *arg)
             OP_EQ, 0);
 
   mock_advertised_server_mode_result = 1;
-  routerinfo.dir_port = 0;
+  routerinfo.ipv4_dirport =  0;
   routerinfo.supports_tunnelled_dir_requests = 0;
   mock_router_get_my_routerinfo_result = &routerinfo;
   tt_assert(server_mode(options) == 1);
@@ -4087,7 +4087,7 @@ test_config_directory_fetch(void *arg)
             OP_EQ, 0);
 
   mock_advertised_server_mode_result = 1;
-  routerinfo.dir_port = 1;
+  routerinfo.ipv4_dirport =  1;
   routerinfo.supports_tunnelled_dir_requests = 1;
   mock_router_get_my_routerinfo_result = &routerinfo;
   tt_assert(server_mode(options) == 1);

--- a/src/test/test_connection.c
+++ b/src/test/test_connection.c
@@ -882,10 +882,8 @@ mock_node_get_mutable_by_id(const char *digest)
   test_node.ri = &node_ri;
   memset(test_node.identity, 'c', sizeof(test_node.identity));
 
-  tor_addr_t ipv4_addr;
-  tor_addr_parse(&ipv4_addr, "18.0.0.1");
-  node_ri.addr = tor_addr_to_ipv4h(&ipv4_addr);
-  node_ri.or_port = 1;
+  tor_addr_parse(&node_ri.ipv4_addr, "18.0.0.1");
+  node_ri.ipv4_orport = 1;
 
   return &test_node;
 }

--- a/src/test/test_dir_common.c
+++ b/src/test/test_dir_common.c
@@ -97,9 +97,9 @@ dir_common_gen_routerstatus_for_v3ns(int idx, time_t now)
       strlcpy(rs->nickname, "router2", sizeof(rs->nickname));
       memset(rs->identity_digest, TEST_DIR_ROUTER_ID_1, DIGEST_LEN);
       memset(rs->descriptor_digest, TEST_DIR_ROUTER_DD_1, DIGEST_LEN);
-      rs->addr = 0x99008801;
-      rs->or_port = 443;
-      rs->dir_port = 8000;
+      tor_addr_from_ipv4h(&rs->ipv4_addr, 0x99008801);
+      rs->ipv4_orport = 443;
+      rs->ipv4_dirport = 8000;
       /* all flags but running and v2dir cleared */
       rs->is_flagged_running = 1;
       rs->is_v2_dir = 1;
@@ -114,9 +114,9 @@ dir_common_gen_routerstatus_for_v3ns(int idx, time_t now)
       strlcpy(rs->nickname, "router1", sizeof(rs->nickname));
       memset(rs->identity_digest, TEST_DIR_ROUTER_ID_2, DIGEST_LEN);
       memset(rs->descriptor_digest, TEST_DIR_ROUTER_DD_2, DIGEST_LEN);
-      rs->addr = 0x99009901;
-      rs->or_port = 443;
-      rs->dir_port = 0;
+      tor_addr_from_ipv4h(&rs->ipv4_addr, 0x99009901);
+      rs->ipv4_orport = 443;
+      rs->ipv4_dirport = 0;
       tor_addr_parse(&addr_ipv6, "[1:2:3::4]");
       tor_addr_copy(&rs->ipv6_addr, &addr_ipv6);
       rs->ipv6_orport = 4711;
@@ -132,9 +132,9 @@ dir_common_gen_routerstatus_for_v3ns(int idx, time_t now)
       strlcpy(rs->nickname, "router3", sizeof(rs->nickname));
       memset(rs->identity_digest, TEST_DIR_ROUTER_ID_3, DIGEST_LEN);
       memset(rs->descriptor_digest, TEST_DIR_ROUTER_DD_3, DIGEST_LEN);
-      rs->addr = 0xAA009901;
-      rs->or_port = 400;
-      rs->dir_port = 9999;
+      tor_addr_from_ipv4h(&rs->ipv4_addr, 0xAA009901);
+      rs->ipv4_orport = 400;
+      rs->ipv4_dirport = 9999;
       rs->is_authority = rs->is_exit = rs->is_stable = rs->is_fast =
         rs->is_flagged_running = rs->is_valid = rs->is_v2_dir =
         rs->is_possible_guard = 1;
@@ -148,9 +148,9 @@ dir_common_gen_routerstatus_for_v3ns(int idx, time_t now)
       strlcpy(rs->nickname, "router4", sizeof(rs->nickname));
       memset(rs->identity_digest, TEST_DIR_ROUTER_ID_4, DIGEST_LEN);
       memset(rs->descriptor_digest, TEST_DIR_ROUTER_DD_4, DIGEST_LEN);
-      rs->addr = 0xC0000203;
-      rs->or_port = 500;
-      rs->dir_port = 1999;
+      tor_addr_from_ipv4h(&rs->ipv4_addr, 0xC0000203);
+      rs->ipv4_orport = 500;
+      rs->ipv4_dirport = 1999;
       rs->is_v2_dir = 1;
       /* Running flag (and others) cleared */
       break;
@@ -313,9 +313,9 @@ dir_common_construct_vote_1(networkstatus_t **vote, authority_cert_t *cert,
   voter = tor_malloc_zero(sizeof(networkstatus_voter_info_t));
   voter->nickname = tor_strdup("Voter1");
   voter->address = tor_strdup("1.2.3.4");
-  voter->addr = 0x01020304;
-  voter->dir_port = 80;
-  voter->or_port = 9000;
+  tor_addr_from_ipv4h(&voter->ipv4_addr, 0x01020304);
+  voter->ipv4_dirport = 80;
+  voter->ipv4_orport = 9000;
   voter->contact = tor_strdup("voter@example.com");
   crypto_pk_get_digest(cert->identity_key, voter->identity_digest);
   /*
@@ -362,9 +362,9 @@ dir_common_construct_vote_2(networkstatus_t **vote, authority_cert_t *cert,
   voter = tor_malloc_zero(sizeof(networkstatus_voter_info_t));
   voter->nickname = tor_strdup("Voter2");
   voter->address = tor_strdup("2.3.4.5");
-  voter->addr = 0x02030405;
-  voter->dir_port = 80;
-  voter->or_port = 9000;
+  tor_addr_from_ipv4h(&voter->ipv4_addr, 0x02030405);
+  voter->ipv4_dirport = 80;
+  voter->ipv4_orport = 9000;
   voter->contact = tor_strdup("voter@example.com");
   crypto_pk_get_digest(cert->identity_key, voter->identity_digest);
   /*
@@ -412,9 +412,9 @@ dir_common_construct_vote_3(networkstatus_t **vote, authority_cert_t *cert,
   voter = tor_malloc_zero(sizeof(networkstatus_voter_info_t));
   voter->nickname = tor_strdup("Voter2");
   voter->address = tor_strdup("3.4.5.6");
-  voter->addr = 0x03040506;
-  voter->dir_port = 80;
-  voter->or_port = 9000;
+  tor_addr_from_ipv4h(&voter->ipv4_addr, 0x03040506);
+  voter->ipv4_dirport = 80;
+  voter->ipv4_orport = 9000;
   voter->contact = tor_strdup("voter@example.com");
   crypto_pk_get_digest(cert->identity_key, voter->identity_digest);
   memset(voter->legacy_id_digest, (int)'A', DIGEST_LEN);

--- a/src/test/test_dos.c
+++ b/src/test/test_dos.c
@@ -446,7 +446,7 @@ test_known_relay(void *arg)
   tor_addr_parse(&or_conn.real_addr, "42.42.42.42");
 
   rs = tor_malloc_zero(sizeof(*rs));
-  rs->addr = tor_addr_to_ipv4h(&or_conn.real_addr);
+  tor_addr_copy(&rs->ipv4_addr, &or_conn.real_addr);
   crypto_rand(rs->identity_digest, sizeof(rs->identity_digest));
   smartlist_add(dummy_ns->routerstatus_list, rs);
 

--- a/src/test/test_guardfraction.c
+++ b/src/test/test_guardfraction.c
@@ -51,9 +51,9 @@ gen_vote_routerstatus_for_tests(const char *digest_in_hex, int is_guard)
     vrs->version = tor_strdup("0.1.2.14");
     strlcpy(rs->nickname, "router2", sizeof(rs->nickname));
     memset(rs->descriptor_digest, 78, DIGEST_LEN);
-    rs->addr = 0x99008801;
-    rs->or_port = 443;
-    rs->dir_port = 8000;
+    tor_addr_from_ipv4h(&rs->ipv4_addr, 0x99008801);
+    rs->ipv4_orport = 443;
+    rs->ipv4_dirport = 8000;
     /* all flags but running cleared */
     rs->is_flagged_running = 1;
     vrs->has_measured_bw = 1;

--- a/src/test/test_hs_common.c
+++ b/src/test/test_hs_common.c
@@ -293,7 +293,6 @@ helper_add_hsdir_to_networkstatus(networkstatus_t *ns,
   routerstatus_t *rs = tor_malloc_zero(sizeof(routerstatus_t));
   routerinfo_t *ri = tor_malloc_zero(sizeof(routerinfo_t));
   uint8_t identity[DIGEST_LEN];
-  tor_addr_t ipv4_addr;
   node_t *node = NULL;
 
   memset(identity, identity_idx, sizeof(identity));
@@ -302,9 +301,8 @@ helper_add_hsdir_to_networkstatus(networkstatus_t *ns,
   rs->is_hs_dir = is_hsdir;
   rs->pv.supports_v3_hsdir = 1;
   strlcpy(rs->nickname, nickname, sizeof(rs->nickname));
-  tor_addr_parse(&ipv4_addr, "1.2.3.4");
-  ri->addr = tor_addr_to_ipv4h(&ipv4_addr);
-  rs->addr = tor_addr_to_ipv4h(&ipv4_addr);
+  tor_addr_parse(&ri->ipv4_addr, "1.2.3.4");
+  tor_addr_parse(&rs->ipv4_addr, "1.2.3.4");
   ri->nickname = tor_strdup(nickname);
   ri->protocol_list = tor_strdup("HSDir=1-2 LinkAuth=3");
   memcpy(ri->cache_info.identity_digest, identity, DIGEST_LEN);

--- a/src/test/test_hs_service.c
+++ b/src/test/test_hs_service.c
@@ -1545,14 +1545,12 @@ test_build_update_descriptors(void *arg)
 
   /* Now, we'll setup a node_t. */
   {
-    tor_addr_t ipv4_addr;
     curve25519_secret_key_t curve25519_secret_key;
 
     memset(&ri, 0, sizeof(routerinfo_t));
 
-    tor_addr_parse(&ipv4_addr, "127.0.0.1");
-    ri.addr = tor_addr_to_ipv4h(&ipv4_addr);
-    ri.or_port = 1337;
+    tor_addr_parse(&ri.ipv4_addr, "127.0.0.1");
+    ri.ipv4_orport = 1337;
     ri.purpose = ROUTER_PURPOSE_GENERAL;
     /* Ugly yes but we never free the "ri" object so this just makes things
      * easier. */

--- a/src/test/test_policy.c
+++ b/src/test/test_policy.c
@@ -1125,7 +1125,7 @@ test_policy_has_address_helper(const smartlist_t *policy_list,
   return 0;
 }
 
-#define TEST_IPV4_ADDR (0x01020304)
+#define TEST_IPV4_ADDR ("1.2.3.4")
 #define TEST_IPV6_ADDR ("2002::abcd")
 
 /** Run unit tests for rejecting the configured addresses on this exit relay
@@ -1138,7 +1138,7 @@ test_policies_reject_exit_address(void *arg)
   smartlist_t *ipv4_list, *ipv6_list, *both_list, *dupl_list;
   (void)arg;
 
-  tor_addr_from_ipv4h(&ipv4_addr, TEST_IPV4_ADDR);
+  tor_addr_parse(&ipv4_addr, TEST_IPV4_ADDR);
   tor_addr_parse(&ipv6_addr, TEST_IPV6_ADDR);
 
   ipv4_list = smartlist_new();
@@ -1256,7 +1256,7 @@ test_policies_reject_port_address(void *arg)
   test_configured_ports = smartlist_new();
 
   ipv4_port = port_cfg_new(0);
-  tor_addr_from_ipv4h(&ipv4_port->addr, TEST_IPV4_ADDR);
+  tor_addr_parse(&ipv4_port->addr, TEST_IPV4_ADDR);
   smartlist_add(test_configured_ports, ipv4_port);
 
   ipv6_port = port_cfg_new(0);
@@ -1374,7 +1374,7 @@ test_policies_reject_interface_address(void *arg)
   }
 
   /* Now do it all again, but mocked */
-  tor_addr_from_ipv4h(&ipv4_addr, TEST_IPV4_ADDR);
+  tor_addr_parse(&ipv4_addr, TEST_IPV4_ADDR);
   mock_ipv4_addrs = smartlist_new();
   smartlist_add(mock_ipv4_addrs, (void *)&ipv4_addr);
 
@@ -1529,7 +1529,7 @@ mock_router_get_my_routerinfo_with_err(int *err)
 }
 
 #define DEFAULT_POLICY_STRING "reject *:*"
-#define TEST_IPV4_ADDR (0x02040608)
+#define TEST_IPV4_ADDR ("2.4.6.8")
 #define TEST_IPV6_ADDR ("2003::ef01")
 
 static or_options_t mock_options;
@@ -1608,13 +1608,13 @@ test_policies_getinfo_helper_policies(void *arg)
   tt_assert(strlen(answer) == 0 || !strcasecmp(answer, DEFAULT_POLICY_STRING));
   tor_free(answer);
 
-  mock_my_routerinfo.addr = TEST_IPV4_ADDR;
+  tor_addr_parse(&mock_my_routerinfo.ipv4_addr, TEST_IPV4_ADDR);
   tor_addr_parse(&mock_my_routerinfo.ipv6_addr, TEST_IPV6_ADDR);
   append_exit_policy_string(&mock_my_routerinfo.exit_policy, "accept *4:*");
   append_exit_policy_string(&mock_my_routerinfo.exit_policy, "reject *6:*");
 
   mock_options.IPv6Exit = 1;
-  tor_addr_from_ipv4h(
+  tor_addr_parse(
       &mock_options.OutboundBindAddresses[OUTBOUND_ADDR_EXIT][0],
       TEST_IPV4_ADDR);
   tor_addr_parse(
@@ -2243,9 +2243,9 @@ test_policies_fascist_firewall_choose_address(void *arg)
   routerstatus_t fake_rs;
   memset(&fake_rs, 0, sizeof(routerstatus_t));
   /* In a routerstatus, the OR and Dir addresses are the same */
-  fake_rs.addr = tor_addr_to_ipv4h(&ipv4_or_ap.addr);
-  fake_rs.or_port = ipv4_or_ap.port;
-  fake_rs.dir_port = ipv4_dir_ap.port;
+  tor_addr_copy(&fake_rs.ipv4_addr, &ipv4_or_ap.addr);
+  fake_rs.ipv4_orport = ipv4_or_ap.port;
+  fake_rs.ipv4_dirport = ipv4_dir_ap.port;
 
   tor_addr_copy(&fake_rs.ipv6_addr, &ipv6_or_ap.addr);
   fake_rs.ipv6_orport = ipv6_or_ap.port;

--- a/src/test/test_router.c
+++ b/src/test/test_router.c
@@ -61,8 +61,8 @@ rtr_tests_router_get_my_routerinfo(void)
 
     mock_routerinfo = tor_malloc_zero(sizeof(routerinfo_t));
     mock_routerinfo->nickname = tor_strdup("ConlonNancarrow");
-    mock_routerinfo->addr = 123456789;
-    mock_routerinfo->or_port = 443;
+    tor_addr_from_ipv4h(&mock_routerinfo->ipv4_addr, 123456789);
+    mock_routerinfo->ipv4_orport = 443;
     mock_routerinfo->platform = tor_strdup("unittest");
     mock_routerinfo->cache_info.published_on = now;
     mock_routerinfo->identity_pkey = crypto_pk_dup_key(ident_key);

--- a/src/test/test_routerlist.c
+++ b/src/test/test_routerlist.c
@@ -341,18 +341,18 @@ test_router_pick_directory_server_impl(void *arg)
 
   node_router1->rs->is_v2_dir = 0;
   node_router3->rs->is_v2_dir = 0;
-  tmp_dirport1 = node_router1->rs->dir_port;
-  tmp_dirport3 = node_router3->rs->dir_port;
-  node_router1->rs->dir_port = 0;
-  node_router3->rs->dir_port = 0;
+  tmp_dirport1 = node_router1->rs->ipv4_dirport;
+  tmp_dirport3 = node_router3->rs->ipv4_dirport;
+  node_router1->rs->ipv4_dirport = 0;
+  node_router3->rs->ipv4_dirport = 0;
   rs = router_pick_directory_server_impl(V3_DIRINFO, flags, NULL);
   tt_ptr_op(rs, OP_NE, NULL);
   tt_assert(tor_memeq(rs->identity_digest, router2_id, DIGEST_LEN));
   rs = NULL;
   node_router1->rs->is_v2_dir = 1;
   node_router3->rs->is_v2_dir = 1;
-  node_router1->rs->dir_port = tmp_dirport1;
-  node_router3->rs->dir_port = tmp_dirport3;
+  node_router1->rs->ipv4_dirport = tmp_dirport1;
+  node_router3->rs->ipv4_dirport = tmp_dirport3;
 
   node_router1->is_valid = 0;
   node_router3->is_valid = 0;
@@ -381,23 +381,23 @@ test_router_pick_directory_server_impl(void *arg)
   options->ReachableORAddresses = policy_line;
   policies_parse_from_options(options);
 
-  node_router1->rs->or_port = 444;
-  node_router2->rs->or_port = 443;
-  node_router3->rs->or_port = 442;
+  node_router1->rs->ipv4_orport = 444;
+  node_router2->rs->ipv4_orport = 443;
+  node_router3->rs->ipv4_orport = 442;
   rs = router_pick_directory_server_impl(V3_DIRINFO, flags, NULL);
   tt_ptr_op(rs, OP_NE, NULL);
   tt_assert(tor_memeq(rs->identity_digest, router3_id, DIGEST_LEN));
-  node_router1->rs->or_port = 442;
-  node_router2->rs->or_port = 443;
-  node_router3->rs->or_port = 444;
+  node_router1->rs->ipv4_orport = 442;
+  node_router2->rs->ipv4_orport = 443;
+  node_router3->rs->ipv4_orport = 444;
   rs = router_pick_directory_server_impl(V3_DIRINFO, flags, NULL);
   tt_ptr_op(rs, OP_NE, NULL);
   tt_assert(tor_memeq(rs->identity_digest, router1_id, DIGEST_LEN));
 
   /* Fascist firewall and overloaded */
-  node_router1->rs->or_port = 442;
-  node_router2->rs->or_port = 443;
-  node_router3->rs->or_port = 442;
+  node_router1->rs->ipv4_orport = 442;
+  node_router2->rs->ipv4_orport = 443;
+  node_router3->rs->ipv4_orport = 442;
   node_router3->rs->last_dir_503_at = now;
   rs = router_pick_directory_server_impl(V3_DIRINFO, flags, NULL);
   tt_ptr_op(rs, OP_NE, NULL);
@@ -410,12 +410,12 @@ test_router_pick_directory_server_impl(void *arg)
   policy_line->value = tor_strdup("accept *:80, reject *:*");
   options->ReachableDirAddresses = policy_line;
   policies_parse_from_options(options);
-  node_router1->rs->or_port = 442;
-  node_router2->rs->or_port = 441;
-  node_router3->rs->or_port = 443;
-  node_router1->rs->dir_port = 80;
-  node_router2->rs->dir_port = 80;
-  node_router3->rs->dir_port = 81;
+  node_router1->rs->ipv4_orport = 442;
+  node_router2->rs->ipv4_orport = 441;
+  node_router3->rs->ipv4_orport = 443;
+  node_router1->rs->ipv4_dirport = 80;
+  node_router2->rs->ipv4_dirport = 80;
+  node_router3->rs->ipv4_dirport = 81;
   node_router1->rs->last_dir_503_at = now;
   rs = router_pick_directory_server_impl(V3_DIRINFO, flags, NULL);
   tt_ptr_op(rs, OP_NE, NULL);

--- a/src/test/test_routerset.c
+++ b/src/test/test_routerset.c
@@ -1438,8 +1438,8 @@ test_rset_contains_router_ipv4(void *arg)
   set = routerset_new();
   s = "10.0.0.1";
   r = routerset_parse(set, s, "");
-  ri.addr = htonl(0x0a000001); /* 10.0.0.1 */
-  ri.or_port = 1234;
+  tor_addr_from_ipv4h(&ri.ipv4_addr, 0x0a000001);
+  ri.ipv4_orport = 1234;
 
   r = routerset_contains_router(set, &ri, country);
   tt_int_op(r, OP_EQ, 3);

--- a/src/test/test_voting_flags.c
+++ b/src/test/test_voting_flags.c
@@ -42,10 +42,10 @@ setup_cfg(flag_vote_test_cfg_t *c)
   c->ri.cache_info.published_on = c->now - 100;
   c->expected.published_on = c->now - 100;
 
-  c->ri.addr = 0x7f010105;
-  c->expected.addr = 0x7f010105;
-  c->ri.or_port = 9090;
-  c->expected.or_port = 9090;
+  tor_addr_from_ipv4h(&c->ri.ipv4_addr, 0x7f010105);
+  tor_addr_from_ipv4h(&c->expected.ipv4_addr, 0x7f010105);
+  c->ri.ipv4_orport = 9090;
+  c->expected.ipv4_orport = 9090;
 
   tor_addr_make_null(&c->ri.ipv6_addr, AF_INET6);
   tor_addr_make_null(&c->expected.ipv6_addr, AF_INET6);
@@ -69,9 +69,9 @@ check_result(flag_vote_test_cfg_t *c)
 
   // identity_digest and descriptor_digest are not set here.
 
-  tt_uint_op(rs.addr, OP_EQ, c->expected.addr);
-  tt_uint_op(rs.or_port, OP_EQ, c->expected.or_port);
-  tt_uint_op(rs.dir_port, OP_EQ, c->expected.dir_port);
+  tt_assert(tor_addr_eq(&rs.ipv4_addr, &c->expected.ipv4_addr));
+  tt_uint_op(rs.ipv4_orport, OP_EQ, c->expected.ipv4_orport);
+  tt_uint_op(rs.ipv4_dirport, OP_EQ, c->expected.ipv4_dirport);
 
   tt_assert(tor_addr_eq(&rs.ipv6_addr, &c->expected.ipv6_addr));
   tt_uint_op(rs.ipv6_orport, OP_EQ, c->expected.ipv6_orport);


### PR DESCRIPTION
This changes a LOT of code but in the end, behavior is the same.
Unfortunately, many functions had to be changed to accomodate but in majority
of cases, to become simpler.

Functions are also removed specifically those that were there to convert an
IPv4 as a host format to a tor_addr_t. Those are not needed anymore.

The IPv4 address field has been standardized to "ipv4_addr", the ORPort to
"ipv4_orport" (currently IPv6 uses ipv6_orport) and DirPort to "ipv4_dirport".

This is related to Sponsor 55 work that adds IPv6 support for relays and this
work is needed in order to have a common interface between IPv4 and IPv6.

Closes #40043.

Signed-off-by: David Goulet <dgoulet@torproject.org>