### PR TITLE
config: Catch missing Bridge for ClientTransportPlugin

### DIFF
--- a/changes/ticket40106
+++ b/changes/ticket40106
@@ -1,0 +1,8 @@
+  o Minor bugfixes (config, bridge):
+    - Really fix the case where torrc has a missing Bridge line while configured
+      with a ClientTransportPlugin. Previously, we failed to also look at the
+      managed proxy list and thus it would fail for the "exec" case. Fixes bug
+      40106; bugfix on 0.4.5.1-alpha.
+    - Our code was supporting a *TransportPlugin line to have multiple
+      transport name but our documentation never detailed it. Remove that
+      capability in favor of using multiple *TransportPlugin line instead.

--- a/src/feature/client/transports.h
+++ b/src/feature/client/transports.h
@@ -41,15 +41,15 @@ void transport_free_(transport_t *transport);
 #define transport_free(tr) FREE_AND_NULL(transport_t, transport_free_, (tr))
 
 MOCK_DECL(transport_t*, transport_get_by_name, (const char *name));
+bool managed_proxy_has_transport(const char *transport_name);
 
 MOCK_DECL(void, pt_kickstart_proxy,
-          (const smartlist_t *transport_list, char **proxy_argv,
-           int is_server));
+          (const char *transport_name, char **proxy_argv, int is_server));
 
-#define pt_kickstart_client_proxy(tl, pa)  \
-  pt_kickstart_proxy(tl, pa, 0)
-#define pt_kickstart_server_proxy(tl, pa) \
-  pt_kickstart_proxy(tl, pa, 1)
+#define pt_kickstart_client_proxy(name, pa)  \
+  pt_kickstart_proxy(name, pa, 0)
+#define pt_kickstart_server_proxy(name, pa) \
+  pt_kickstart_proxy(name, pa, 1)
 
 void pt_configure_remaining_proxies(void);
 
@@ -87,6 +87,7 @@ struct process_t;
 
 /** Structure containing information of a managed proxy. */
 typedef struct {
+  char *transport_name; /* Transport name */
   enum pt_proto_state conf_state; /* the current configuration state */
   char **argv; /* the cli arguments of this proxy */
   int conf_protocol; /* the configuration protocol version used */
@@ -135,8 +136,9 @@ STATIC char *get_transport_options_for_server_proxy(const managed_proxy_t *mp);
 STATIC void managed_proxy_destroy(managed_proxy_t *mp,
                                   int also_terminate_process);
 
-STATIC managed_proxy_t *managed_proxy_create(const smartlist_t *transport_list,
-                                             char **proxy_argv, int is_server);
+STATIC managed_proxy_t *managed_proxy_create(const char *name,
+                                             char **proxy_argv,
+                                             int is_server);
 
 STATIC int configure_proxy(managed_proxy_t *mp);
 

--- a/src/test/test_pt.c
+++ b/src/test/test_pt.c
@@ -146,7 +146,6 @@ static void
 test_pt_get_transport_options(void *arg)
 {
   char **execve_args;
-  smartlist_t *transport_list = smartlist_new();
   managed_proxy_t *mp;
   or_options_t *options = get_options_mutable();
   char *opt_str = NULL;
@@ -157,7 +156,7 @@ test_pt_get_transport_options(void *arg)
   execve_args[0] = tor_strdup("cheeseshop");
   execve_args[1] = NULL;
 
-  mp = managed_proxy_create(transport_list, execve_args, 1);
+  mp = managed_proxy_create("aname", execve_args, 1);
   tt_ptr_op(mp, OP_NE, NULL);
   opt_str = get_transport_options_for_server_proxy(mp);
   tt_ptr_op(opt_str, OP_EQ, NULL);
@@ -191,7 +190,6 @@ test_pt_get_transport_options(void *arg)
   tor_free(opt_str);
   config_free_lines(cl);
   managed_proxy_destroy(mp, 0);
-  smartlist_free(transport_list);
 }
 
 static void
@@ -250,7 +248,6 @@ test_pt_get_extrainfo_string(void *arg)
 {
   managed_proxy_t *mp1 = NULL, *mp2 = NULL;
   char **argv1, **argv2;
-  smartlist_t *t1 = smartlist_new(), *t2 = smartlist_new();
   int r;
   char *s = NULL;
   (void) arg;
@@ -265,8 +262,8 @@ test_pt_get_extrainfo_string(void *arg)
   argv2[2] = tor_strdup("Schlangenkraft");
   argv2[3] = NULL;
 
-  mp1 = managed_proxy_create(t1, argv1, 1);
-  mp2 = managed_proxy_create(t2, argv2, 1);
+  mp1 = managed_proxy_create("aname", argv1, 1);
+  mp2 = managed_proxy_create("aname", argv2, 1);
 
   r = parse_smethod_line("SMETHOD hagbard 127.0.0.1:5555", mp1);
   tt_int_op(r, OP_EQ, 0);
@@ -284,9 +281,6 @@ test_pt_get_extrainfo_string(void *arg)
             "transport celine 127.0.0.1:1723 card=no-enemy\n");
 
  done:
-  /* XXXX clean up better */
-  smartlist_free(t1);
-  smartlist_free(t2);
   tor_free(s);
 }
 


### PR DESCRIPTION
First of all, tor doesn't support multiple transport name on a single
*TransportPlugin line so get rid of that. The manpage has never documented
that feature and it complexifies the line for no reason. A user can just use
multiple ClientTransportPlugin line instead.

Second, if no Bridge line is found, error immediately and exit. Don't leave
the Bridge line alone there leading to bugs like #25528

Third, when making sure we have a Bridge line with a ClientTransportPlugin, we
now check at the managed proxy list. In order to pull this off, the transport
name had to be added to the managed_proxy_t object so we can match for which
transport it is used for. And thus justifying the removal of multiple
transport support which adds no benefit except complexity.

Fixes #40106

Signed-off-by: David Goulet <dgoulet@torproject.org>