### PR TITLE
conn: Remove assert on new listener connection when retrying

### DIFF
--- a/changes/ticket40073
+++ b/changes/ticket40073
@@ -1,0 +1,3 @@
+  o Minor bugfixes (relay configuration, crash):
+    - Avoid a fatal assert() when failing to create a listener connection for an
+      address that was in use. Fixes bug 40073; bugfix on 0.3.5.1-alpha.

--- a/src/core/mainloop/connection.c
+++ b/src/core/mainloop/connection.c
@@ -2923,7 +2923,14 @@ retry_all_listeners(smartlist_t *new_conns, int close_all_noncontrol)
                                                   &skip, &addr_in_use);
     }
 
-    tor_assert(new_conn);
+    /* There are many reasons why we can't open a new listener port so in case
+     * we hit those, bail early so tor can stop. */
+    if (!new_conn) {
+      log_warn(LD_NET, "Unable to create listener port: %s:%d",
+               fmt_addr(&r->new_port->addr), r->new_port->port);
+      retval = -1;
+      break;
+    }
 
     smartlist_add(new_conns, new_conn);
 


### PR DESCRIPTION
Opening a new listener connection can fail in many ways like a bind()
permission denied on a low port for instance.

And thus, we should expect to handle an error when creating a new one instead
of assert() on it.

To hit the removed assert:

  ORPort 80
  KeepBindCapabilities 0

Start tor. Then edit torrc:

  ORPort <some-IP>:80

HUP tor and the assert is hit.

Fixes #40073

Signed-off-by: David Goulet <dgoulet@torproject.org>