### PR TITLE
Fix allocation counting in clean_v2_descs_as_dir test.

### DIFF
--- a/changes/bug40099
+++ b/changes/bug40099
@@ -1,0 +1,4 @@
+  o Minor bugfixes (tests):
+    - Fix the behavior of the rend_cache/clean_v2_descs_as_dir when run on
+      its own.  Previously, it would exit with an error.
+      Fixes bug 40099; bugfix on 0.2.8.1-alpha.

--- a/src/test/test_rendcache.c
+++ b/src/test/test_rendcache.c
@@ -1101,6 +1101,7 @@ test_rend_cache_clean_v2_descs_as_dir(void *data)
   desc->timestamp = now;
   desc->pk = pk_generate(0);
   e->parsed = desc;
+  rend_cache_increment_allocation(rend_cache_entry_allocation(e));
   digestmap_set(rend_cache_v2_dir, key, e);
 
   /* Set the cutoff to minus 10 seconds. */
@@ -1250,4 +1251,3 @@ struct testcase_t rend_cache_tests[] = {
     test_rend_cache_validate_intro_point_failure, 0, NULL, NULL },
   END_OF_TESTCASES
 };
-


### PR DESCRIPTION
Without this fix, running this test on its own would fail.

Fixes bug 40099. Bugfix on ade5005853c17b3 in 0.2.8.1-alpha.