### PR TITLE
Remove the connection_t.outbuf_flushlen field

### DIFF
--- a/changes/bug33097
+++ b/changes/bug33097
@@ -1,0 +1,4 @@
+  o Code simplification and refactoring:
+    - Remove the now-redundant 'outbuf_flushlen' field from our connection
+      type. It was previously used for an older version of our rate-limiting
+      logic. Closes ticket 33097.

--- a/src/core/mainloop/mainloop.c
+++ b/src/core/mainloop/mainloop.c
@@ -985,33 +985,29 @@ conn_close_if_marked(int i)
     if (!conn->hold_open_until_flushed)
       log_info(LD_NET,
                "Conn (addr %s, fd %d, type %s, state %d) marked, but wants "
-               "to flush %d bytes. (Marked at %s:%d)",
+               "to flush %"TOR_PRIuSZ" bytes. (Marked at %s:%d)",
                escaped_safe_str_client(conn->address),
                (int)conn->s, conn_type_to_string(conn->type), conn->state,
-               (int)conn->outbuf_flushlen,
-                conn->marked_for_close_file, conn->marked_for_close);
+               connection_get_outbuf_len(conn),
+               conn->marked_for_close_file, conn->marked_for_close);
     if (conn->linked_conn) {
-      retval = buf_move_to_buf(conn->linked_conn->inbuf, conn->outbuf,
-                               &conn->outbuf_flushlen);
+      retval = buf_move_all(conn->linked_conn->inbuf, conn->outbuf);
       if (retval >= 0) {
         /* The linked conn will notice that it has data when it notices that
          * we're gone. */
         connection_start_reading_from_linked_conn(conn->linked_conn);
       }
       log_debug(LD_GENERAL, "Flushed last %d bytes from a linked conn; "
-               "%d left; flushlen %d; wants-to-flush==%d", retval,
+               "%d left; wants-to-flush==%d", retval,
                 (int)connection_get_outbuf_len(conn),
-                (int)conn->outbuf_flushlen,
                 connection_wants_to_flush(conn));
     } else if (connection_speaks_cells(conn)) {
       if (conn->state == OR_CONN_STATE_OPEN) {
-        retval = buf_flush_to_tls(conn->outbuf, TO_OR_CONN(conn)->tls, sz,
-                               &conn->outbuf_flushlen);
+        retval = buf_flush_to_tls(conn->outbuf, TO_OR_CONN(conn)->tls, sz);
       } else
         retval = -1; /* never flush non-open broken tls connections */
     } else {
-      retval = buf_flush_to_socket(conn->outbuf, conn->s, sz,
-                                   &conn->outbuf_flushlen);
+      retval = buf_flush_to_socket(conn->outbuf, conn->s, sz);
     }
     if (retval >= 0 && /* Technically, we could survive things like
                           TLS_WANT_WRITE here. But don't bother for now. */

--- a/src/core/mainloop/mainloop.c
+++ b/src/core/mainloop/mainloop.c
@@ -991,7 +991,7 @@ conn_close_if_marked(int i)
                connection_get_outbuf_len(conn),
                conn->marked_for_close_file, conn->marked_for_close);
     if (conn->linked_conn) {
-      retval = buf_move_all(conn->linked_conn->inbuf, conn->outbuf);
+      retval = (int) buf_move_all(conn->linked_conn->inbuf, conn->outbuf);
       if (retval >= 0) {
         /* The linked conn will notice that it has data when it notices that
          * we're gone. */

--- a/src/core/or/circuitlist.c
+++ b/src/core/or/circuitlist.c
@@ -2437,7 +2437,6 @@ single_conn_free_bytes(connection_t *conn)
   if (conn->outbuf) {
     result += buf_allocation(conn->outbuf);
     buf_clear(conn->outbuf);
-    conn->outbuf_flushlen = 0;
   }
   if (conn->type == CONN_TYPE_DIR) {
     dir_connection_t *dir_conn = TO_DIR_CONN(conn);

--- a/src/core/or/connection_st.h
+++ b/src/core/or/connection_st.h
@@ -98,8 +98,6 @@ struct connection_t {
   struct buf_t *inbuf; /**< Buffer holding data read over this connection. */
   struct buf_t *outbuf; /**< Buffer holding data to write over this
                          * connection. */
-  size_t outbuf_flushlen; /**< How much data should we try to flush from the
-                           * outbuf? */
   time_t timestamp_last_read_allowed; /**< When was the last time libevent said
                                        * we could read? */
   time_t timestamp_last_write_allowed; /**< When was the last time libevent

--- a/src/core/or/sendme.c
+++ b/src/core/or/sendme.c
@@ -394,7 +394,7 @@ sendme_connection_edge_consider_sending(edge_connection_t *conn)
   while (conn->deliver_window <=
          (STREAMWINDOW_START - STREAMWINDOW_INCREMENT)) {
     log_debug(log_domain, "Outbuf %" TOR_PRIuSZ ", queuing stream SENDME.",
-              TO_CONN(conn)->outbuf_flushlen);
+              buf_datalen(TO_CONN(conn)->outbuf));
     conn->deliver_window += STREAMWINDOW_INCREMENT;
     if (connection_edge_send_command(conn, RELAY_COMMAND_SENDME,
                                      NULL, 0) < 0) {

--- a/src/lib/buf/buffers.c
+++ b/src/lib/buf/buffers.c
@@ -685,17 +685,20 @@ buf_move_to_buf(buf_t *buf_out, buf_t *buf_in, size_t *buf_flushlen)
 }
 
 /** Moves all data from <b>buf_in</b> to <b>buf_out</b>, without copying.
+ * Return the number of bytes that were moved.
  */
-void
+size_t
 buf_move_all(buf_t *buf_out, buf_t *buf_in)
 {
   tor_assert(buf_out);
   if (!buf_in)
-    return;
+    return 0;
   if (BUG(buf_out->datalen > BUF_MAX_LEN || buf_in->datalen > BUF_MAX_LEN))
-    return;
+    return 0;
   if (BUG(buf_out->datalen > BUF_MAX_LEN - buf_in->datalen))
-    return;
+    return 0;
+
+  size_t n_bytes_moved = buf_in->datalen;
 
   if (buf_out->head == NULL) {
     buf_out->head = buf_in->head;
@@ -708,6 +711,8 @@ buf_move_all(buf_t *buf_out, buf_t *buf_in)
   buf_out->datalen += buf_in->datalen;
   buf_in->head = buf_in->tail = NULL;
   buf_in->datalen = 0;
+
+  return n_bytes_moved;
 }
 
 /** Internal structure: represents a position in a buffer. */

--- a/src/lib/buf/buffers.h
+++ b/src/lib/buf/buffers.h
@@ -46,7 +46,7 @@ void buf_add_printf(buf_t *buf, const char *format, ...)
 void buf_add_vprintf(buf_t *buf, const char *format, va_list args)
   CHECK_PRINTF(2, 0);
 int buf_move_to_buf(buf_t *buf_out, buf_t *buf_in, size_t *buf_flushlen);
-void buf_move_all(buf_t *buf_out, buf_t *buf_in);
+size_t buf_move_all(buf_t *buf_out, buf_t *buf_in);
 void buf_peek(const buf_t *buf, char *string, size_t string_len);
 void buf_drain(buf_t *buf, size_t n);
 int buf_get_bytes(buf_t *buf, char *string, size_t string_len);

--- a/src/lib/net/buffers_net.h
+++ b/src/lib/net/buffers_net.h
@@ -21,14 +21,12 @@ int buf_read_from_socket(struct buf_t *buf, tor_socket_t s, size_t at_most,
                          int *reached_eof,
                          int *socket_error);
 
-int buf_flush_to_socket(struct buf_t *buf, tor_socket_t s, size_t sz,
-                        size_t *buf_flushlen);
+int buf_flush_to_socket(struct buf_t *buf, tor_socket_t s, size_t sz);
 
 int buf_read_from_pipe(struct buf_t *buf, int fd, size_t at_most,
                        int *reached_eof,
                        int *socket_error);
 
-int buf_flush_to_pipe(struct buf_t *buf, int fd, size_t sz,
-                      size_t *buf_flushlen);
+int buf_flush_to_pipe(struct buf_t *buf, int fd, size_t sz);
 
 #endif /* !defined(TOR_BUFFERS_NET_H) */

--- a/src/lib/process/process_unix.c
+++ b/src/lib/process/process_unix.c
@@ -418,7 +418,7 @@ process_unix_write(process_t *process, buf_t *buffer)
   /* We have data to write and the kernel have told us to write it. */
   return buf_flush_to_pipe(buffer,
                            process_get_unix_process(process)->stdin_handle.fd,
-                           max_to_write, &buffer_flush_len);
+                           max_to_write);
 }
 
 /** Read data from the given process's standard output and put it into

--- a/src/lib/tls/buffers_tls.h
+++ b/src/lib/tls/buffers_tls.h
@@ -18,6 +18,6 @@ struct tor_tls_t;
 int buf_read_from_tls(struct buf_t *buf,
                       struct tor_tls_t *tls, size_t at_most);
 int buf_flush_to_tls(struct buf_t *buf, struct tor_tls_t *tls,
-                     size_t sz, size_t *buf_flushlen);
+                     size_t sz);
 
 #endif /* !defined(TOR_BUFFERS_TLS_H) */

--- a/src/test/test_relaycell.c
+++ b/src/test/test_relaycell.c
@@ -220,7 +220,6 @@ subtest_circbw_halfclosed(origin_circuit_t *circ, streamid_t init_id)
   int sendme_cells = (STREAMWINDOW_START-edgeconn->package_window)
                              /STREAMWINDOW_INCREMENT;
   ENTRY_TO_CONN(entryconn2)->marked_for_close = 0;
-  ENTRY_TO_CONN(entryconn2)->outbuf_flushlen = 0;
   connection_edge_reached_eof(edgeconn);
 
   /* Data cell not in the half-opened list */
@@ -272,7 +271,6 @@ subtest_circbw_halfclosed(origin_circuit_t *circ, streamid_t init_id)
   /* DATA cells up to limit */
   while (data_cells > 0) {
     ENTRY_TO_CONN(entryconn2)->marked_for_close = 0;
-    ENTRY_TO_CONN(entryconn2)->outbuf_flushlen = 0;
     PACK_CELL(edgeconn->stream_id, RELAY_COMMAND_DATA, "Data1234");
     if (circ->base_.purpose == CIRCUIT_PURPOSE_PATH_BIAS_TESTING)
       pathbias_count_valid_cells(TO_CIRCUIT(circ), &cell);
@@ -283,7 +281,6 @@ subtest_circbw_halfclosed(origin_circuit_t *circ, streamid_t init_id)
     data_cells--;
   }
   ENTRY_TO_CONN(entryconn2)->marked_for_close = 0;
-  ENTRY_TO_CONN(entryconn2)->outbuf_flushlen = 0;
   PACK_CELL(edgeconn->stream_id, RELAY_COMMAND_DATA, "Data1234");
   if (circ->base_.purpose == CIRCUIT_PURPOSE_PATH_BIAS_TESTING)
     pathbias_count_valid_cells(TO_CIRCUIT(circ), &cell);
@@ -295,7 +292,6 @@ subtest_circbw_halfclosed(origin_circuit_t *circ, streamid_t init_id)
   /* SENDME cells up to limit */
   while (sendme_cells > 0) {
     ENTRY_TO_CONN(entryconn2)->marked_for_close = 0;
-    ENTRY_TO_CONN(entryconn2)->outbuf_flushlen = 0;
     PACK_CELL(edgeconn->stream_id, RELAY_COMMAND_SENDME, "Data1234");
     if (circ->base_.purpose == CIRCUIT_PURPOSE_PATH_BIAS_TESTING)
       pathbias_count_valid_cells(TO_CIRCUIT(circ), &cell);
@@ -306,7 +302,6 @@ subtest_circbw_halfclosed(origin_circuit_t *circ, streamid_t init_id)
     sendme_cells--;
   }
   ENTRY_TO_CONN(entryconn2)->marked_for_close = 0;
-  ENTRY_TO_CONN(entryconn2)->outbuf_flushlen = 0;
   PACK_CELL(edgeconn->stream_id, RELAY_COMMAND_SENDME, "Data1234");
   if (circ->base_.purpose == CIRCUIT_PURPOSE_PATH_BIAS_TESTING)
     pathbias_count_valid_cells(TO_CIRCUIT(circ), &cell);
@@ -317,7 +312,6 @@ subtest_circbw_halfclosed(origin_circuit_t *circ, streamid_t init_id)
 
   /* Only one END cell */
   ENTRY_TO_CONN(entryconn2)->marked_for_close = 0;
-  ENTRY_TO_CONN(entryconn2)->outbuf_flushlen = 0;
   PACK_CELL(edgeconn->stream_id, RELAY_COMMAND_END, "Data1234");
   if (circ->base_.purpose == CIRCUIT_PURPOSE_PATH_BIAS_TESTING)
     pathbias_count_valid_cells(TO_CIRCUIT(circ), &cell);
@@ -327,7 +321,6 @@ subtest_circbw_halfclosed(origin_circuit_t *circ, streamid_t init_id)
   ASSERT_COUNTED_BW();
 
   ENTRY_TO_CONN(entryconn2)->marked_for_close = 0;
-  ENTRY_TO_CONN(entryconn2)->outbuf_flushlen = 0;
   PACK_CELL(edgeconn->stream_id, RELAY_COMMAND_END, "Data1234");
   if (circ->base_.purpose == CIRCUIT_PURPOSE_PATH_BIAS_TESTING)
     pathbias_count_valid_cells(TO_CIRCUIT(circ), &cell);
@@ -339,7 +332,6 @@ subtest_circbw_halfclosed(origin_circuit_t *circ, streamid_t init_id)
   edgeconn = ENTRY_TO_EDGE_CONN(entryconn3);
   edgeconn->base_.state = AP_CONN_STATE_OPEN;
   ENTRY_TO_CONN(entryconn3)->marked_for_close = 0;
-  ENTRY_TO_CONN(entryconn3)->outbuf_flushlen = 0;
   /* sendme cell on open entryconn with full window */
   PACK_CELL(edgeconn->stream_id, RELAY_COMMAND_SENDME, "Data1234");
   int ret =
@@ -350,7 +342,6 @@ subtest_circbw_halfclosed(origin_circuit_t *circ, streamid_t init_id)
 
   /* connected cell on a after EOF */
   ENTRY_TO_CONN(entryconn3)->marked_for_close = 0;
-  ENTRY_TO_CONN(entryconn3)->outbuf_flushlen = 0;
   edgeconn->base_.state = AP_CONN_STATE_CONNECT_WAIT;
   connection_edge_reached_eof(edgeconn);
   PACK_CELL(edgeconn->stream_id, RELAY_COMMAND_CONNECTED, "Data1234");
@@ -362,7 +353,6 @@ subtest_circbw_halfclosed(origin_circuit_t *circ, streamid_t init_id)
   ASSERT_COUNTED_BW();
 
   ENTRY_TO_CONN(entryconn3)->marked_for_close = 0;
-  ENTRY_TO_CONN(entryconn3)->outbuf_flushlen = 0;
   PACK_CELL(edgeconn->stream_id, RELAY_COMMAND_CONNECTED, "Data1234");
   if (circ->base_.purpose == CIRCUIT_PURPOSE_PATH_BIAS_TESTING)
     pathbias_count_valid_cells(TO_CIRCUIT(circ), &cell);
@@ -373,7 +363,6 @@ subtest_circbw_halfclosed(origin_circuit_t *circ, streamid_t init_id)
 
   /* DATA and SENDME after END cell */
   ENTRY_TO_CONN(entryconn3)->marked_for_close = 0;
-  ENTRY_TO_CONN(entryconn3)->outbuf_flushlen = 0;
   PACK_CELL(edgeconn->stream_id, RELAY_COMMAND_END, "Data1234");
   if (circ->base_.purpose == CIRCUIT_PURPOSE_PATH_BIAS_TESTING)
     pathbias_count_valid_cells(TO_CIRCUIT(circ), &cell);
@@ -383,7 +372,6 @@ subtest_circbw_halfclosed(origin_circuit_t *circ, streamid_t init_id)
   ASSERT_COUNTED_BW();
 
   ENTRY_TO_CONN(entryconn3)->marked_for_close = 0;
-  ENTRY_TO_CONN(entryconn3)->outbuf_flushlen = 0;
   PACK_CELL(edgeconn->stream_id, RELAY_COMMAND_SENDME, "Data1234");
   ret =
     connection_edge_process_relay_cell(&cell, TO_CIRCUIT(circ), NULL,
@@ -392,7 +380,6 @@ subtest_circbw_halfclosed(origin_circuit_t *circ, streamid_t init_id)
   ASSERT_UNCOUNTED_BW();
 
   ENTRY_TO_CONN(entryconn3)->marked_for_close = 0;
-  ENTRY_TO_CONN(entryconn3)->outbuf_flushlen = 0;
   PACK_CELL(edgeconn->stream_id, RELAY_COMMAND_DATA, "Data1234");
   if (circ->base_.purpose == CIRCUIT_PURPOSE_PATH_BIAS_TESTING)
     pathbias_count_valid_cells(TO_CIRCUIT(circ), &cell);
@@ -407,11 +394,9 @@ subtest_circbw_halfclosed(origin_circuit_t *circ, streamid_t init_id)
   edgeconn->base_.state = AP_CONN_STATE_RESOLVE_WAIT;
   edgeconn->on_circuit = TO_CIRCUIT(circ);
   ENTRY_TO_CONN(entryconn4)->marked_for_close = 0;
-  ENTRY_TO_CONN(entryconn4)->outbuf_flushlen = 0;
   connection_edge_reached_eof(edgeconn);
 
   ENTRY_TO_CONN(entryconn4)->marked_for_close = 0;
-  ENTRY_TO_CONN(entryconn4)->outbuf_flushlen = 0;
   PACK_CELL(edgeconn->stream_id, RELAY_COMMAND_RESOLVED,
             "\x04\x04\x12\x00\x00\x01\x00\x00\x02\x00");
   if (circ->base_.purpose == CIRCUIT_PURPOSE_PATH_BIAS_TESTING)
@@ -422,7 +407,6 @@ subtest_circbw_halfclosed(origin_circuit_t *circ, streamid_t init_id)
   ASSERT_COUNTED_BW();
 
   ENTRY_TO_CONN(entryconn4)->marked_for_close = 0;
-  ENTRY_TO_CONN(entryconn4)->outbuf_flushlen = 0;
   PACK_CELL(edgeconn->stream_id, RELAY_COMMAND_RESOLVED,
             "\x04\x04\x12\x00\x00\x01\x00\x00\x02\x00");
   connection_edge_process_relay_cell(&cell, TO_CIRCUIT(circ), NULL,
@@ -431,7 +415,6 @@ subtest_circbw_halfclosed(origin_circuit_t *circ, streamid_t init_id)
 
   /* Data not counted after resolved */
   ENTRY_TO_CONN(entryconn4)->marked_for_close = 0;
-  ENTRY_TO_CONN(entryconn4)->outbuf_flushlen = 0;
   PACK_CELL(edgeconn->stream_id, RELAY_COMMAND_DATA, "Data1234");
   if (circ->base_.purpose == CIRCUIT_PURPOSE_PATH_BIAS_TESTING)
     pathbias_count_valid_cells(TO_CIRCUIT(circ), &cell);
@@ -442,7 +425,6 @@ subtest_circbw_halfclosed(origin_circuit_t *circ, streamid_t init_id)
 
   /* End not counted after resolved */
   ENTRY_TO_CONN(entryconn4)->marked_for_close = 0;
-  ENTRY_TO_CONN(entryconn4)->outbuf_flushlen = 0;
   PACK_CELL(edgeconn->stream_id, RELAY_COMMAND_END, "Data1234");
   if (circ->base_.purpose == CIRCUIT_PURPOSE_PATH_BIAS_TESTING)
     pathbias_count_valid_cells(TO_CIRCUIT(circ), &cell);
@@ -660,7 +642,6 @@ test_halfstream_wrap(void *arg)
 
   /* Insert an opened stream on the circ with that id */
   ENTRY_TO_CONN(entryconn)->marked_for_close = 0;
-  ENTRY_TO_CONN(entryconn)->outbuf_flushlen = 0;
   edgeconn->base_.state = AP_CONN_STATE_CONNECT_WAIT;
   circ->p_streams = edgeconn;
 
@@ -784,14 +765,12 @@ test_circbw_relay(void *arg)
 
   /* Sendme on valid stream: counted */
   edgeconn->package_window -= STREAMWINDOW_INCREMENT;
-  ENTRY_TO_CONN(entryconn1)->outbuf_flushlen = 0;
   PACK_CELL(1, RELAY_COMMAND_SENDME, "Data1234");
   connection_edge_process_relay_cell(&cell, TO_CIRCUIT(circ), edgeconn,
                                      circ->cpath);
   ASSERT_COUNTED_BW();
 
   /* Sendme on valid stream with full window: not counted */
-  ENTRY_TO_CONN(entryconn1)->outbuf_flushlen = 0;
   PACK_CELL(1, RELAY_COMMAND_SENDME, "Data1234");
   edgeconn->package_window = STREAMWINDOW_START;
   connection_edge_process_relay_cell(&cell, TO_CIRCUIT(circ), edgeconn,
@@ -799,7 +778,6 @@ test_circbw_relay(void *arg)
   ASSERT_UNCOUNTED_BW();
 
   /* Sendme on unknown stream: not counted */
-  ENTRY_TO_CONN(entryconn1)->outbuf_flushlen = 0;
   PACK_CELL(1, RELAY_COMMAND_SENDME, "Data1234");
   connection_edge_process_relay_cell(&cell, TO_CIRCUIT(circ), NULL,
                                      circ->cpath);


### PR DESCRIPTION
This was once used for rate-limiting, but now it's only for
accounting.  It hasn't served a useful purpose in a long time.

Closes ticket 33097.