### PR TITLE
Only log port self-testing message when we are _starting_ to test.

### DIFF
--- a/src/feature/relay/selftest.c
+++ b/src/feature/relay/selftest.c
@@ -57,11 +57,24 @@ static bool can_reach_or_port_ipv6 = false;
 /** Whether we can reach our DirPort from the outside. */
 static bool can_reach_dir_port = false;
 
+/** Has informed_testing_reachable logged a message about testing our IPv4
+ * ORPort? */
+static bool have_informed_testing_or_port_ipv4 = false;
+/** Has informed_testing_reachable logged a message about testing our IPv6
+ * ORPort? */
+static bool have_informed_testing_or_port_ipv6 = false;
+/** Has informed_testing_reachable logged a message about testing our
+ * DirPort? */
+static bool have_informed_testing_dir_port = false;
+
 /** Forget what we have learned about our reachability status. */
 void
 router_reset_reachability(void)
 {
   can_reach_or_port_ipv4 = can_reach_or_port_ipv6 = can_reach_dir_port = false;
+  have_informed_testing_or_port_ipv4 =
+    have_informed_testing_or_port_ipv6 =
+    have_informed_testing_dir_port = false;
 }
 
 /** Return 1 if we won't do reachability checks, because:
@@ -260,12 +273,9 @@ router_do_orport_reachability_checks(const routerinfo_t *me,
     log_info(LD_CIRC, "Testing %s of my %s ORPort: %s.",
              !orport_reachable ? "reachability" : "bandwidth",
              family_name, fmt_addrport_ap(ap));
-    if (!orport_reachable) {
-      /* This is only a 'reachability test' if we don't already think that
-       * the port is reachable.  If we _do_ think it's reachable, then
-       * it counts as a 'bandwidth test'. */
-      inform_testing_reachability(&ap->addr, ap->port, false);
-    }
+
+    inform_testing_reachability(&ap->addr, ap->port, false);
+
     circuit_launch_by_extend_info(CIRCUIT_PURPOSE_TESTING, ei,
                                   CIRCLAUNCH_NEED_CAPACITY|
                                   CIRCLAUNCH_IS_INTERNAL|
@@ -349,10 +359,13 @@ router_do_reachability_checks(int test_or, int test_dir)
 }
 
 /** Log a message informing the user that we are testing a port for
- * reachability.
+ * reachability, if we have not already logged such a message.
  *
  * If @a is_dirport is true, then the port is a DirPort; otherwise it is an
- * ORPort. */
+ * ORPort.
+ *
+ * Calls to rouer_reset_reachability() will reset our view of whether we have
+ * logged this message for a given port. */
 static void
 inform_testing_reachability(const tor_addr_t *addr,
                             uint16_t port,
@@ -360,6 +373,21 @@ inform_testing_reachability(const tor_addr_t *addr,
 {
   if (!router_get_my_routerinfo())
     return;
+
+  bool *have_informed_ptr;
+  if (is_dirport) {
+    have_informed_ptr = &have_informed_testing_dir_port;
+  } else if (tor_addr_family(addr) == AF_INET) {
+    have_informed_ptr = &have_informed_testing_or_port_ipv4;
+  } else {
+    have_informed_ptr = &have_informed_testing_or_port_ipv6;
+  }
+
+  if (*have_informed_ptr) {
+    /* We already told the user that we're testing this port; no need to
+     * do it again. */
+    return;
+  }
 
   char addr_buf[TOR_ADDRPORT_BUF_LEN];
   strlcpy(addr_buf, fmt_addrport(addr, port), sizeof(addr_buf));
@@ -377,6 +405,8 @@ inform_testing_reachability(const tor_addr_t *addr,
              "messages indicating success)",
              afname, port_type, addr_buf,
              TIMEOUT_UNTIL_UNREACHABILITY_COMPLAINT/60);
+
+  *have_informed_ptr = true;
 }
 
 /**


### PR DESCRIPTION
(Unlike approaches in earlier versions of Tor, this one logs if and
only if we are launching a test, and we haven't said that we're
testing this port.)

Fixes bug 40068; bug not in any released version.

Closes #40068.