### PR TITLE
Launch early reachability tests once a minute, not once a second.

### DIFF
--- a/changes/bug40083
+++ b/changes/bug40083
@@ -1,0 +1,5 @@
+  o Minor bugfixes (relay, self-testing):
+    - When starting up as a relay, if we haven't been able to verify that
+      we're reachable, only launch reachability tests at most once a minute.
+      Previously, we had been launching tests up to once a second, which
+      was needlessly noisy. Fixes bug 40083; bugfix on 0.2.8.1-alpha.

--- a/src/core/mainloop/mainloop.c
+++ b/src/core/mainloop/mainloop.c
@@ -2280,6 +2280,9 @@ check_for_reachability_bw_callback(time_t now, const or_options_t *options)
 {
   /* XXXX This whole thing was stuck in the middle of what is now
    * XXXX check_descriptor_callback.  I'm not sure it's right. */
+  /** How often should we consider launching reachability tests in our first
+   * TIMEOUT_UNTIL_UNREACHABILITY_COMPLAINT seconds? */
+#define EARLY_CHECK_REACHABILITY_INTERVAL (60)
 
   static int dirport_reachability_count = 0;
   /* also, check religiously for reachability, if it's within the first
@@ -2291,7 +2294,7 @@ check_for_reachability_bw_callback(time_t now, const or_options_t *options)
       router_do_reachability_checks(1, dirport_reachability_count==0);
       if (++dirport_reachability_count > 5)
         dirport_reachability_count = 0;
-      return 1;
+      return EARLY_CHECK_REACHABILITY_INTERVAL;
     } else {
       /* If we haven't checked for 12 hours and our bandwidth estimate is
        * low, do another bandwidth test. This is especially important for


### PR DESCRIPTION
This fixes bug 40083, which was introduced in 9f31908a in
0.2.8.1-alpha.