### PR TITLE
Log a warning if Tor was built with any "risky" compile-time options

### DIFF
--- a/changes/ticket18888
+++ b/changes/ticket18888
@@ -1,0 +1,3 @@
+  o Minor features (safety):
+    - Log a warning at startup if Tor is built with compile-time options that
+      are likely to make it less stable or reliable. Closes ticket 18888.

--- a/src/app/main/include.am
+++ b/src/app/main/include.am
@@ -2,6 +2,7 @@
 # ADD_C_FILE: INSERT SOURCES HERE.
 LIBTOR_APP_A_SOURCES += 			\
 	src/app/main/main.c			\
+	src/app/main/risky_options.c		\
 	src/app/main/shutdown.c			\
 	src/app/main/subsystem_list.c		\
 	src/app/main/subsysmgr.c
@@ -10,6 +11,7 @@ LIBTOR_APP_A_SOURCES += 			\
 noinst_HEADERS +=					\
 	src/app/main/main.h				\
 	src/app/main/ntmain.h				\
+	src/app/main/risky_options.h			\
 	src/app/main/shutdown.h 			\
 	src/app/main/subsysmgr.h
 

--- a/src/app/main/risky_options.c
+++ b/src/app/main/risky_options.c
@@ -1,0 +1,35 @@
+/* Copyright (c) 2001 Matej Pfajfar.
+ * Copyright (c) 2001-2004, Roger Dingledine.
+ * Copyright (c) 2004-2006, Roger Dingledine, Nick Mathewson.
+ * Copyright (c) 2007-2020, The Tor Project, Inc. */
+/* See LICENSE for licensing information */
+
+/**
+ * \file risky_options.c
+ * \brief List compile-time options that might make Tor less reliable.
+ **/
+
+#include "orconfig.h"
+#include "app/main/risky_options.h"
+
+/** A space-separated list of the compile-time options might make Tor less
+ *  reliable or secure.  These options mainly exist for testing or debugging.
+ */
+const char risky_option_list[] =
+  ""
+#ifdef DISABLE_ASSERTS_IN_TEST
+  " --disable-asserts-in-test"
+#endif
+#ifdef TOR_UNIT_TESTS
+  " TOR_UNIT_TESTS"
+#endif
+#ifdef ENABLE_RESTART_DEBUGGING
+  " --enable-restart-debugging"
+#endif
+#ifdef ALL_BUGS_ARE_FATAL
+  " --enable-all-bugs-are-fatal"
+#endif
+#ifdef DISABLE_MEMORY_SENTINELS
+  " --disable-memory-sentinels"
+#endif
+  ;

--- a/src/app/main/risky_options.h
+++ b/src/app/main/risky_options.h
@@ -1,0 +1,17 @@
+/* Copyright (c) 2001 Matej Pfajfar.
+ * Copyright (c) 2001-2004, Roger Dingledine.
+ * Copyright (c) 2004-2006, Roger Dingledine, Nick Mathewson.
+ * Copyright (c) 2007-2020, The Tor Project, Inc. */
+/* See LICENSE for licensing information */
+
+/**
+ * \file risky_options.h
+ * \brief Header for risky_options.c
+ **/
+
+#ifndef TOR_RISKY_OPTIONS_H
+#define TOR_RISKY_OPTIONS_H
+
+extern const char risky_option_list[];
+
+#endif


### PR DESCRIPTION
These options are meant for testing builds only, and are likely to
cause trouble if used in a production environment.

Closes #18888.