### PR TITLE
[Tor Gitlab #40047]: Add running glibc version to the log

### DIFF
--- a/changes/feature40047
+++ b/changes/feature40047
@@ -1,0 +1,6 @@
+  o Minor features (logging):
+    - Adds the running glibc version to the log. Also adds the
+      running and compiled glibc version to the library list
+      returned when using the flag --library-versions. Patch 
+      from Daniel Pinto. Closes ticket 40047; bugfix on 
+      0.4.5.0-alpha-dev.

--- a/scripts/maint/practracker/exceptions.txt
+++ b/scripts/maint/practracker/exceptions.txt
@@ -34,10 +34,10 @@
 # Remember: It is better to fix the problem than to add a new exception!
 
 problem file-size /src/app/config/config.c 7525
-problem include-count /src/app/config/config.c 80
+problem include-count /src/app/config/config.c 81
 problem function-size /src/app/config/config.c:options_act() 381
 problem function-size /src/app/config/config.c:options_validate_cb() 794
-problem function-size /src/app/config/config.c:options_init_from_torrc() 192
+problem function-size /src/app/config/config.c:options_init_from_torrc() 198
 problem function-size /src/app/config/config.c:options_init_from_string() 103
 problem function-size /src/app/config/config.c:options_init_logs() 125
 problem function-size /src/app/config/config.c:parse_bridge_line() 104
@@ -48,9 +48,9 @@ problem function-size /src/app/config/config.c:port_parse_config() 435
 problem function-size /src/app/config/config.c:parse_ports() 132
 problem function-size /src/app/config/resolve_addr.c:resolve_my_address_v4() 197
 problem file-size /src/app/config/or_options_st.h 1050
-problem include-count /src/app/main/main.c 68
+problem include-count /src/app/main/main.c 71
 problem function-size /src/app/main/main.c:dumpstats() 102
-problem function-size /src/app/main/main.c:tor_init() 101
+problem function-size /src/app/main/main.c:tor_init() 109
 problem function-size /src/app/main/main.c:sandbox_init_filter() 291
 problem function-size /src/app/main/main.c:run_tor_main_loop() 105
 problem function-size /src/app/main/ntmain.c:nt_service_install() 126

--- a/src/app/config/config.c
+++ b/src/app/config/config.c
@@ -140,6 +140,7 @@
 
 #include "lib/meminfo/meminfo.h"
 #include "lib/osinfo/uname.h"
+#include "lib/osinfo/libc.h"
 #include "lib/process/daemon.h"
 #include "lib/process/pidfile.h"
 #include "lib/process/restrict.h"
@@ -4364,6 +4365,12 @@ options_init_from_torrc(int argc, char **argv)
       printf("Libzstd \t\t%-15s\t\t%s\n",
                         tor_compress_version_str(ZSTD_METHOD),
                         tor_compress_header_version_str(ZSTD_METHOD));
+    }
+    if (tor_libc_get_name()) {
+      printf("%-7s \t\t%-15s\t\t%s\n",
+             tor_libc_get_name(),
+             tor_libc_get_header_version_str(),
+             tor_libc_get_version_str());
     }
     //TODO: Hex versions?
     return 1;

--- a/src/app/main/main.c
+++ b/src/app/main/main.c
@@ -67,6 +67,7 @@
 
 #include "lib/meminfo/meminfo.h"
 #include "lib/osinfo/uname.h"
+#include "lib/osinfo/libc.h"
 #include "lib/sandbox/sandbox.h"
 #include "lib/fs/lockfile.h"
 #include "lib/tls/tortls.h"
