### PR TITLE
Turn ConsensusParams into a Linelist

### DIFF
--- a/changes/ticket40164
+++ b/changes/ticket40164
@@ -1,0 +1,6 @@
+  o Minor features:
+    - Make it possible to specify multiple ConsensusParams torrc lines.
+      Now directory authority operators can for example put the main
+      ConsensusParams config in one torrc file and then add to it from
+      a different torrc file. Closes ticket 40164.
+

--- a/doc/tor.1.txt
+++ b/doc/tor.1.txt
@@ -3014,7 +3014,8 @@ on the public Tor network.
 
 [[ConsensusParams]] **ConsensusParams** __STRING__::
     STRING is a space-separated list of key=value pairs that Tor will include
-    in the "params" line of its networkstatus vote.
+    in the "params" line of its networkstatus vote. This directive can be
+    specified multiple times so you don't have to put it all on one line.
 
 [[DirAllowPrivateAddresses]] **DirAllowPrivateAddresses** **0**|**1**::
     If set to 1, Tor will accept server descriptors with arbitrary "Address"

--- a/src/feature/dirauth/dirauth_options.inc
+++ b/src/feature/dirauth/dirauth_options.inc
@@ -46,7 +46,7 @@ CONF_VAR(AuthDirTestEd25519LinkKeys, BOOL, 0, "1")
 
 /** Authority only: key=value pairs that we add to our networkstatus
  * consensus vote on the 'params' line. */
-CONF_VAR(ConsensusParams, STRING, 0, NULL)
+CONF_VAR(ConsensusParams, LINELIST, 0, NULL)
 
 /** Authority only: minimum number of measured bandwidths we must see
  * before we only believe measured bandwidths to assign flags. */

--- a/src/feature/dirauth/dirvote.c
+++ b/src/feature/dirauth/dirvote.c
@@ -4709,9 +4709,12 @@ dirserv_generate_networkstatus_vote_obj(crypto_pk_t *private_key,
   smartlist_sort_strings(v3_out->known_flags);
 
   if (d_options->ConsensusParams) {
+    config_line_t *paramline = d_options->ConsensusParams;
     v3_out->net_params = smartlist_new();
-    smartlist_split_string(v3_out->net_params,
-                           d_options->ConsensusParams, NULL, 0, 0);
+    for ( ; paramline; paramline = paramline->next) {
+      smartlist_split_string(v3_out->net_params,
+                             paramline->value, NULL, 0, 0);
+    }
     smartlist_sort_strings(v3_out->net_params);
   }
   v3_out->bw_file_headers = bw_file_headers;


### PR DESCRIPTION
Make it possible to specify multiple ConsensusParams torrc
lines.

Now directory authority operators can for example put the
main ConsensusParams config in one torrc file and then add to it
from a different torrc file.

Closes ticket 40164.