### PR TITLE
GNU autoconf 2.70 update

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -454,7 +454,7 @@ AM_CONDITIONAL(BUILD_MANPAGE, [test "x$enable_manpage" != "xno"])
 AM_CONDITIONAL(BUILD_HTML_DOCS, [test "x$enable_html_manual" != "xno"])
 
 AM_PROG_CC_C_O
-AC_PROG_CC_C99
+AC_PROG_CC
 
 AC_CACHE_CHECK([for Python 3], [tor_cv_PYTHON],
    [AC_PATH_PROGS_FEATURE_CHECK([PYTHON], [ \


### PR DESCRIPTION
ac_prog_cc_c99 is outdated. looks like they've lumped multiple configurations into the main ac_prog_cc. I changed this and could continue with the config/make/installation process. autoconfig 2.70 patchnotes: https://lwn.net/Articles/839395/

this is my first functional pull request! I've read the README and /doc/HACKING/README.1st.md so hopefully im meeting your PR conventions. 

MAD respect for this team btw, the fate of the future is in your hands, truly 