### PR TITLE
docs: fix simple typo, verifcation -> verification

### DIFF
--- a/src/ext/ed25519/donna/modm-donna-32bit.h
+++ b/src/ext/ed25519/donna/modm-donna-32bit.h
@@ -376,7 +376,7 @@ contract256_slidingwindow_modm(signed char r[256], const bignum256modm s, int wi
 
 
 /*
-	helpers for batch verifcation, are allowed to be vartime
+	helpers for batch verification, are allowed to be vartime
 */
 
 /* out = a - b, a must be larger than b */

--- a/src/ext/ed25519/donna/modm-donna-64bit.h
+++ b/src/ext/ed25519/donna/modm-donna-64bit.h
@@ -285,7 +285,7 @@ contract256_slidingwindow_modm(signed char r[256], const bignum256modm s, int wi
 }
 
 /*
-	helpers for batch verifcation, are allowed to be vartime
+	helpers for batch verification, are allowed to be vartime
 */
 
 /* out = a - b, a must be larger than b */


### PR DESCRIPTION
There is a small typo in src/ext/ed25519/donna/modm-donna-32bit.h, src/ext/ed25519/donna/modm-donna-64bit.h.

Should read `verification` rather than `verifcation`.

