### PR TITLE
sendme: Turn log warning into debug

### DIFF
--- a/changes/ticket40142
+++ b/changes/ticket40142
@@ -1,0 +1,3 @@
+  o Minor bugfixes (logging, flow control):
+    - Turn a SENDME failure log warning into a debug. It can actually happen
+      naturally. Fixes bug 40142; bugfix on 0.4.1.1-alpha.

--- a/src/core/or/sendme.c
+++ b/src/core/or/sendme.c
@@ -398,8 +398,8 @@ sendme_connection_edge_consider_sending(edge_connection_t *conn)
     conn->deliver_window += STREAMWINDOW_INCREMENT;
     if (connection_edge_send_command(conn, RELAY_COMMAND_SENDME,
                                      NULL, 0) < 0) {
-      log_warn(LD_BUG, "connection_edge_send_command failed while sending "
-                       "a SENDME. Circuit probably closed, skipping.");
+      log_debug(LD_CIRC, "connection_edge_send_command failed while sending "
+                         "a SENDME. Circuit probably closed, skipping.");
       goto end; /* The circuit's closed, don't continue */
     }
   }


### PR DESCRIPTION
When sending the stream level SENDME, it is possible the cirucit was marked
for close or any other failures that can occur. These events can occur
naturally.

Fixes #40142

Signed-off-by: David Goulet <dgoulet@torproject.org>