### PR TITLE
[Tor Gitlab #27315 - maint-0.3.5]: Fix seccomp sandbox rules for openat

### DIFF
--- a/changes/bug27315
+++ b/changes/bug27315
@@ -1,0 +1,6 @@
+  o Minor bugfixes (linux seccomp2 sandbox):
+    - Fix a regression on sandboxing rules for the openat() syscall.
+      The fix for bug 25440 fixed the problem on systems with glibc >=
+      2.27 but broke tor on previous versions of glibc. We now apply 
+      the correct seccomp rule according to the running glibc version.
+      Patch from Daniel Pinto. Fixes bug 27315; bugfix on 0.3.5.11.


### PR DESCRIPTION
The need for casting negative syscall arguments depends on the
glibc version. This affects the rules for the openat syscall which
uses the constant AT_FDCWD that is defined as a negative number.
This commit adds logic to only apply the cast when necessary, on
glibc versions from 2.27 onwards.