### PR TITLE
#40066: Make policies such as ExitPolicy truly dual-stack

### DIFF
--- a/doc/man/tor.1.txt
+++ b/doc/man/tor.1.txt
@@ -2233,6 +2233,10 @@ is non-zero):
     ("private" always produces rules for IPv4 and IPv6 addresses, even when
     used with accept6/reject6.) +
      +
+    To specify only IPv4 private networks as defined above, you may use the
+    "private4" alias. Similarly, you may use "private6" for only the IPv6
+    private networks. +
+     +
     Private addresses are rejected by default (at the beginning of your exit
     policy), along with any configured primary public IPv4 and IPv6 addresses.
     These private addresses are rejected unless you set the

--- a/src/core/or/addr_policy_st.h
+++ b/src/core/or/addr_policy_st.h
@@ -22,13 +22,22 @@ typedef enum {
 } addr_policy_action_t;
 #define addr_policy_action_bitfield_t ENUM_BF(addr_policy_action_t)
 
+/** Is this a "private", "private4", or "private6" pseudo-address? */
+typedef enum {
+  ADDR_POLICY_NOT_PRIVATE=0,
+  ADDR_POLICY_PRIVATE=1,
+  ADDR_POLICY_PRIVATE4=2,
+  ADDR_POLICY_PRIVATE6=3,
+} addr_policy_private_t;
+#define addr_policy_private_bitfield_t ENUM_BF(addr_policy_private_t)
+
 /** A reference-counted address policy rule. */
 struct addr_policy_t {
   int refcnt; /**< Reference count */
   /** What to do when the policy matches.*/
   addr_policy_action_bitfield_t policy_type:2;
-  unsigned int is_private:1; /**< True iff this is the pseudo-address,
-                              * "private". */
+  /** Whether this is a "private" pseudo-address. */
+  addr_policy_private_bitfield_t is_private:2;
   unsigned int is_canonical:1; /**< True iff this policy is the canonical
                                 * copy (stored in a hash table to avoid
                                 * duplication of common policies) */

--- a/src/core/or/policies.c
+++ b/src/core/or/policies.c
@@ -131,18 +131,18 @@ policy_expand_private(smartlist_t **policy)
         private_nets = private_nets_v6;
         break;
     }
-     for (i = 0; private_nets[i]; ++i) {
-       addr_policy_t newpolicy;
-       memcpy(&newpolicy, p, sizeof(addr_policy_t));
-       newpolicy.is_private = 0;
-       newpolicy.is_canonical = 0;
-       if (tor_addr_parse_mask_ports(private_nets[i], 0,
-                               &newpolicy.addr,
-                               &newpolicy.maskbits, &port_min, &port_max)<0) {
-         tor_assert_unreached();
-       }
-       smartlist_add(tmp, addr_policy_get_canonical_entry(&newpolicy));
-     }
+    for (i = 0; private_nets[i]; ++i) {
+      addr_policy_t newpolicy;
+      memcpy(&newpolicy, p, sizeof(addr_policy_t));
+      newpolicy.is_private = 0;
+      newpolicy.is_canonical = 0;
+      if (tor_addr_parse_mask_ports(private_nets[i], 0,
+       &newpolicy.addr,
+       &newpolicy.maskbits, &port_min, &port_max)<0) {
+        tor_assert_unreached();
+      }
+      smartlist_add(tmp, addr_policy_get_canonical_entry(&newpolicy));
+    }
      addr_policy_free(p);
   } SMARTLIST_FOREACH_END(p);
 

--- a/src/core/or/policies.c
+++ b/src/core/or/policies.c
@@ -224,7 +224,7 @@ parse_addr_policy(config_line_t *cfg, smartlist_t **dest,
       log_debug(LD_CONFIG,"Adding new entry '%s'",ent);
       malformed_list = 0;
       item = router_parse_addr_policy_item_from_string(ent, assume_action,
-                                                       &malformed_list);
+                                                       &malformed_list, true);
       if (item) {
         smartlist_add(result, item);
       } else if (malformed_list) {

--- a/src/feature/dirparse/policy_parse.c
+++ b/src/feature/dirparse/policy_parse.c
@@ -178,7 +178,7 @@ router_parse_addr_policy(directory_token_t *tok, unsigned fmt_flags)
   return result;
 }
 
