### PR TITLE
Avoid guard-related warning when upgrading from 043 to 044.

### DIFF
--- a/changes/bug40105
+++ b/changes/bug40105
@@ -1,0 +1,3 @@
+  o Minor bugfixes (guard selection algorithm):
+    - Avoid needless guard-related warning when upgrading from 0.4.3 to 0.4.4.
+      Fixes bug 40105; bugfix on 0.4.4.1-alpha.

--- a/src/feature/client/entrynodes.c
+++ b/src/feature/client/entrynodes.c
@@ -3139,9 +3139,9 @@ entry_guard_parse_from_state(const char *s)
 
     guard->sampled_idx = guard->confirmed_idx;
   } else {
-    log_warn(LD_GUARD, "The state file seems to be into a status that could"
-        " yield to weird entry node selection: we're missing both a"
-        " sampled_idx and a confirmed_idx.");
+    log_info(LD_GUARD, "The state file seems to be into a status that could"
+             " yield to weird entry node selection: we're missing both a"
+             " sampled_idx and a confirmed_idx.");
     guard->sampled_idx = invalid_sampled_idx++;
   }
 


### PR DESCRIPTION
Fixes #40105.