### PR TITLE
[Tor Trac #40141]: Fix %include bug with pattern with */ on glibc < 2.19

### DIFF
--- a/changes/bug40141
+++ b/changes/bug40141
@@ -1,0 +1,4 @@
+  o Minor bugfixes (configuration):
+    - Fix bug where %including a pattern ending with */ would include files
+      and folders (instead of folders only) in versions of glibc < 2.19.
+      Fixes bug 40141; bugfix on 0.4.5.0-alpha-dev. Patch by Daniel Pinto.


### PR DESCRIPTION
Fix bug where %including a pattern ending in */ would include
files and folders (instead of folders only) in versions of
glibc < 2.19.