-/** Parse an exit policy line of the format "accept[6]/reject[6] private[46]:...".
+/** Parse an exit policy line of the format "accept[6]/reject[6] private:...".
  * This didn't exist until Tor 0.1.1.15, so nobody should generate it in
  * router descriptors until earlier versions are obsolete.
  *
@@ -204,17 +204,14 @@ router_parse_addr_policy_private(directory_token_t *tok)
   /* we want to warn on accept6/reject6 in conjunction with IPv4 private addrs */
   bool has_ipv4_policies = (*arg != '6');
 
-  /* "private4" and "private6" which may be followed by a port specifier */
+  /* "private4" and "private6" keywords */
   if (*arg == '4' || *arg == '6')
     ++arg;
 
-  /* accept only "private", "private4", "private6", with or without following
-   * port, or bail */
-  if (*arg != ':' || *arg != '\0')
+  if (*arg != ':')
     return NULL;
 
-  /* handle port or bail */
-  if (*arg == ':' && parse_port_range(arg+1, &port_min, &port_max)<0)
+  if (parse_port_range(arg+1, &port_min, &port_max)<0)
     return NULL;
 
   memset(&result, 0, sizeof(result));

--- a/src/feature/dirparse/policy_parse.c
+++ b/src/feature/dirparse/policy_parse.c
@@ -203,15 +203,17 @@ router_parse_addr_policy_private(directory_token_t *tok)
     return NULL;
 
   switch (*arg) {
-    case '4':
+    case '4': /* "private4" */
       private_flag = ADDR_POLICY_PRIVATE4;
       break;
-    case '6':
+    case '6': /* "private6" */
       private_flag = ADDR_POLICY_PRIVATE6;
       break;
-    default:
+    case ':': /* "private" */
       private_flag = ADDR_POLICY_PRIVATE;
       break;
+    default: /* invalid token */
+      return NULL;
   }
 
   /* we want to warn on accept6/reject6 in conjunction with IPv4 private addrs */

--- a/src/feature/dirparse/policy_parse.c
+++ b/src/feature/dirparse/policy_parse.c
@@ -191,6 +191,7 @@ router_parse_addr_policy_private(directory_token_t *tok)
   const char *arg;
   uint16_t port_min, port_max;
   addr_policy_t result;
+  addr_policy_private_bitfield_t private_flag = ADDR_POLICY_NOT_PRIVATE;
 
   arg = tok->args[0];
   if (strcmpstart(arg, "private"))
@@ -201,11 +202,24 @@ router_parse_addr_policy_private(directory_token_t *tok)
   if (!arg)
     return NULL;
 
+  switch (*arg) {
+    case '4':
+      private_flag = ADDR_POLICY_PRIVATE4;
+      break;
+    case '6':
+      private_flag = ADDR_POLICY_PRIVATE6;
+      break;
+    default:
+      private_flag = ADDR_POLICY_PRIVATE;
+      break;
+  }
+
   /* we want to warn on accept6/reject6 in conjunction with IPv4 private addrs */
-  bool has_ipv4_policies = (*arg != '6');
+  bool has_ipv4_policies = (private_flag != ADDR_POLICY_PRIVATE6);
 
   /* "private4" and "private6" keywords */
-  if (*arg == '4' || *arg == '6')
+  if (private_flag == ADDR_POLICY_PRIVATE4 ||
+      private_flag == ADDR_POLICY_PRIVATE6)
     ++arg;
 
   if (*arg != ':')

--- a/src/feature/dirparse/policy_parse.h
+++ b/src/feature/dirparse/policy_parse.h
@@ -17,9 +17,10 @@
 struct directory_token_t;
 
 MOCK_DECL(addr_policy_t *, router_parse_addr_policy_item_from_string,
-         (const char *s, int assume_action, int *malformed_list));
+         (const char *s, int assume_action, int *malformed_list,
+          bool is_torrc));
 
 addr_policy_t *router_parse_addr_policy(struct directory_token_t *tok,
-                                        unsigned fmt_flags);
+                                        unsigned fmt_flags, bool is_torrc);
 
 #endif /* !defined(TOR_POLICY_PARSE_H) */

