### PR TITLE
config: Really ignore non ORPorts when removing duplicates

### DIFF
--- a/changes/ticket40195
+++ b/changes/ticket40195
@@ -1,0 +1,5 @@
+  o Minor bugfixes (configuration, ports):
+    - Fix an issue where an ORPort was validated against other type of ports
+      when it should have been only checked against other ORPorts. This lead to
+      "DirPort auto" to be ignored and failing to be used. Fixes bug 40195;
+      bugfix on 0.4.5.1-alpha.

--- a/src/feature/relay/relay_config.c
+++ b/src/feature/relay/relay_config.c
@@ -227,6 +227,10 @@ remove_duplicate_orports(smartlist_t *ports)
       if (removing[j]) {
         continue;
       }
+      /* Skip non ORPorts. */
+      if (next->type != CONN_TYPE_OR_LISTENER) {
+        continue;
+      }
       /* Same address family and same port number, we have a match. */
       if (tor_addr_family(&current->addr) == tor_addr_family(&next->addr) &&
           current->port == next->port) {


### PR DESCRIPTION
The function in charge of removing duplicate ORPorts from our configured ports
was skipping all non ORPorts port but only for the outer loop thus resulting
in comparing an ORPort with a non-ORPort which lead to problems.

For example, tor configured with the following would fail:

  ORPort auto
  DirPort auto

Both end up being the same configuration except that one is a OR listener and
one is a Dir listener. Thus because of the missing check in the inner loop,
they looked exactly the same and thus one is removed.

Fixes #40195

Signed-off-by: David Goulet <dgoulet@torproject.org>