### PR TITLE
#40062: Tor always overwrites onion service hostname file, but should leave it alone if it shouldn't change

### DIFF
--- a/changes/bug40062
+++ b/changes/bug40062
@@ -1,0 +1,5 @@
+  o Major bugfixes (onion services):
+    - When writing an onion service hostname file, first read it to make
+      sure it contains what we want before attempting to write it. This
+      prevents a bug where we can't read an onion service directory if it's
+      read-only. Fixes bug 40062; bugfix on 0.0.6. Patch by Neel Chauhan.

--- a/src/feature/hs/hs_service.c
+++ b/src/feature/hs/hs_service.c
@@ -990,7 +990,7 @@ write_address_to_file(const hs_service_t *service, const char *fname_)
   tor_asprintf(&addr_buf, "%s.%s\n", service->onion_address, address_tld);
   /* Notice here that we use the given "fname_". */
   fname = hs_path_from_filename(service->config.directory_path, fname_);
-  if (write_str_to_file(fname, addr_buf, 0) < 0) {
+  if (write_str_if_not_equal(fname, addr_buf)) {
     log_warn(LD_REND, "Could not write onion address to hostname file %s",
              escaped(fname));
     goto end;

--- a/src/feature/relay/router.c
+++ b/src/feature/relay/router.c
@@ -870,15 +870,11 @@ router_write_fingerprint(int hashed, int ed25519_identity)
   tor_asprintf(&fingerprint_line, "%s %s\n", options->Nickname, fingerprint);
 
   /* Check whether we need to write the (hashed-)fingerprint file. */
-
-  cp = read_file_to_str(keydir, RFTS_IGNORE_MISSING, NULL);
-  if (!cp || strcmp(cp, fingerprint_line)) {
-    if (write_str_to_file(keydir, fingerprint_line, 0)) {
-      log_err(LD_FS, "Error writing %s%s line to file",
-              hashed ? "hashed " : "",
-              ed25519_identity ? "ed25519 identity" : "fingerprint");
-      goto done;
-    }
+  if (write_str_if_not_equal(keydir, fingerprint_line)) {
+    log_err(LD_FS, "Error writing %s%s line to file",
+            hashed ? "hashed " : "",
+            ed25519_identity ? "ed25519 identity" : "fingerprint");
+    goto done;
   }
 
   log_notice(LD_GENERAL, "Your Tor %s identity key %s fingerprint is '%s %s'",

--- a/src/feature/rend/rendservice.c
+++ b/src/feature/rend/rendservice.c
@@ -1554,7 +1554,7 @@ rend_service_load_keys(rend_service_t *s)
   fname = rend_service_path(s, hostname_fname);
 
   tor_snprintf(buf, sizeof(buf),"%s.onion\n", s->service_id);
-  if (write_str_to_file(fname,buf,0)<0) {
+  if (write_str_if_not_equal(fname, buf)) {
     log_warn(LD_CONFIG, "Could not write onion address to hostname file.");
     goto err;
   }

--- a/src/lib/fs/files.c
+++ b/src/lib/fs/files.c
@@ -718,6 +718,25 @@ read_file_to_str, (const char *filename, int flags, struct stat *stat_out))
   return string;
 }
 
+/** Attempt to read a file <b>fname</b>. If the file's contents is
+ * equal to the string <b>str</b>, return 0. Otherwise, attempt to
+ * overwrite the file with the contents of <b>str</b> and return
+ * the value of write_str_to_file().
+ */
+int
+write_str_if_not_equal(const char *fname, const char *str)
+{
+  char *fstr;
+
+  fstr = read_file_to_str(fname, RFTS_IGNORE_MISSING, NULL);
+
+  if (!fstr || strcmp(str, fstr)) {
+    return write_str_to_file(fname, str, 0);
+  } else {
+    return 0;
+  }
+}
+
 #if !defined(HAVE_GETDELIM) || defined(TOR_UNIT_TESTS)
 #include "ext/getdelim.c"
 #endif

--- a/src/lib/fs/files.h
+++ b/src/lib/fs/files.h
@@ -91,6 +91,8 @@ int append_bytes_to_file(const char *fname, const char *str, size_t len,
 int write_bytes_to_new_file(const char *fname, const char *str, size_t len,
                             int bin);
 
+int write_str_if_not_equal(const char *fname, const char *str);
+
 /** Flag for read_file_to_str: open the file in binary mode. */
 #define RFTS_BIN            1
 /** Flag for read_file_to_str: it's okay if the file doesn't exist. */


### PR DESCRIPTION
Ticket: https://gitlab.torproject.org/tpo/core/tor/-/issues/40062