--- a/src/feature/dirparse/routerparse.c
+++ b/src/feature/dirparse/routerparse.c
@@ -1182,7 +1182,7 @@ router_add_exit_policy(routerinfo_t *router, directory_token_t *tok)
 {
   addr_policy_t *newe;
   /* Use the standard interpretation of accept/reject *, an IPv4 wildcard. */
-  newe = router_parse_addr_policy(tok, 0);
+  newe = router_parse_addr_policy(tok, 0, false);
   if (!newe)
     return -1;
   if (! router->exit_policy)

--- a/src/feature/nodelist/routerset.c
+++ b/src/feature/nodelist/routerset.c
@@ -142,7 +142,7 @@ routerset_parse(routerset_t *target, const char *s, const char *description)
       } else if ((strchr(nick,'.') || strchr(nick, ':') ||  strchr(nick, '*'))
                  && (p = router_parse_addr_policy_item_from_string(
                                      nick, ADDR_POLICY_REJECT,
-                                     &malformed_list))) {
+                                     &malformed_list, false))) {
         /* IPv4 addresses contain '.', IPv6 addresses contain ':',
          * and wildcard addresses contain '*'. */
         log_debug(LD_CONFIG, "Adding address %s to %s", nick, description);

--- a/src/test/test_policy.c
+++ b/src/test/test_policy.c
@@ -160,7 +160,7 @@ test_policies_general(void *arg)
   policy = smartlist_new();
 
   p = router_parse_addr_policy_item_from_string("reject 192.168.0.0/16:*", -1,
-                                                &malformed_list);
+                                                &malformed_list, false);
   tt_ptr_op(p, OP_NE, NULL);
   tt_int_op(ADDR_POLICY_REJECT,OP_EQ, p->policy_type);
   tor_addr_from_ipv4h(&tar, 0xc0a80000u);
@@ -205,75 +205,75 @@ test_policies_general(void *arg)
 
   policy3 = smartlist_new();
   p = router_parse_addr_policy_item_from_string("reject *:*", -1,
-                                                &malformed_list);
+                                                &malformed_list, false);
   tt_ptr_op(p, OP_NE, NULL);
   smartlist_add(policy3, p);
   p = router_parse_addr_policy_item_from_string("accept *:*", -1,
-                                                &malformed_list);
+                                                &malformed_list, false);
   tt_ptr_op(p, OP_NE, NULL);
   smartlist_add(policy3, p);
 
   policy4 = smartlist_new();
   p = router_parse_addr_policy_item_from_string("accept *:443", -1,
-                                                &malformed_list);
+                                                &malformed_list, false);
   tt_ptr_op(p, OP_NE, NULL);
   smartlist_add(policy4, p);
   p = router_parse_addr_policy_item_from_string("accept *:443", -1,
-                                                &malformed_list);
+                                                &malformed_list, false);
   tt_ptr_op(p, OP_NE, NULL);
   smartlist_add(policy4, p);
 
   policy5 = smartlist_new();
   p = router_parse_addr_policy_item_from_string("reject 0.0.0.0/8:*", -1,
-                                                &malformed_list);
+                                                &malformed_list, false);
   tt_ptr_op(p, OP_NE, NULL);
   smartlist_add(policy5, p);
   p = router_parse_addr_policy_item_from_string("reject 169.254.0.0/16:*", -1,
-                                                &malformed_list);
+                                                &malformed_list, false);
   tt_ptr_op(p, OP_NE, NULL);
   smartlist_add(policy5, p);
   p = router_parse_addr_policy_item_from_string("reject 127.0.0.0/8:*", -1,
-                                                &malformed_list);
+                                                &malformed_list, false);
   tt_ptr_op(p, OP_NE, NULL);
   smartlist_add(policy5, p);
   p = router_parse_addr_policy_item_from_string("reject 192.168.0.0/16:*",
-                                                -1, &malformed_list);
+                                                -1, &malformed_list, false);
   tt_ptr_op(p, OP_NE, NULL);
   smartlist_add(policy5, p);
   p = router_parse_addr_policy_item_from_string("reject 10.0.0.0/8:*", -1,
-                                                &malformed_list);
+                                                &malformed_list, false);
   tt_ptr_op(p, OP_NE, NULL);
   smartlist_add(policy5, p);
   p = router_parse_addr_policy_item_from_string("reject 172.16.0.0/12:*", -1,
-                                                &malformed_list);
+                                                &malformed_list, false);
   tt_ptr_op(p, OP_NE, NULL);
   smartlist_add(policy5, p);
   p = router_parse_addr_policy_item_from_string("reject 80.190.250.90:*", -1,
-                                                &malformed_list);
+                                                &malformed_list, false);
   tt_ptr_op(p, OP_NE, NULL);
   smartlist_add(policy5, p);
   p = router_parse_addr_policy_item_from_string("reject *:1-65534", -1,
-                                                &malformed_list);
+                                                &malformed_list, false);
   tt_ptr_op(p, OP_NE, NULL);
   smartlist_add(policy5, p);
   p = router_parse_addr_policy_item_from_string("reject *:65535", -1,
-                                                &malformed_list);
+                                                &malformed_list, false);
   tt_ptr_op(p, OP_NE, NULL);
   smartlist_add(policy5, p);
   p = router_parse_addr_policy_item_from_string("accept *:1-65535", -1,
-                                                &malformed_list);
+                                                &malformed_list, false);
   tt_ptr_op(p, OP_NE, NULL);
   smartlist_add(policy5, p);
 
   policy6 = smartlist_new();
   p = router_parse_addr_policy_item_from_string("accept 43.3.0.0/9:*", -1,
-                                                &malformed_list);
+                                                &malformed_list, false);
   tt_ptr_op(p, OP_NE, NULL);
   smartlist_add(policy6, p);
 
   policy7 = smartlist_new();
   p = router_parse_addr_policy_item_from_string("accept 0.0.0.0/8:*", -1,
-                                                &malformed_list);
+                                                &malformed_list, false);
   tt_ptr_op(p, OP_NE, NULL);
   smartlist_add(policy7, p);
 