@@ -578,7 +579,8 @@ tor_init(int argc, char *argv[])
     const char *version = get_version();
 
     log_notice(LD_GENERAL, "Tor %s running on %s with Libevent %s, "
-               "%s %s, Zlib %s, Liblzma %s, and Libzstd %s.", version,
+               "%s %s, Zlib %s, Liblzma %s, Libzstd %s and %s %s as libc.",
+               version,
                get_uname(),
                tor_libevent_get_version_str(),
                crypto_get_library_name(),
@@ -588,7 +590,10 @@ tor_init(int argc, char *argv[])
                tor_compress_supports_method(LZMA_METHOD) ?
                  tor_compress_version_str(LZMA_METHOD) : "N/A",
                tor_compress_supports_method(ZSTD_METHOD) ?
-                 tor_compress_version_str(ZSTD_METHOD) : "N/A");
+                 tor_compress_version_str(ZSTD_METHOD) : "N/A",
+               tor_libc_get_name() ?
+                 tor_libc_get_name() : "Unknown",
+               tor_libc_get_version_str());
 
     log_notice(LD_GENERAL, "Tor can't help you if you use it wrong! "
                "Learn how to be safe at "

--- a/src/lib/osinfo/include.am
+++ b/src/lib/osinfo/include.am
@@ -7,7 +7,8 @@ endif
 
 # ADD_C_FILE: INSERT SOURCES HERE.
 src_lib_libtor_osinfo_a_SOURCES =			\
-	src/lib/osinfo/uname.c
+	src/lib/osinfo/uname.c		\
+	src/lib/osinfo/libc.c
 
 src_lib_libtor_osinfo_testing_a_SOURCES = \
 	$(src_lib_libtor_osinfo_a_SOURCES)
@@ -16,4 +17,5 @@ src_lib_libtor_osinfo_testing_a_CFLAGS = $(AM_CFLAGS) $(TEST_CFLAGS)
 
 # ADD_C_FILE: INSERT HEADERS HERE.
 noinst_HEADERS +=					\
-	src/lib/osinfo/uname.h
+	src/lib/osinfo/uname.h		\
+	src/lib/osinfo/libc.h

--- a/src/lib/osinfo/libc.c
+++ b/src/lib/osinfo/libc.c
@@ -1,0 +1,66 @@
+/* Copyright (c) 2001 Matej Pfajfar.
+ * Copyright (c) 2001-2004, Roger Dingledine.
+ * Copyright (c) 2004-2006, Roger Dingledine, Nick Mathewson.
+ * Copyright (c) 2007-2020, The Tor Project, Inc. */
+/* See LICENSE for licensing information */
+
+/**
+ * @file libc.c
+ * @brief Functions to get the name and version of the system libc.
+ **/
+
+#include "orconfig.h"
+#include "lib/osinfo/libc.h"
+#include <stdlib.h>
+
+#ifdef HAVE_GNU_LIBC_VERSION_H
+#include <gnu/libc-version.h>
+#endif
+
+#ifdef HAVE_GNU_LIBC_VERSION_H
+#ifdef HAVE_GNU_GET_LIBC_VERSION
+#define CHECK_LIBC_VERSION
+#endif
+#endif
+
+#define STR_IMPL(x) #x
+#define STR(x) STR_IMPL(x)
+
+/** Return the name of the compile time libc. Returns NULL if we
+ * cannot identify the libc. */
+const char *
+tor_libc_get_name(void)
+{
+#ifdef __GLIBC__
+  return "Glibc";
+#else /* !defined(__GLIBC__) */
+  return NULL;
+#endif /* defined(__GLIBC__) */
+}
+
+/** Return a string representation of the version of the currently running
+ * version of Glibc. */
+const char *
+tor_libc_get_version_str(void)
+{
+#ifdef CHECK_LIBC_VERSION
+  const char *version = gnu_get_libc_version();
+  if (version == NULL)
+    return "N/A";
+  return version;
+#else /* !defined(CHECK_LIBC_VERSION) */
+  return "N/A";
+#endif /* defined(CHECK_LIBC_VERSION) */
+}
+
+/** Return a string representation of the version of Glibc that was used at
+ * compilation time. */
+const char *
+tor_libc_get_header_version_str(void)
+{
+#ifdef __GLIBC__
+  return STR(__GLIBC__) "." STR(__GLIBC_MINOR__);
+#else
+  return "N/A";
+#endif /* defined(__GLIBC__) */
+}

--- a/src/lib/osinfo/libc.h
+++ b/src/lib/osinfo/libc.h
@@ -1,0 +1,19 @@
+/* Copyright (c) 2001 Matej Pfajfar.
+ * Copyright (c) 2001-2004, Roger Dingledine.
+ * Copyright (c) 2004-2006, Roger Dingledine, Nick Mathewson.
+ * Copyright (c) 2007-2020, The Tor Project, Inc. */
+/* See LICENSE for licensing information */
+
+/**
+ * @file libc.h
+ * @brief Header for lib/osinfo/libc.c
+ **/
+
+#ifndef TOR_LIB_OSINFO_LIBC_H
+#define TOR_LIB_OSINFO_LIBC_H
+
+const char *tor_libc_get_name(void);
+const char *tor_libc_get_version_str(void);
+const char *tor_libc_get_header_version_str(void);
+
+#endif /* !defined(TOR_LIB_OSINFO_LIBC_H) */

--- a/src/test/conf_examples/crypto_accel/expected_log_nss
+++ b/src/test/conf_examples/crypto_accel/expected_log_nss
@@ -1,1 +1,1 @@
-Tor 0.* running on .* with Libevent .*, NSS .*, Zlib .*, Liblzma .*, and Libzstd .*
+Tor 0.* running on .* with Libevent .*, NSS .*, Zlib .*, Liblzma .*, Libzstd .* and .* .* as libc

--- a/src/test/conf_examples/crypto_accel_req/expected_log_nss
+++ b/src/test/conf_examples/crypto_accel_req/expected_log_nss
@@ -1,1 +1,1 @@
-Tor 0.* running on .* with Libevent .*, NSS .*, Zlib .*, Liblzma .*, and Libzstd .*
+Tor 0.* running on .* with Libevent .*, NSS .*, Zlib .*, Liblzma .*, Libzstd .* and .* .* as libc

--- a/src/test/conf_examples/lzma_zstd_1/expected_log
+++ b/src/test/conf_examples/lzma_zstd_1/expected_log
@@ -1,1 +1,1 @@
-Tor 0.* running on .* with Libevent .*, .*, Zlib .*, Liblzma N/A, and Libzstd N/A
+Tor 0.* running on .* with Libevent .*, .*, Zlib .*, Liblzma N/A, Libzstd N/A and .* .* as libc

--- a/src/test/conf_examples/lzma_zstd_1/expected_log_lzma
+++ b/src/test/conf_examples/lzma_zstd_1/expected_log_lzma
@@ -1,1 +1,1 @@
-Tor 0.* running on .* with Libevent .*, .*, Zlib .*, Liblzma .*, and Libzstd N/A
+Tor 0.* running on .* with Libevent .*, .*, Zlib .*, Liblzma .*, Libzstd N/A and .* .* as libc

--- a/src/test/conf_examples/lzma_zstd_1/expected_log_lzma_zstd
+++ b/src/test/conf_examples/lzma_zstd_1/expected_log_lzma_zstd
@@ -1,1 +1,1 @@
-Tor 0.* running on .* with Libevent .*, .*, Zlib .*, Liblzma .*, and Libzstd .*
+Tor 0.* running on .* with Libevent .*, .*, Zlib .*, Liblzma .*, Libzstd .* and .* .* as libc

--- a/src/test/conf_examples/lzma_zstd_1/expected_log_zstd
+++ b/src/test/conf_examples/lzma_zstd_1/expected_log_zstd
@@ -1,1 +1,1 @@
-Tor 0.* running on .* with Libevent .*, .*, Zlib .*, Liblzma N/A, and Libzstd .*
+Tor 0.* running on .* with Libevent .*, .*, Zlib .*, Liblzma N/A, Libzstd .* and .* .* as libc

--- a/src/test/conf_examples/nss_1/expected_log
+++ b/src/test/conf_examples/nss_1/expected_log
@@ -1,1 +1,1 @@
-Tor 0.* running on .* with Libevent .*, OpenSSL .*, Zlib .*, Liblzma .*, and Libzstd .*
+Tor 0.* running on .* with Libevent .*, OpenSSL .*, Zlib .*, Liblzma .*, Libzstd .* and .* .* as libc

--- a/src/test/conf_examples/nss_1/expected_log_nss
+++ b/src/test/conf_examples/nss_1/expected_log_nss
@@ -1,1 +1,1 @@
-Tor 0.* running on .* with Libevent .*, NSS .*, Zlib .*, Liblzma .*, and Libzstd .*
+Tor 0.* running on .* with Libevent .*, NSS .*, Zlib .*, Liblzma .*, Libzstd .* and .* .* as libc

--- a/src/test/test_parseconf.sh
+++ b/src/test/test_parseconf.sh
@@ -202,7 +202,7 @@ STANDARD_LIBS="libevent\\|openssl\\|zlib"
 # shellcheck disable=SC2018,SC2019
 TOR_LIBS_ENABLED="$("$TOR_BINARY" --verify-config \
                       -f "$EMPTY" --defaults-torrc "$EMPTY" \
-                    | sed -n 's/.* Tor .* running on .* with\(.*\)\./\1/p' \
+                    | sed -n 's/.* Tor .* running on .* with\(.*\) and .* .* as libc\./\1/p' \
                     | tr 'A-Z' 'a-z' | tr ',' '\n' \
                     | grep -v "$STANDARD_LIBS" | grep -v "n/a" \
                     | sed 's/\( and\)* \(lib\)*\([a-z0-9]*\) .*/\3/' \


### PR DESCRIPTION
Adds the running glibc version to the log. Also adds the running and compiled glibc version to the library list returned when using the flag --library-versions.