### PR TITLE
Treat all extorport connections with un-set addresses as remote

### DIFF
--- a/changes/ticket33747
+++ b/changes/ticket33747
@@ -1,0 +1,7 @@
+  o Minor bugfixes (rate limiting, bridges, pluggable transports):
+    - On a bridge, treat all connections from an ExtORPort as remote
+      by default for the purposes of rate-limiting. Previously,
+      bridges would treat the connection as local unless they explicitly
+      received a "USERADDR" command.  ExtORPort connections still
+      count as local if there is a USERADDR command with an  explicit local
+      address. Fixes bug 33747; bugfix on 0.2.5.1-alpha.

--- a/src/core/mainloop/connection.c
+++ b/src/core/mainloop/connection.c
@@ -379,8 +379,12 @@ or_connection_new(int type, int socket_family)
 
   connection_or_set_canonical(or_conn, 0);
 
-  if (type == CONN_TYPE_EXT_OR)
+  if (type == CONN_TYPE_EXT_OR) {
+    /* If we aren't told an address for this connection, we should
+     * presume it isn't local, and should be rate-limited. */
+    TO_CONN(or_conn)->always_rate_limit_as_remote = 1;
     connection_or_set_ext_or_identifier(or_conn);
+  }
 
   return or_conn;
 }
@@ -3025,6 +3029,7 @@ connection_is_rate_limited(connection_t *conn)
   if (conn->linked)
     return 0; /* Internal connection */
   else if (! options->CountPrivateBandwidth &&
+           ! conn->always_rate_limit_as_remote &&
            (tor_addr_family(&conn->addr) == AF_UNSPEC || /* no address */
             tor_addr_family(&conn->addr) == AF_UNIX ||   /* no address */
             tor_addr_is_internal(&conn->addr, 0)))

--- a/src/core/or/connection_st.h
+++ b/src/core/or/connection_st.h
@@ -64,6 +64,9 @@ struct connection_t {
   /** True if connection_handle_write is currently running on this connection.
    */
   unsigned int in_connection_handle_write:1;
+  /** If true, then we treat this connection as remote for the purpose of
+   * rate-limiting, no matter what its address is. */
+  unsigned int always_rate_limit_as_remote:1;
 
   /* For linked connections:
    */

--- a/src/feature/relay/ext_orport.c
+++ b/src/feature/relay/ext_orport.c
@@ -494,6 +494,10 @@ connection_ext_or_handle_cmd_useraddr(connection_t *conn,
   }
   conn->address = tor_addr_to_str_dup(&addr);
 
+  /* Now that we know the address, we don't have to manually override rate
+   * limiting. */
+  conn->always_rate_limit_as_remote = 0;
+
   return 0;
 }
 
@@ -659,4 +663,3 @@ ext_orport_free_all(void)
   if (ext_or_auth_cookie) /* Free the auth cookie */
     tor_free(ext_or_auth_cookie);
 }
-


### PR DESCRIPTION
Without this fix, if an PT forgets to send a USERADDR command, that
results in a connection getting treated as local for the purposes of
rate-limiting.

If the PT _does_ use USERADDR, we still believe it.

Closes ticket 33747.