### PR TITLE
Detect extra bytes in HAProxy inbuf when transitioning to OR handshake

### DIFF
--- a/changes/ticket40017_redux
+++ b/changes/ticket40017_redux
@@ -1,0 +1,3 @@
+  o Minor features (protocol, proxy support, defense in depth):
+    - Close HAProxy connections if they somehow manage to send us data before
+      we start reading.  Closes another case of ticket 40017.

--- a/src/core/or/connection_or.c
+++ b/src/core/or/connection_or.c
@@ -686,6 +686,11 @@ connection_or_finished_flushing(or_connection_t *conn)
       /* PROXY_HAPROXY gets connected by receiving an ack. */
       if (conn->proxy_type == PROXY_HAPROXY) {
         tor_assert(TO_CONN(conn)->proxy_state == PROXY_HAPROXY_WAIT_FOR_FLUSH);
+        IF_BUG_ONCE(buf_datalen(TO_CONN(conn)->inbuf) != 0) {
+          /* This should be impossible; we're not even reading. */
+          connection_or_close_for_error(conn, 0);
+          return -1;
+        }
         TO_CONN(conn)->proxy_state = PROXY_CONNECTED;
 
         if (connection_tls_start_handshake(conn, 0) < 0) {


### PR DESCRIPTION
This shouldn't be possible, but let's add it for defense-in-depth.

Closes #40017.