### PR TITLE
test: Increment rend cache allocation before freeing

### DIFF
--- a/changes/ticket40125
+++ b/changes/ticket40125
@@ -1,0 +1,4 @@
+  o Testing (onion service v2):
+    - Fix a rendezvous cache unit test that was triggering an underflow on the
+      global rend cache allocation. Fixes bug 40125; bugfix on
+      0.2.8.1-alpha.

--- a/src/test/test_rendcache.c
+++ b/src/test/test_rendcache.c
@@ -978,11 +978,13 @@ test_rend_cache_entry_free(void *data)
 
   // Handles NULL descriptor correctly
   e = tor_malloc_zero(sizeof(rend_cache_entry_t));
+  rend_cache_increment_allocation(rend_cache_entry_allocation(e));
   rend_cache_entry_free(e);
 
   // Handles non-NULL descriptor correctly
   e = tor_malloc_zero(sizeof(rend_cache_entry_t));
   e->desc = tor_malloc(10);
+  rend_cache_increment_allocation(rend_cache_entry_allocation(e));
   rend_cache_entry_free(e);
 
  /* done: */


### PR DESCRIPTION
The rend_cache/entry_free was missing the rend cache allocation increment
before freeing the object.

Without it, it had an underflow bug:

  Sep 17 08:40:13.845 [warn] rend_cache_decrement_allocation(): Bug: Underflow
  in rend_cache_decrement_allocation (on Tor 0.4.5.0-alpha-dev
  7eef9ced61e72b1d)

Fixes #40125

Signed-off-by: David Goulet <dgoulet@torproject.org>