### PR TITLE
Resolve some coverity complaints in test_util_glob().

### DIFF
--- a/src/test/test_util.c
+++ b/src/test/test_util.c
@@ -4670,7 +4670,9 @@ test_util_get_glob_opened_files(void *ptr)
   // used for cleanup
   char *dir1_forbidden = NULL, *dir2_forbidden = NULL;
   char *forbidden_forbidden = NULL;
+#ifndef _WIN32
   int chmod_failed;
+#endif
 
   dirname = tor_strdup(get_fname("test_get_glob_opened_files"));
   tt_ptr_op(dirname, OP_NE, NULL);

--- a/src/test/test_util.c
+++ b/src/test/test_util.c
@@ -4475,11 +4475,11 @@ test_util_glob(void *ptr)
   tor_asprintf(&forbidden_forbidden,
                "%s"PATH_SEPARATOR"forbidden"PATH_SEPARATOR"forbidden",dirname);
 #ifndef _WIN32
-  chmod(forbidden, 0700);
+  tt_int_op(0, OP_EQ, chmod(forbidden, 0700));
 #endif
   tt_int_op(0, OP_EQ, create_test_directory_structure(forbidden));
 #ifndef _WIN32
-  chmod(forbidden, 0);
+  tt_int_op(0, OP_EQ, chmod(forbidden, 0));
 #endif
 
 #define TEST(input) \
@@ -4638,10 +4638,10 @@ test_util_glob(void *ptr)
 
  done:
 #ifndef _WIN32
-  chmod(forbidden, 0700);
-  chmod(dir1_forbidden, 0700);
-  chmod(dir2_forbidden, 0700);
-  chmod(forbidden_forbidden, 0700);
+  (void) chmod(forbidden, 0700);
+  (void) chmod(dir1_forbidden, 0700);
+  (void) chmod(dir2_forbidden, 0700);
+  (void) chmod(forbidden_forbidden, 0700);
 #endif
   tor_free(dir1);
   tor_free(dir2);
@@ -4670,6 +4670,7 @@ test_util_get_glob_opened_files(void *ptr)
   // used for cleanup
   char *dir1_forbidden = NULL, *dir2_forbidden = NULL;
   char *forbidden_forbidden = NULL;
+  int chmod_failed;
 
   dirname = tor_strdup(get_fname("test_get_glob_opened_files"));
   tt_ptr_op(dirname, OP_NE, NULL);
@@ -4825,10 +4826,18 @@ test_util_get_glob_opened_files(void *ptr)
 
  done:
 #ifndef _WIN32
-  chmod(forbidden, 0700);
-  chmod(dir1_forbidden, 0700);
-  chmod(dir2_forbidden, 0700);
-  chmod(forbidden_forbidden, 0700);
+  chmod_failed = 0;
+  if (forbidden)
+    chmod_failed |= chmod(forbidden, 0700);
+  if (dir1_forbidden)
+    chmod_failed |= chmod(dir1_forbidden, 0700);
+  if (dir2_forbidden)
+    chmod_failed |= chmod(dir2_forbidden, 0700);
+  if (forbidden_forbidden)
+    chmod_failed |= chmod(forbidden_forbidden, 0700);
+  if (chmod_failed) {
+    TT_FAIL(("unable to chmod a file on cleanup: %s", strerror(errno)));
+  }
 #endif
   tor_free(dir1);
   tor_free(dir2);


### PR DESCRIPTION
Coverity's first complaint was that we didn't check the return
values from chmod.  That's easily fixed.

Coverity's second complaint was that there were code paths where we pass
NULL to chmod.  For example, if this line failed, we'd "goto done",
and then pass NULL to chmod.
  tt_ptr_op(dirname, OP_NE, NULL);

Closes #40103.  Bug not in any released Tor.