### PR TITLE
statistics: Properly count all rendezvous cells (avoid undercounting).

### DIFF
--- a/changes/bug40117
+++ b/changes/bug40117
@@ -1,0 +1,5 @@
+  o Major bugfixes (stats, onion services):
+    - Fix a bug where we were undercounting the Tor network's total onion
+      service traffic, by only counting rendezvous traffic originating from
+      services and ignoring any traffic originating from clients. Fixes bug
+      40117; bugfix on 0.2.6.2-alpha.

--- a/src/feature/rend/rendmid.c
+++ b/src/feature/rend/rendmid.c
@@ -343,10 +343,12 @@ rend_mid_rendezvous(or_circuit_t *circ, const uint8_t *request,
     goto err;
   }
 
-  /* Statistics: Mark this circuit as an RP circuit so that we collect
-     stats from it. */
+  /* Statistics: Mark circuits as RP circuits */
   if (options->HiddenServiceStatistics) {
+    /* `circ` is the RP <-> service circuit */
     circ->circuit_carries_hs_traffic_stats = 1;
+    /* `rend_circ` is the client <-> RP circuit */
+    rend_circ->circuit_carries_hs_traffic_stats = 1;
   }
 
   /* Send the RENDEZVOUS2 cell to the client. */


### PR DESCRIPTION
tl;dr We were not counting cells flying from the client to the service, but we
were counting cells flying from the service to the client.

When a rendezvous cell arrives from the client to the RP, the RP forwards it to
the service.

For this to happen, the cell first passes through command_process_relay_cell()
which normally does the statistics counting. However because the `rend_circ`
circuit was not flagged with `circuit_carries_hs_traffic_stats` in
rend_mid_rendezvous(), the cell is not counted there.

Then the cell goes to circuit_receive_relay_cell() which has a special code
block based on `rend_splice` specifically for rendezvous cells, and the cell
gets directly passed to `rend_circ` via a direct call to
circuit_receive_relay_cell(). The cell never passes through
command_process_relay_cell() ever again and hence is never counted by our
rephist module.

The fix here is to flag the `rend_circ` circuit with
`circuit_carries_hs_traffic_stats` so that the cell is counted as soon as it
hits command_process_relay_cell().

Furthermore we avoid double-counting cells since the special code block of
circuit_receive_relay_cell() makes us count rendezvous cells only as they enter
the RP and not as they exit it.

Fixes #40117.