### PR TITLE
Remove support for old android "logcat" API

### DIFF
--- a/changes/ticket32181
+++ b/changes/ticket32181
@@ -1,0 +1,4 @@
+  o Removed features:
+    - We no longer ship support for the Android logging API. Modern
+      versions of Android can use the syslog API instead.
+      Closes ticket 32181.

--- a/configure.ac
+++ b/configure.ac
@@ -328,10 +328,6 @@ AM_CONDITIONAL([USE_ANDROID], [test "x$enable_android" = "xyes"])
 if test "x$enable_android" = "xyes"; then
   AC_DEFINE([USE_ANDROID], [1], [Compile with Android specific features enabled])
 
-  dnl Check if the Android log library is available.
-  AC_CHECK_HEADERS([android/log.h])
-  AC_SEARCH_LIBS(__android_log_write, [log])
-
 fi
 
 dnl ---

--- a/doc/man/tor.1.txt
+++ b/doc/man/tor.1.txt
@@ -276,11 +276,6 @@ forward slash (/) in the configuration file and on the command line.
     AlternateBridgeAuthority replaces the default bridge authority,
     but leaves the directory authorities alone.
 
-[[AndroidIdentityTag]] **AndroidIdentityTag** __tag__::
-    When logging to Android's logging subsystem, adds a tag to the log identity
-    such that log entries are marked with "Tor-__tag__". Can not be changed while
-    tor is running. (Default: none)
-
 [[AvoidDiskWrites]] **AvoidDiskWrites** **0**|**1**::
     If non-zero, try to write to disk less frequently than we would otherwise.
     This is useful when running on flash memory or other media that support
@@ -688,7 +683,7 @@ forward slash (/) in the configuration file and on the command line.
     Signal-safe logs are always sent to stderr or stdout. They are also sent to
     a limited number of log files that are configured to log messages at error
     severity from the bug or general domains. They are never sent as syslogs,
-    android logs, control port log events, or to any API-based log
+    control port log events, or to any API-based log
     destinations.
 
 [[Log2]] **Log** __minSeverity__[-__maxSeverity__] **file** __FILENAME__::

--- a/src/app/config/config.c
+++ b/src/app/config/config.c
@@ -548,7 +548,7 @@ static const config_var_t option_vars_[] = {
   V(LogTimeGranularity,          MSEC_INTERVAL, "1 second"),
   V(TruncateLogFile,             BOOL,     "0"),
   V_IMMUTABLE(SyslogIdentityTag, STRING,   NULL),
-  V_IMMUTABLE(AndroidIdentityTag,STRING,   NULL),
+  OBSOLETE("AndroidIdentityTag"),
   V(LongLivedPorts,              CSV,
         "21,22,706,1863,5050,5190,5222,5223,6523,6667,6697,8300"),
   VAR("MapAddress",              LINELIST, AddressMap,           NULL),
@@ -4934,15 +4934,19 @@ options_init_logs(const or_options_t *old_options, const or_options_t *options,
         goto cleanup;
       }
 
+      /* We added this workaround in 0.4.5.x; we can remove it in 0.4.6 or
+       * later */
       if (!strcasecmp(smartlist_get(elts, 0), "android")) {
-#ifdef HAVE_ANDROID_LOG_H
+#ifdef HAVE_SYSLOG_H
+        log_warn(LD_CONFIG, "The android logging API is no longer supported;"
+                            " adding a syslog instead. The 'android' logging "
+                            " type will no longer work in the future.");
         if (!validate_only) {
-          add_android_log(severity, options->AndroidIdentityTag);
+          add_syslog_log(severity, options->SyslogIdentityTag);
         }
 #else
-        log_warn(LD_CONFIG, "Android logging is not supported"
-                            " on this system. Sorry.");
-#endif /* defined(HAVE_ANDROID_LOG_H) */
+        log_warn(LD_CONFIG, "The android logging API is no longer supported.");
+#endif
         goto cleanup;
       }
     }

--- a/src/app/config/or_options_st.h
+++ b/src/app/config/or_options_st.h
@@ -58,7 +58,6 @@ struct or_options_t {
   int TruncateLogFile; /**< Boolean: Should we truncate the log file
                             before we start writing? */
   char *SyslogIdentityTag; /**< Identity tag to add for syslog logging. */
-  char *AndroidIdentityTag; /**< Identity tag to add for Android logging. */
 
   char *DebugLogFile; /**< Where to send verbose log messages. */
   char *DataDirectory_option; /**< Where to store long-term data, as

--- a/src/lib/log/log.c
+++ b/src/lib/log/log.c
@@ -51,10 +51,6 @@
 #include "lib/fdio/fdio.h"
 #include "lib/cc/ctassert.h"
 
-#ifdef HAVE_ANDROID_LOG_H
-#include <android/log.h>
-#endif // HAVE_ANDROID_LOG_H.
-
 /** @{ */
 /** The string we stick at the end of a log message when it is too long,
  * and its length. */
@@ -78,8 +74,6 @@ typedef struct logfile_t {
   int needs_close; /**< Boolean: true if the stream gets closed on shutdown. */
   int is_temporary; /**< Boolean: close after initializing logging subsystem.*/
   int is_syslog; /**< Boolean: send messages to syslog. */
-  int is_android; /**< Boolean: send messages to Android's log subsystem. */
-  char *android_tag; /**< Identity Tag used in Android's log subsystem. */
   log_callback callback; /**< If not NULL, send messages to this function. */
   log_severity_list_t *severities; /**< Which severity of messages should we
                                     * log for each log domain? */
@@ -125,33 +119,6 @@ should_log_function_name(log_domain_mask_t domain, int severity)
       raw_assert(0); return 0; // LCOV_EXCL_LINE
   }
 }
