### PR TITLE
When choosing an orport from an extendinfo, pick randomly.

### DIFF
--- a/changes/ticket33220
+++ b/changes/ticket33220
@@ -1,0 +1,5 @@
+  o Major features (relay, IPv6):
+    - When a relay with IPv6 support opens a connection to another
+      relay, and the extend cell lists both IPv4 and IPv6 addresses, the
+      first relay now picks randomly which address to use.  Closes
+      ticket 33220.


### PR DESCRIPTION
(This is not fully general yet: we only pick randomly among
_supported_ addresses, and each extendinfo contains at most one IPv4
address and at most one IPv6 address, no matter what the extend cell
had.)

This change will help dual-stack relays do IPv6 reachability tests,
in theory, by having them sometimes do IPv4 connections and
sometimes do ipv6 connections.

Closes ticket 33220.