@@ -295,13 +295,13 @@ test_policies_general(void *arg)
   /* accept6 * and reject6 * produce IPv6 wildcards only */
   policy10 = smartlist_new();
   p = router_parse_addr_policy_item_from_string("accept6 *:*", -1,
-                                                &malformed_list);
+                                                &malformed_list, false);
   tt_ptr_op(p, OP_NE, NULL);
   smartlist_add(policy10, p);
 
   policy11 = smartlist_new();
   p = router_parse_addr_policy_item_from_string("reject6 *:*", -1,
-                                                &malformed_list);
+                                                &malformed_list, false);
   tt_ptr_op(p, OP_NE, NULL);
   smartlist_add(policy11, p);
 
@@ -341,63 +341,63 @@ test_policies_general(void *arg)
   malformed_list = 0;
   p = router_parse_addr_policy_item_from_string("127.0.0.1",
                                                 ADDR_POLICY_ACCEPT,
-                                                &malformed_list);
+                                                &malformed_list, false);
   tt_assert(p);
   addr_policy_free(p);
   tt_assert(!malformed_list);
 
   p = router_parse_addr_policy_item_from_string("127.0.0.1:*",
                                                 ADDR_POLICY_ACCEPT,
-                                                &malformed_list);
+                                                &malformed_list, false);
   tt_assert(p);
   addr_policy_free(p);
   tt_assert(!malformed_list);
 
   p = router_parse_addr_policy_item_from_string("[::]",
                                                 ADDR_POLICY_ACCEPT,
-                                                &malformed_list);
+                                                &malformed_list, false);
   tt_assert(p);
   addr_policy_free(p);
   tt_assert(!malformed_list);
 
   p = router_parse_addr_policy_item_from_string("[::]:*",
                                                 ADDR_POLICY_ACCEPT,
-                                                &malformed_list);
+                                                &malformed_list, false);
   tt_assert(p);
   addr_policy_free(p);
   tt_assert(!malformed_list);
 
   p = router_parse_addr_policy_item_from_string("[face::b]",
                                                 ADDR_POLICY_ACCEPT,
-                                                &malformed_list);
+                                                &malformed_list, false);
   tt_assert(p);
   addr_policy_free(p);
   tt_assert(!malformed_list);
 
   p = router_parse_addr_policy_item_from_string("[b::aaaa]",
                                                 ADDR_POLICY_ACCEPT,
-                                                &malformed_list);
+                                                &malformed_list, false);
   tt_assert(p);
   addr_policy_free(p);
   tt_assert(!malformed_list);
 
   p = router_parse_addr_policy_item_from_string("*",
                                                 ADDR_POLICY_ACCEPT,
-                                                &malformed_list);
+                                                &malformed_list, false);
   tt_assert(p);
   addr_policy_free(p);
   tt_assert(!malformed_list);
 
   p = router_parse_addr_policy_item_from_string("*4",
                                                 ADDR_POLICY_ACCEPT,
-                                                &malformed_list);
+                                                &malformed_list, false);
   tt_assert(p);
   addr_policy_free(p);
   tt_assert(!malformed_list);
 
   p = router_parse_addr_policy_item_from_string("*6",
                                                 ADDR_POLICY_ACCEPT,
-                                                &malformed_list);
+                                                &malformed_list, false);
   tt_assert(p);
   addr_policy_free(p);
   tt_assert(!malformed_list);