-
-#ifdef HAVE_ANDROID_LOG_H
-/** Helper function to convert Tor's log severity into the matching
- * Android log priority.
- */
-static int
-severity_to_android_log_priority(int severity)
-{
-  switch (severity) {
-    case LOG_DEBUG:
-      return ANDROID_LOG_VERBOSE;
-    case LOG_INFO:
-      return ANDROID_LOG_DEBUG;
-    case LOG_NOTICE:
-      return ANDROID_LOG_INFO;
-    case LOG_WARN:
-      return ANDROID_LOG_WARN;
-    case LOG_ERR:
-      return ANDROID_LOG_ERROR;
-    default:
-      // LCOV_EXCL_START
-      raw_assert(0);
-      return 0;
-      // LCOV_EXCL_STOP
-  }
-}
-#endif /* defined(HAVE_ANDROID_LOG_H) */
 
 /** A mutex to guard changes to logfiles and logging. */
 static tor_mutex_t log_mutex;
@@ -475,13 +442,13 @@ pending_log_message_free_(pending_log_message_t *msg)
 }
 
 /** Helper function: returns true iff the log file, given in <b>lf</b>, is
- * handled externally via the system log API, the Android logging API, or is an
+ * handled externally via the system log API, or is an
  * external callback function. */
 static inline int
 logfile_is_external(const logfile_t *lf)
 {
   raw_assert(lf);
-  return lf->is_syslog || lf->is_android || lf->callback;
+  return lf->is_syslog || lf->callback;
 }
 
 /** Return true iff <b>lf</b> would like to receive a message with the
@@ -537,11 +504,6 @@ logfile_deliver(logfile_t *lf, const char *buf, size_t msg_len,
     syslog(severity, "%s", msg_after_prefix);
 #endif /* defined(MAXLINE) */
 #endif /* defined(HAVE_SYSLOG_H) */
-  } else if (lf->is_android) {
-#ifdef HAVE_ANDROID_LOG_H
-    int priority = severity_to_android_log_priority(severity);
-    __android_log_write(priority, lf->android_tag, msg_after_prefix);
-#endif // HAVE_ANDROID_LOG_H.
   } else if (lf->callback) {
     if (domain & LD_NOCB) {
       if (!*callbacks_deferred && pending_cb_messages) {
@@ -677,7 +639,7 @@ tor_log_update_sigsafe_err_fds(void)
   n_fds = 1;
 
   for (lf = logfiles; lf; lf = lf->next) {
-     /* Don't try callback to the control port, syslogs, android logs, or any
+     /* Don't try callback to the control port, syslogs, or any
       * other non-file descriptor log: We can't call arbitrary functions from a
       * signal handler.
       */
@@ -775,7 +737,6 @@ log_free_(logfile_t *victim)
     return;
   tor_free(victim->severities);
   tor_free(victim->filename);
-  tor_free(victim->android_tag);
   tor_free(victim);
 }
 
@@ -1247,39 +1208,6 @@ add_syslog_log(const log_severity_list_t *severity,
 }
 #endif /* defined(HAVE_SYSLOG_H) */
 
-#ifdef HAVE_ANDROID_LOG_H
-/**
- * Add a log handler to send messages to the Android platform log facility.
- */
-int
-add_android_log(const log_severity_list_t *severity,
-                const char *android_tag)
-{
-  logfile_t *lf = NULL;
-
-  lf = tor_malloc_zero(sizeof(logfile_t));
-  lf->fd = -1;
-  lf->severities = tor_memdup(severity, sizeof(log_severity_list_t));
-  lf->filename = tor_strdup("<android>");
-  lf->is_android = 1;
-
-  if (android_tag == NULL)
-    lf->android_tag = tor_strdup("Tor");
-  else {
-    char buf[256];
-    tor_snprintf(buf, sizeof(buf), "Tor-%s", android_tag);
-    lf->android_tag = tor_strdup(buf);
-  }
-
-  LOCK_LOGS();
-  lf->next = logfiles;
-  logfiles = lf;
-  log_global_min_severity_ = get_min_log_level();
-  UNLOCK_LOGS();
-  return 0;
-}
-#endif /* defined(HAVE_ANDROID_LOG_H) */
-
 /** If <b>level</b> is a valid log severity, return the corresponding
  * numeric value.  Otherwise, return -1. */
 int
@@ -1457,8 +1385,7 @@ parse_log_severity_config(const char **cfg_ptr,
     if (!strcasecmpstart(cfg, "file") ||
         !strcasecmpstart(cfg, "stderr") ||
         !strcasecmpstart(cfg, "stdout") ||
-        !strcasecmpstart(cfg, "syslog") ||
-        !strcasecmpstart(cfg, "android")) {
+        !strcasecmpstart(cfg, "syslog")) {
       goto done;
     }
     if (got_an_unqualified_range > 1)

--- a/src/lib/log/log.h
+++ b/src/lib/log/log.h
@@ -175,10 +175,6 @@ MOCK_DECL(int, add_file_log,(const log_severity_list_t *severity,
 int add_syslog_log(const log_severity_list_t *severity,
                    const char* syslog_identity_tag);
 #endif // HAVE_SYSLOG_H.
-#ifdef HAVE_ANDROID_LOG_H
-int add_android_log(const log_severity_list_t *severity,
-                    const char *android_identity_tag);
-#endif // HAVE_ANDROID_LOG_H.
 int add_callback_log(const log_severity_list_t *severity, log_callback cb);
 typedef void (*pending_callback_callback)(void);
 void logs_set_pending_callback_callback(pending_callback_callback cb);


### PR DESCRIPTION
This is apparently obsolete; syslog is modern instead.  If users
have an android log configured, given them a syslog if we can.

Closes #32181.