### PR TITLE
config: Bridge line with a transport must have a ClientTransportPlugin

### DIFF
--- a/changes/ticket25528
+++ b/changes/ticket25528
@@ -1,0 +1,6 @@
+  o Minor bugfixes (client, bridge, configuration):
+    - Exit tor on a misconfiguration when the Bridge line has a transport but
+      no corresponding ClientTransportPlugin can be found. Prior to this fix,
+      tor would attempt to connect to the bridge directly without using the
+      transport leading to a possible leak on the wire. Fixes bug 25528;
+      bugfix on 0.2.6.1-alpha.

--- a/src/app/config/config.c
+++ b/src/app/config/config.c
@@ -2189,6 +2189,22 @@ options_act,(const or_options_t *old_options))
     }
   }
 
+  /* Validate that we actually have a configured transport for a Bridge line
+   * that has one.  This is done here because we require the bridge and
+   * transport to be added to the global list before doing the validation.
+   *
+   * In an ideal world, pt_parse_transport_line() would actually return a
+   * transport_t object so we could inspect it and thus do this step at
+   * validation time. */
+  SMARTLIST_FOREACH_BEGIN(bridge_list_get(), const bridge_info_t *, bi) {
+    const char *bi_transport_name = bridget_get_transport_name(bi);
+    if (bi_transport_name && !transport_get_by_name(bi_transport_name)) {
+      log_warn(LD_CONFIG, "Bridge line with transport %s is missing a "
+                          "ClientTransportPlugin line", bi_transport_name);
+      return -1;
+    }
+  } SMARTLIST_FOREACH_END(bi);
+
   if (options_act_server_transport(old_options) < 0)
     return -1;
 

--- a/src/feature/client/bridges.c
+++ b/src/feature/client/bridges.c
@@ -164,6 +164,17 @@ bridge_get_addr_port(const bridge_info_t *bridge)
   return &bridge->addrport_configured;
 }
 
+/**
+ * Given a <b>bridge</b>, return the transport name. If none were configured,
+ * NULL is returned.
+ */
+const char *
+bridget_get_transport_name(const bridge_info_t *bridge)
+{
+  tor_assert(bridge);
+  return bridge->transport_name;
+}
+
 /** If we have a bridge configured whose digest matches <b>digest</b>, or a
  * bridge with no known digest whose address matches any of the
  * tor_addr_port_t's in <b>orports</b>, return that bridge.  Else return

--- a/src/feature/client/bridges.h
+++ b/src/feature/client/bridges.h
@@ -23,6 +23,7 @@ void sweep_bridge_list(void);
 const smartlist_t *bridge_list_get(void);
 const uint8_t *bridge_get_rsa_id_digest(const bridge_info_t *bridge);
 const tor_addr_port_t * bridge_get_addr_port(const bridge_info_t *bridge);
+const char *bridget_get_transport_name(const bridge_info_t *bridge);
 bridge_info_t *get_configured_bridge_by_addr_port_digest(
                                           const tor_addr_t *addr,
                                           uint16_t port,


### PR DESCRIPTION
Fixes #25528

Signed-off-by: David Goulet <dgoulet@torproject.org>