### PR TITLE
node: Standardize interface of format_node_description()

### DIFF
--- a/src/feature/nodelist/describe.c
+++ b/src/feature/nodelist/describe.c
@@ -36,8 +36,8 @@ STATIC const char *
 format_node_description(char *buf,
                         const char *id_digest,
                         const char *nickname,
-                        const tor_addr_t *ipv6_addr,
-                        const tor_addr_t *ipv4_addr)
+                        const tor_addr_t *ipv4_addr,
+                        const tor_addr_t *ipv6_addr)
 {
   size_t rv = 0;
   bool has_ipv6 = ipv6_addr && !tor_addr_is_null(ipv6_addr);
@@ -129,8 +129,8 @@ router_describe(const routerinfo_t *ri)
   return format_node_description(buf,
                                  ri->cache_info.identity_digest,
                                  ri->nickname,
-                                 &ri->ipv6_addr,
-                                 &ri->ipv4_addr);
+                                 &ri->ipv4_addr,
+                                 &ri->ipv6_addr);
 }
 
 /** Return a human-readable description of the node_t <b>node</b>.
@@ -169,8 +169,8 @@ node_describe(const node_t *node)
   return format_node_description(buf,
                                  node->identity,
                                  nickname,
-                                 ipv6_addr,
-                                 ipv4_addr);
+                                 ipv4_addr,
+                                 ipv6_addr);
 }
 
 /** Return a human-readable description of the routerstatus_t <b>rs</b>.
@@ -189,8 +189,8 @@ routerstatus_describe(const routerstatus_t *rs)
   return format_node_description(buf,
                                  rs->identity_digest,
                                  rs->nickname,
-                                 &rs->ipv6_addr,
-                                 &rs->ipv4_addr);
+                                 &rs->ipv4_addr,
+                                 &rs->ipv6_addr);
 }
 
 /** Return a human-readable description of the extend_info_t <b>ei</b>.
@@ -214,8 +214,8 @@ extend_info_describe(const extend_info_t *ei)
   return format_node_description(buf,
                                  ei->identity_digest,
                                  ei->nickname,
-                                 addr6,
-                                 addr4);
+                                 addr4,
+                                 addr6);
 }
 
 /** Set <b>buf</b> (which must have MAX_VERBOSE_NICKNAME_LEN+1 bytes) to the

--- a/src/feature/nodelist/describe.h
+++ b/src/feature/nodelist/describe.h
@@ -49,8 +49,8 @@ void router_get_verbose_nickname(char *buf, const routerinfo_t *router);
 STATIC const char *format_node_description(char *buf,
                                            const char *id_digest,
                                            const char *nickname,
-                                           const tor_addr_t *ipv6_addr,
-                                           const tor_addr_t *ipv4_addr);
+                                           const tor_addr_t *ipv4_addr,
+                                           const tor_addr_t *ipv6_addr);
 
 #endif /* defined(TOR_UNIT_TESTS) */
 

--- a/src/test/test_nodelist.c
+++ b/src/test/test_nodelist.c
@@ -703,8 +703,8 @@ test_nodelist_format_node_description(void *arg)
   rv = format_node_description(ndesc,
                                mock_digest,
                                mock_nickname,
-                               &mock_null_ip,
-                               NULL);
+                               NULL,
+                               &mock_null_ip);
   tt_ptr_op(rv, OP_EQ, ndesc);
   tt_str_op(ndesc, OP_EQ,
             "$AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA~TestOR7890123456789");
@@ -722,8 +722,8 @@ test_nodelist_format_node_description(void *arg)
   rv = format_node_description(ndesc,
                                mock_digest,
                                mock_nickname,
-                               &mock_ipv6,
-                               NULL);
+                               NULL,
+                               &mock_ipv6);
   tt_ptr_op(rv, OP_EQ, ndesc);
   tt_str_op(ndesc, OP_EQ,
             "$AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA~TestOR7890123456789 at "
@@ -732,18 +732,18 @@ test_nodelist_format_node_description(void *arg)
   rv = format_node_description(ndesc,
                                mock_digest,
                                mock_nickname,
-                               &mock_ipv6,
-                               &mock_ipv4);
+                               &mock_ipv4,
+                               &mock_ipv6);
   tt_ptr_op(rv, OP_EQ, ndesc);
   tt_str_op(ndesc, OP_EQ,
             "$AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA~TestOR7890123456789 at "
             "111.222.233.244 and [1111:2222:3333:4444:5555:6666:7777:8888]");
 
   /* test NULL handling */
-  rv = format_node_description(NULL, NULL, NULL, NULL, 0);
+  rv = format_node_description(NULL, NULL, NULL, NULL, NULL);
   tt_str_op(rv, OP_EQ, "<NULL BUFFER>");
 
-  rv = format_node_description(ndesc, NULL, NULL, NULL, 0);
+  rv = format_node_description(ndesc, NULL, NULL, NULL, NULL);
   tt_ptr_op(rv, OP_EQ, ndesc);
   tt_str_op(rv, OP_EQ, "<NULL ID DIGEST>");
 


### PR DESCRIPTION
Pass the IPv4 before the IPv6 like all our other interfaces.

Changes unreleased code related to #40043.

Closes #40045

Signed-off-by: David Goulet <dgoulet@torproject.org>