### PR TITLE
Fix testcases regarding O_NONBLOCK on parisc/hppa architecture

### DIFF
--- a/src/test/test_util.c
+++ b/src/test/test_util.c
@@ -5937,7 +5937,7 @@ static int
 fd_is_nonblocking(tor_socket_t fd)
 {
   int flags = fcntl(fd, F_GETFL, 0);
-  return (flags & O_NONBLOCK) == O_NONBLOCK;
+  return (flags & O_NONBLOCK) != 0;
 }
 #endif /* !defined(_WIN32) */
 


### PR DESCRIPTION
On the parisc/hppa architecture, the O_NONBLOCK constant can be either
000200000 or 000200004, depending on the Linux kernel and glibc version
on which the binary is running.
Background of this can be read in this upstream Linux kernel patch:
https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/commit/?id=75ae04206a4d0e4f541c1d692b7febd1c0fdb814

The tor testcases fail because of this, because function
fd_is_nonblocking() checks hard against the O_NONBLOCK value, while it's
sufficient if it would only check if one of the bits is set.

Fix this trivial issue by just comparing if the returned file descriptor flag
and'ed with O_NONBLOCK is non-zero.

As reference, a failing build on parisc/hppa can be seen here:
https://buildd.debian.org/status/fetch.php?pkg=tor&arch=hppa&ver=0.4.4.6-1%2Bb1&stamp=1612225628&raw=0