### PR TITLE
When TestingTorNetwork is enabled, skip the permission check on the hidden service directory

### DIFF
--- a/changes/issue40338
+++ b/changes/issue40338
@@ -1,0 +1,3 @@
+  o Minor features (testing configuration):
+    - When TestingTorNetwork is enabled, skip the permission check on
+      the hidden service directory.

--- a/src/feature/hs/hs_config.c
+++ b/src/feature/hs/hs_config.c
@@ -544,15 +544,19 @@ config_service(config_line_t *line, const or_options_t *options,
 
   tor_assert(service->config.version <= HS_VERSION_MAX);
 
-  /* Check permission on service directory that was just parsed. And this must
-   * be done regardless of the service version. Do not ask for the directory
-   * to be created, this is done when the keys are loaded because we could be
-   * in validation mode right now. */
-  if (hs_check_service_private_dir(options->User,
-                                   service->config.directory_path,
-                                   service->config.dir_group_readable,
-                                   0) < 0) {
-    goto err;
+  /* If we're running with TestingTorNetwork enabled, we relax the permissions
+   * check on the hs directory. */
+  if (!options->TestingTorNetwork) {
+    /* Check permission on service directory that was just parsed. And this must
+     * be done regardless of the service version. Do not ask for the directory
+     * to be created, this is done when the keys are loaded because we could be
+     * in validation mode right now. */
+    if (hs_check_service_private_dir(options->User,
+                                     service->config.directory_path,
+                                     service->config.dir_group_readable,
+                                     0) < 0) {
+      goto err;
+    }
   }
 
   /* We'll try to learn the service version here by loading the key(s) if


### PR DESCRIPTION
https://gitlab.torproject.org/tpo/core/tor/-/issues/40338

> When running tor with TestingTorNetwork enabled, don't exit if the hs directory has other/world permissions set.
>
> For Tor experiments with configurations that are tracked in git, it is a bit of a pain to fix up ownership of the configuration files before running tor. To work around this, Shadow puts all of the files in an archive to preserve permissions and commits the archive to git, but it would be nice to be able to commit the configuration files to git directly and track changes properly.
>
> In almost all cases where the permissions are incorrect, tor will automatically fix them and continue running, but the only exception to this that I can find is the hidden service directory.
>
> As the TestingTorNetwork is explicitly about running a testing Tor network, I don't see any security implications of disabling the permissions check when this option is enabled.