### PR TITLE
Remove long-obsolete members from the state file.

### DIFF
--- a/changes/ticket40137
+++ b/changes/ticket40137
@@ -1,0 +1,6 @@
+  o Minor features (state):
+    - When loading the state file, remove entries from the statefile that
+      have been obsolete for a long time.  Ordinarily Tor preserves
+      unrecognized entries in order to keep forward-compatibility, but
+      these statefile entries have not actually been used in any release
+      since before the 0.3.5.x. Closes ticket 40137.

--- a/src/app/config/or_state_st.h
+++ b/src/app/config/or_state_st.h
@@ -38,16 +38,10 @@ struct or_state_t {
   uint64_t AccountingBytesAtSoftLimit;
   uint64_t AccountingExpectedUsage;
 
-  /** A list of Entry Guard-related configuration lines. (pre-prop271) */
-  struct config_line_t *EntryGuards;
-
-  /** A list of guard-related configuration lines. (post-prop271) */
+  /** A list of guard-related configuration lines. */
   struct config_line_t *Guard;
 
   struct config_line_t *TransportProxies;
-
-  /** Cached revision counters for active hidden services on this host */
-  struct config_line_t *HidServRevCounter;
 
   /** These fields hold information on the history of bandwidth usage for
    * servers.  The "Ends" fields hold the time when we last updated the

--- a/src/app/config/statefile.h
+++ b/src/app/config/statefile.h
@@ -33,6 +33,7 @@ STATIC void or_state_free_(or_state_t *state);
 STATIC or_state_t *or_state_new(void);
 struct config_mgr_t;
 STATIC const struct config_mgr_t *get_state_mgr(void);
+STATIC void or_state_remove_obsolete_lines(struct config_line_t **extra_lines);
 #endif /* defined(STATEFILE_PRIVATE) */
 
 #endif /* !defined(TOR_STATEFILE_H) */

--- a/src/test/include.am
+++ b/src/test/include.am
@@ -234,6 +234,7 @@ src_test_test_SOURCES += \
 	src/test/test_sendme.c \
 	src/test/test_shared_random.c \
 	src/test/test_socks.c \
+	src/test/test_statefile.c \
 	src/test/test_stats.c \
 	src/test/test_status.c \
 	src/test/test_storagedir.c \

--- a/src/test/test.c
+++ b/src/test/test.c
@@ -769,6 +769,7 @@ struct testgroup_t testgroups[] = {
   { "sendme/", sendme_tests },
   { "shared-random/", sr_tests },
   { "socks/", socks_tests },
+  { "statefile/", statefile_tests },
   { "stats/", stats_tests },
   { "status/" , status_tests },
   { "storagedir/", storagedir_tests },

--- a/src/test/test.h
+++ b/src/test/test.h
@@ -186,6 +186,7 @@ extern struct testcase_t scheduler_tests[];
 extern struct testcase_t sendme_tests[];
 extern struct testcase_t socks_tests[];
 extern struct testcase_t sr_tests[];
+extern struct testcase_t statefile_tests[];
 extern struct testcase_t stats_tests[];
 extern struct testcase_t status_tests[];
 extern struct testcase_t storagedir_tests[];

--- a/src/test/test_statefile.c
+++ b/src/test/test_statefile.c
@@ -1,0 +1,56 @@
+/* Copyright (c) 2001-2004, Roger Dingledine.
+ * Copyright (c) 2004-2006, Roger Dingledine, Nick Mathewson.
+ * Copyright (c) 2007-2020, The Tor Project, Inc. */
+/* See LICENSE for licensing information */
+
+#include "orconfig.h"
+
+#define STATEFILE_PRIVATE
+
+#include "core/or/or.h"
+#include "lib/encoding/confline.h"
+#include "app/config/statefile.h"
+
+#include "test/test.h"
+
+static void
+test_statefile_remove_obsolete(void *arg)
+{
+  (void)arg;
+  config_line_t *inp = NULL;
+  /* try empty config */
+  or_state_remove_obsolete_lines(&inp);
+  tt_assert(!inp);
+
+  /* try removing every line */
+  config_line_append(&inp, "EntryGuard", "doesn't matter");
+  config_line_append(&inp, "HidServRevCounter", "ignore");
+  config_line_append(&inp, "hidservrevcounter", "foobar"); // note case
+  or_state_remove_obsolete_lines(&inp);
+  tt_assert(!inp);
+
+  /* Now try removing a subset of lines. */
+  config_line_append(&inp, "EntryGuard", "doesn't matter");
+  config_line_append(&inp, "Guard", "in use");
+  config_line_append(&inp, "HidServRevCounter", "ignore");
+  config_line_append(&inp, "TorVersion", "this test doesn't care");
+  or_state_remove_obsolete_lines(&inp);
+  tt_assert(inp);
+  tt_str_op(inp->key, OP_EQ, "Guard");
+  tt_str_op(inp->value, OP_EQ, "in use");
+  tt_assert(inp->next);
+  tt_str_op(inp->next->key, OP_EQ, "TorVersion");
+  tt_str_op(inp->next->value, OP_EQ, "this test doesn't care");
+  tt_assert(! inp->next->next);
+
+ done:
+  config_free_lines(inp);
+}
+
+#define T(name) \
+  { #name, test_statefile_##name, 0, NULL, NULL }
+
+struct testcase_t statefile_tests[] = {
+  T(remove_obsolete),
+  END_OF_TESTCASES
+};


### PR DESCRIPTION
Tor has a feature to preserve unrecognized state file entries in
order to maintain forward compatibility.  But this feature, along
with some unused code that we never actually removed, led to us
keeping items that were of no use to the user, other than at worst
to preserve ancient information about them.

This commit adds a feature to remove obsolete entries when we load
the file.

Closes ticket 40137.