### PR TITLE
Fake the current time when we're loading TEST_DESCRIPTORS.

### DIFF
--- a/changes/bug40187
+++ b/changes/bug40187
@@ -1,0 +1,5 @@
+  o Minor bugfixes (testing):
+    - Fix unit tests that used newly generated list of routers so that they
+      check them with respect to the date when they were generated, not
+      with respect to the current time.  Fixes bug 40187; bugfix on
+      0.4.5.1-alpha.

--- a/src/test/test_helpers.c
+++ b/src/test/test_helpers.c
@@ -113,11 +113,16 @@ helper_setup_fake_routerlist(void)
   MOCK(router_descriptor_is_older_than,
        router_descriptor_is_older_than_replacement);
 
+  // Pick a time when these descriptors' certificates were valid.
+  update_approx_time(1603981036);
+
   /* Load all the test descriptors to the routerlist. */
   retval = router_load_routers_from_string(TEST_DESCRIPTORS,
                                            NULL, SAVED_IN_JOURNAL,
                                            NULL, 0, NULL);
   tt_int_op(retval, OP_EQ, HELPER_NUMBER_OF_DESCRIPTORS);
+
+  update_approx_time(0); // this restores the regular approx_time behavior
 
   /* Sanity checking of routerlist and nodelist. */
   our_routerlist = router_get_routerlist();


### PR DESCRIPTION
Fixes bug 40187; bugfix on 0.4.5.1-alpha.