### PR TITLE
[Tor Gitlab #40102]: Make options_init_from_torrc smaller

### DIFF
--- a/changes/ticket40102
+++ b/changes/ticket40102
@@ -1,0 +1,4 @@
+  o Code simplification and refactoring:
+    - Split implementation of several command line options from
+      options_init_from_torrc into smaller isolated functions.
+      Patch by Daniel Pinto. Closes ticket 40102.

--- a/scripts/maint/practracker/exceptions.txt
+++ b/scripts/maint/practracker/exceptions.txt
@@ -37,7 +37,7 @@ problem file-size /src/app/config/config.c 7525
 problem include-count /src/app/config/config.c 81
 problem function-size /src/app/config/config.c:options_act() 381
 problem function-size /src/app/config/config.c:options_validate_cb() 794
-problem function-size /src/app/config/config.c:options_init_from_torrc() 230
+problem function-size /src/app/config/config.c:options_init_from_torrc() 139
 problem function-size /src/app/config/config.c:options_init_from_string() 103
 problem function-size /src/app/config/config.c:options_init_logs() 125
 problem function-size /src/app/config/config.c:parse_bridge_line() 104


### PR DESCRIPTION
Split implementation of several command line options from
options_init_from_torrc into smaller isolated functions.