### PR TITLE
Use _lseeki64() on windows.

### DIFF
--- a/changes/bug31036
+++ b/changes/bug31036
@@ -1,0 +1,3 @@
+  o Minor bugfixes (windows):
+    - Fix a bug that prevented Tor from starting if its log file
+      grew above 2GB.  Fixes bug 31036; bugfix on 0.2.1.8-alpha.

--- a/src/lib/fdio/fdio.c
+++ b/src/lib/fdio/fdio.c
@@ -43,7 +43,7 @@ off_t
 tor_fd_getpos(int fd)
 {
 #ifdef _WIN32
-  return (off_t) _lseek(fd, 0, SEEK_CUR);
+  return (off_t) _lseeki64(fd, 0, SEEK_CUR);
 #else
   return (off_t) lseek(fd, 0, SEEK_CUR);
 #endif
@@ -56,7 +56,7 @@ int
 tor_fd_seekend(int fd)
 {
 #ifdef _WIN32
-  return _lseek(fd, 0, SEEK_END) < 0 ? -1 : 0;
+  return _lseeki64(fd, 0, SEEK_END) < 0 ? -1 : 0;
 #else
   off_t rc = lseek(fd, 0, SEEK_END) < 0 ? -1 : 0;
 #ifdef ESPIPE
@@ -75,7 +75,7 @@ int
 tor_fd_setpos(int fd, off_t pos)
 {
 #ifdef _WIN32
-  return _lseek(fd, pos, SEEK_SET) < 0 ? -1 : 0;
+  return _lseeki64(fd, pos, SEEK_SET) < 0 ? -1 : 0;
 #else
   return lseek(fd, pos, SEEK_SET) < 0 ? -1 : 0;
 #endif


### PR DESCRIPTION
Fixes bug 31036; bugfix on 0.2.1.8-alpha when we moved the logging
system to use posix fds.