@@ -405,21 +405,21 @@ test_policies_general(void *arg)
   /* These are all ambiguous IPv6 addresses, it's good that we reject them */
   p = router_parse_addr_policy_item_from_string("acce::abcd",
                                                 ADDR_POLICY_ACCEPT,
-                                                &malformed_list);
+                                                &malformed_list, false);
   tt_ptr_op(p, OP_EQ, NULL);
   tt_assert(malformed_list);
   malformed_list = 0;
 
   p = router_parse_addr_policy_item_from_string("7:1234",
                                                 ADDR_POLICY_ACCEPT,
-                                                &malformed_list);
+                                                &malformed_list, false);
   tt_ptr_op(p, OP_EQ, NULL);
   tt_assert(malformed_list);
   malformed_list = 0;
 
   p = router_parse_addr_policy_item_from_string("::",
                                                 ADDR_POLICY_ACCEPT,
-                                                &malformed_list);
+                                                &malformed_list, false);
   tt_ptr_op(p, OP_EQ, NULL);
   tt_assert(malformed_list);
   malformed_list = 0;
@@ -981,63 +981,63 @@ test_policies_general(void *arg)
 
   /* Make sure that IPv4 addresses are ignored in accept6/reject6 lines. */
   p = router_parse_addr_policy_item_from_string("accept6 1.2.3.4:*", -1,
-                                                &malformed_list);
+                                                &malformed_list, false);
   tt_ptr_op(p, OP_EQ, NULL);
   tt_assert(!malformed_list);
 
   p = router_parse_addr_policy_item_from_string("reject6 2.4.6.0/24:*", -1,
-                                                &malformed_list);
+                                                &malformed_list, false);
   tt_ptr_op(p, OP_EQ, NULL);
   tt_assert(!malformed_list);
 
   p = router_parse_addr_policy_item_from_string("accept6 *4:*", -1,
-                                                &malformed_list);
+                                                &malformed_list, false);
   tt_ptr_op(p, OP_EQ, NULL);
   tt_assert(!malformed_list);
 
   /* Make sure malformed policies are detected as such. */
   p = router_parse_addr_policy_item_from_string("bad_token *4:*", -1,
-                                                &malformed_list);
+                                                &malformed_list, false);
   tt_ptr_op(p, OP_EQ, NULL);
   tt_assert(malformed_list);
 
   p = router_parse_addr_policy_item_from_string("accept6 **:*", -1,
-                                                &malformed_list);
+                                                &malformed_list, false);
   tt_ptr_op(p, OP_EQ, NULL);
   tt_assert(malformed_list);
 
   p = router_parse_addr_policy_item_from_string("accept */15:*", -1,
-                                                &malformed_list);
+                                                &malformed_list, false);
   tt_ptr_op(p, OP_EQ, NULL);
   tt_assert(malformed_list);
 
   p = router_parse_addr_policy_item_from_string("reject6 */:*", -1,
-                                                &malformed_list);
+                                                &malformed_list, false);
   tt_ptr_op(p, OP_EQ, NULL);
   tt_assert(malformed_list);
 
   p = router_parse_addr_policy_item_from_string("accept 127.0.0.1/33:*", -1,
-                                                &malformed_list);
+                                                &malformed_list, false);
   tt_ptr_op(p, OP_EQ, NULL);
   tt_assert(malformed_list);
 
   p = router_parse_addr_policy_item_from_string("accept6 [::1]/129:*", -1,
-                                                &malformed_list);
+                                                &malformed_list, false);
   tt_ptr_op(p, OP_EQ, NULL);
   tt_assert(malformed_list);
 
   p = router_parse_addr_policy_item_from_string("reject 8.8.8.8/-1:*", -1,
-                                                &malformed_list);
+                                                &malformed_list, false);
   tt_ptr_op(p, OP_EQ, NULL);
   tt_assert(malformed_list);
 
   p = router_parse_addr_policy_item_from_string("reject 8.8.4.4:10-5", -1,
-                                                &malformed_list);
+                                                &malformed_list, false);
   tt_ptr_op(p, OP_EQ, NULL);
   tt_assert(malformed_list);
 
   p = router_parse_addr_policy_item_from_string("reject 1.2.3.4:-1", -1,
-                                                &malformed_list);
+                                                &malformed_list, false);
   tt_ptr_op(p, OP_EQ, NULL);
   tt_assert(malformed_list);
 
