### PR TITLE
Fix compile error with ratelimit

### DIFF
--- a/src/feature/dirclient/dirclient.c
+++ b/src/feature/dirclient/dirclient.c
@@ -1907,8 +1907,7 @@ dir_client_decompress_response_body(char **bodyp, size_t *bodylenp,
   /* If we're pretty sure that we have a compressed directory, and
    * we didn't manage to uncompress it, then warn and bail. */
   if (!plausible && !new_body) {
-    const int LOG_INTERVAL = 3600;
-    static ratelim_t warning_limit = RATELIM_INIT(LOG_INTERVAL);
+    static ratelim_t warning_limit = RATELIM_INIT(3600);
     log_fn_ratelim(&warning_limit, LOG_WARN, LD_HTTP,
            "Unable to decompress HTTP body (tried %s%s%s, on %s).",
            description1,


### PR DESCRIPTION
../src/lib/log/ratelim.h:55:27: error: initializer element is not constant