### PR TITLE
Handle a change in the implementation of hashlib in Python 3.9

### DIFF
--- a/changes/bug40179_part1
+++ b/changes/bug40179_part1
@@ -1,0 +1,4 @@
+  o Minor bugfixes (testing, portability):
+    - Fix our Python reference-implementation for the v3 onion service
+      handshake so that it works correctly with the version of hashlib provided
+      by Python 3.9. Fixes part of bug 40179; bugfix on 0.3.1.6-rc.

--- a/src/test/hs_ntor_ref.py
+++ b/src/test/hs_ntor_ref.py
@@ -65,14 +65,16 @@ except ImportError:
 try:
     # Pull the sha3 functions in.
     from hashlib import sha3_256, shake_256
-    shake_squeeze = shake_256.digest
+    def shake_squeeze(obj, n):
+        return obj.digest(n)
 except ImportError:
     if hasattr(sha3, "SHA3256"):
         # If this happens, then we have the old "sha3" module which
         # hashlib and pysha3 superseded.
         sha3_256 = sha3.SHA3256
         shake_256 = sha3.SHAKE256
-        shake_squeeze = shake_256.squeeze
+        def shake_squeeze(obj, n):
+            return obj.squeeze(n)
     else:
         # error code 77 tells automake to skip this test
         sys.exit(77)


### PR DESCRIPTION
Previously, hashlib.shake_256 was a class (if present); now it can
also be a function.  This change invalidated our old
compatibility/workaround code, and made one of our tests fail.

Fixes bug 40179; bugfix on 0.3.1.6-rc when the workaround code was
added.