@@ -1443,7 +1443,7 @@ test_dump_exit_policy_to_string(void *arg)
  ri->policy_is_reject_star = 0;
 
  policy_entry = router_parse_addr_policy_item_from_string("accept *:*", -1,
-                                                          &malformed_list);
+                                                          &malformed_list, false);
 
  smartlist_add(ri->exit_policy,policy_entry);
 
@@ -1454,7 +1454,7 @@ test_dump_exit_policy_to_string(void *arg)
  tor_free(ep);
 
  policy_entry = router_parse_addr_policy_item_from_string("reject *:25", -1,
-                                                          &malformed_list);
+                                                          &malformed_list, false);
 
  smartlist_add(ri->exit_policy,policy_entry);
 
@@ -1466,7 +1466,7 @@ test_dump_exit_policy_to_string(void *arg)
 
  policy_entry =
  router_parse_addr_policy_item_from_string("reject 8.8.8.8:*", -1,
-                                           &malformed_list);
+                                           &malformed_list, false);
 
  smartlist_add(ri->exit_policy,policy_entry);
 
@@ -1477,7 +1477,7 @@ test_dump_exit_policy_to_string(void *arg)
 
  policy_entry =
  router_parse_addr_policy_item_from_string("reject6 [FC00::]/7:*", -1,
-                                           &malformed_list);
+                                           &malformed_list, false);
 
  smartlist_add(ri->exit_policy,policy_entry);
 
@@ -1489,7 +1489,7 @@ test_dump_exit_policy_to_string(void *arg)
 
  policy_entry =
  router_parse_addr_policy_item_from_string("accept6 [c000::]/3:*", -1,
-                                           &malformed_list);
+                                           &malformed_list, false);
 
  smartlist_add(ri->exit_policy,policy_entry);
 
@@ -1774,27 +1774,27 @@ test_policies_fascist_firewall_allows_address(void *arg)
   item = router_parse_addr_policy_item_from_string("accept "
                                                    TEST_IPV4_ADDR_STR ":*",
                                                    ADDR_POLICY_ACCEPT,
-                                                   &malformed_list);
+                                                   &malformed_list, false);
   tt_assert(item);
   tt_assert(!malformed_list);
   smartlist_add(policy, item);
   item = router_parse_addr_policy_item_from_string("accept "
                                                    TEST_IPV6_ADDR_STR,
                                                    ADDR_POLICY_ACCEPT,
-                                                   &malformed_list);
+                                                   &malformed_list, false);
   tt_assert(item);
   tt_assert(!malformed_list);
   smartlist_add(policy, item);
   /* Normally, policy_expand_unspec would do this for us */
   item = router_parse_addr_policy_item_from_string(REJECT_IPv4_FINAL_STR,
                                                    ADDR_POLICY_ACCEPT,
-                                                   &malformed_list);
+                                                   &malformed_list, false);
   tt_assert(item);
   tt_assert(!malformed_list);
   smartlist_add(policy, item);
   item = router_parse_addr_policy_item_from_string(REJECT_IPv6_FINAL_STR,
                                                    ADDR_POLICY_ACCEPT,
-                                                   &malformed_list);
+                                                   &malformed_list, false);
   tt_assert(item);
   tt_assert(!malformed_list);
   smartlist_add(policy, item);

--- a/src/test/test_routerset.c
+++ b/src/test/test_routerset.c
@@ -517,7 +517,7 @@ test_rset_parse_policy_ipv4(void *arg)
 addr_policy_t *
 rset_parse_policy_ipv4_parse_item_from_string(
                                       const char *s, int assume_action,
-                                      int *bogus)
+                                      int *bogus, bool is_torrc)
 {
   (void)s;
   (void)assume_action;


### PR DESCRIPTION
See [#40066](https://gitlab.torproject.org/tpo/core/tor/-/issues/40066) ticket for further details. Basically, add new `private4` and `private6` keywords for policies, make sure all warnings/errors in parsing are what we expect, and ensure we can pave the way toward obsoleting `accept6` and `reject6` in favour of `accept` and `reject` in the distant future.