### PR TITLE
port: Don't ignore ports of a different family

### DIFF
--- a/changes/ticket40183
+++ b/changes/ticket40183
@@ -1,0 +1,4 @@
+  o Minor bugfixes (port configuration):
+    - Second non ORPort of a different family (ex: SocksPort [::1]:9050) was
+      ignored due to a logical configuration parsing error. Fixes bug 40183;
+      bugfix on 0.4.5.1-alpha.

--- a/src/feature/relay/relay_config.c
+++ b/src/feature/relay/relay_config.c
@@ -228,15 +228,16 @@ remove_duplicate_orports(smartlist_t *ports)
         continue;
       }
       /* Same address family and same port number, we have a match. */
-      if (!current->explicit_addr && next->explicit_addr &&
-          tor_addr_family(&current->addr) == tor_addr_family(&next->addr) &&
+      if (tor_addr_family(&current->addr) == tor_addr_family(&next->addr) &&
           current->port == next->port) {
         /* Remove current because next is explicitly set. */
         removing[i] = true;
-        char *next_str = tor_strdup(describe_relay_port(next));
-        log_warn(LD_CONFIG, "Configuration port %s superseded by %s",
-                 describe_relay_port(current), next_str);
-        tor_free(next_str);
+        if (!current->explicit_addr && next->explicit_addr) {
+          char *next_str = tor_strdup(describe_relay_port(next));
+          log_warn(LD_CONFIG, "Configuration port %s superseded by %s",
+                   describe_relay_port(current), next_str);
+          tor_free(next_str);
+        }
       }
     }
   }


### PR DESCRIPTION
Commit c3a0f757964de0e8a24911d72abff5df20bb323c added this feature for ORPort
that we ignore any port that is not the family of our default address when
parsing the port. So if port_parse_config() was called with an IPv4 default
address, all IPv6 address would be ignored.

That makes sense for ORPort since we call twice port_parse_config() for
0.0.0.0 and [::] but for the rest of the ports, it is not good since a
perfectly valid configuration can be:

  SocksPort 9050
  SocksPort [::1]:9050

Any non-ORPort only binds by default to an IPv4 except the ORPort that binds
to both IPv4 and IPv6 by default.

The fix here is to always parse all ports within port_parse_config() and then,
specifically for ORPort, remove the duplicates or superseding ones. The
warning is only emitted when a port supersedes another.

A unit tests is added to make sure SocksPort of different family always exists
together.

Fixes #40183

Signed-off-by: David Goulet <dgoulet@torproject.org>