### PR TITLE
[Tor Gitlab #40072 - maint-0.4.4]: Fix startup crash with seccomp sandbox enabled

### DIFF
--- a/changes/bug40072
+++ b/changes/bug40072
@@ -1,0 +1,4 @@
+  o Minor bugfixes (linux seccomp2 sandbox):
+    - Fix startup crash with seccomp sandbox enabled when tor tries to
+      open the data directory. Patch from Daniel Pinto. Fixes bug 40072; 
+      bugfix on 0.4.4.3-alpha-dev.

--- a/scripts/maint/practracker/exceptions.txt
+++ b/scripts/maint/practracker/exceptions.txt
@@ -51,7 +51,7 @@ problem file-size /src/app/config/or_options_st.h 1050
 problem include-count /src/app/main/main.c 68
 problem function-size /src/app/main/main.c:dumpstats() 102
 problem function-size /src/app/main/main.c:tor_init() 101
-problem function-size /src/app/main/main.c:sandbox_init_filter() 291
+problem function-size /src/app/main/main.c:sandbox_init_filter() 302
 problem function-size /src/app/main/main.c:run_tor_main_loop() 105
 problem function-size /src/app/main/ntmain.c:nt_service_install() 126
 problem dependency-violation /src/core/crypto/hs_ntor.c 1

--- a/src/app/main/main.c
+++ b/src/app/main/main.c
@@ -841,8 +841,10 @@ sandbox_init_filter(void)
     OPEN_DATADIR2(name, name2 suffix);                  \
   } while (0)
 
+// KeyDirectory is a directory, but it is only opened in check_private_dir
+// which calls open instead of opendir
 #define OPEN_KEY_DIRECTORY() \
-  OPENDIR(options->KeyDirectory)
+  OPEN(options->KeyDirectory)
 #define OPEN_CACHEDIR(name)                      \
   sandbox_cfg_allow_open_filename(&cfg, get_cachedir_fname(name))
 #define OPEN_CACHEDIR_SUFFIX(name, suffix) do {  \
@@ -856,7 +858,9 @@ sandbox_init_filter(void)
     OPEN_KEYDIR(name suffix);                    \
   } while (0)
 
-  OPENDIR(options->DataDirectory);
+  // DataDirectory is a directory, but it is only opened in check_private_dir
+  // which calls open instead of opendir
+  OPEN(options->DataDirectory);
   OPEN_KEY_DIRECTORY();
 
   OPEN_CACHEDIR_SUFFIX("cached-certs", ".tmp");

--- a/src/lib/sandbox/sandbox.c
+++ b/src/lib/sandbox/sandbox.c
@@ -671,15 +671,7 @@ sb_opendir(scmp_filter_ctx ctx, sandbox_cfg_t *filter)
 
     if (param != NULL && param->prot == 1 && param->syscall
         == PHONY_OPENDIR_SYSCALL) {
-      if (libc_uses_openat_for_opendir()) {
-        rc = seccomp_rule_add_3(ctx, SCMP_ACT_ALLOW, SCMP_SYS(openat),
-            SCMP_CMP_NEG(0, SCMP_CMP_EQ, AT_FDCWD),
-            SCMP_CMP_STR(1, SCMP_CMP_EQ, param->value),
-            SCMP_CMP(2, SCMP_CMP_EQ, O_RDONLY|O_NONBLOCK|O_LARGEFILE|
-                O_DIRECTORY|O_CLOEXEC));
-      } else {
-        rc = allow_file_open(ctx, 0, param->value);
-      }
+      rc = allow_file_open(ctx, libc_uses_openat_for_opendir(), param->value);
       if (rc != 0) {
         log_err(LD_BUG,"(Sandbox) failed to add openat syscall, received "
             "libseccomp error %d", rc);


### PR DESCRIPTION
Fix crash introduced in #40020. On startup, tor calls
check_private_dir on the data and key directories. This function
uses open instead of opendir on the received directory. Data and
key directoryes are only opened here, so the seccomp rule added
should be for open instead of opendir, despite the fact that they
are directories.