### PR TITLE
configure: Fix the --enable-static-tor switch

### DIFF
--- a/changes/ticket40111
+++ b/changes/ticket40111
@@ -1,0 +1,4 @@
+  o Minor bugfixes (configure, build):
+    - Fix the --enable-static-tor switch to properly set the -static compile
+      option onto the tor binary only. Fixes bug 40111; bugfix on
+      0.2.3.1-alpha.

--- a/configure.ac
+++ b/configure.ac
@@ -129,8 +129,9 @@ if test "$enable_static_tor" = "yes"; then
   enable_static_libevent="yes";
   enable_static_openssl="yes";
   enable_static_zlib="yes";
-  CFLAGS="$CFLAGS -static"
+  TOR_STATIC_LDFLAGS="-static"
 fi
+AC_SUBST(TOR_STATIC_LDFLAGS)
 
 if test "$enable_system_torrc" = "no"; then
   AC_DEFINE(DISABLE_SYSTEM_TORRC, 1,
@@ -949,7 +950,7 @@ if test "$enable_static_libevent" = "yes"; then
    if test "$tor_cv_library_libevent_dir" = "(system)"; then
      AC_MSG_ERROR("You must specify an explicit --with-libevent-dir=x option when using --enable-static-libevent")
    else
-     TOR_LIBEVENT_LIBS="$TOR_LIBDIR_libevent/libevent.a $STATIC_LIBEVENT_FLAGS"
+     TOR_LIBEVENT_LIBS="$TOR_LIBDIR_libevent/.libs/libevent.a $STATIC_LIBEVENT_FLAGS"
    fi
 else
      if test "x$ac_cv_header_event2_event_h" = "xyes"; then

--- a/src/app/include.am
+++ b/src/app/include.am
@@ -14,7 +14,8 @@ src_app_tor_SOURCES = src/app/main/tor_main.c
 # This seems to matter nowhere but on windows, but I assure you that it
 # matters a lot there, and is quite hard to debug if you forget to do it.
 
-src_app_tor_LDFLAGS = @TOR_LDFLAGS_zlib@ $(TOR_LDFLAGS_CRYPTLIB) @TOR_LDFLAGS_libevent@
+src_app_tor_LDFLAGS = @TOR_LDFLAGS_zlib@ $(TOR_LDFLAGS_CRYPTLIB) \
+	@TOR_LDFLAGS_libevent@ @TOR_STATIC_LDFLAGS@
 src_app_tor_LDADD = libtor.a \
 	$(rust_ldadd) \
 	@TOR_ZLIB_LIBS@ @TOR_LIB_MATH@ @TOR_LIBEVENT_LIBS@ $(TOR_LIBS_CRYPTLIB) \
@@ -26,7 +27,8 @@ if COVERAGE_ENABLED
 src_app_tor_cov_SOURCES = $(src_app_tor_SOURCES)
 src_app_tor_cov_CPPFLAGS = $(AM_CPPFLAGS) $(TEST_CPPFLAGS)
 src_app_tor_cov_CFLAGS = $(AM_CFLAGS) $(TEST_CFLAGS)
-src_app_tor_cov_LDFLAGS = @TOR_LDFLAGS_zlib@ $(TOR_LDFLAGS_CRYPTLIB) @TOR_LDFLAGS_libevent@
+src_app_tor_cov_LDFLAGS = @TOR_LDFLAGS_zlib@ $(TOR_LDFLAGS_CRYPTLIB) \
+	@TOR_LDFLAGS_libevent@ @TOR_STATIC_LDFALGS@
 src_app_tor_cov_LDADD = src/test/libtor-testing.a \
 	@TOR_ZLIB_LIBS@ @TOR_LIB_MATH@ @TOR_LIBEVENT_LIBS@ $(TOR_LIBS_CRYPTLIB) \
 	@TOR_LIB_WS32@ @TOR_LIB_IPHLPAPI@ @TOR_LIB_SHLWAPI@ @TOR_LIB_GDI@ \


### PR DESCRIPTION
The "-static" compile flag was set globally which means that all autoconf test
were attempting to be built statically and lead to failures of detecting
OpenSSL libraries and others.

This commit adds this flag only to the "tor" binary build.

There is also a fix on where to find libevent.a since it is using libtool, it
is in .libs/.

At this commit, there are still warnings being emitted that informs the user
that the built binary must still be linked dynamically with glibc.

Fixes #40111

Signed-off-by: David Goulet <dgoulet@torproject.org>