### PR TITLE
Add an optional flag to export circuit id per port

### DIFF
--- a/doc/man/tor.1.txt
+++ b/doc/man/tor.1.txt
@@ -3421,7 +3421,7 @@ The next section describes the per service options that can only be set
     Number of introduction points the hidden service will have. You can't
     have more than 20. (Default: 3)
 
-[[HiddenServicePort]] **HiddenServicePort** __VIRTPORT__ [__TARGET__]::
+[[HiddenServicePort]] **HiddenServicePort** __VIRTPORT__ [__TARGET__ [__EXPORT-CIRCUIT-ID-PROTOCOL__]]::
     Configure a virtual port VIRTPORT for a hidden service. You may use this
     option multiple times; each time applies to the service using the most
     recent HiddenServiceDir. By default, this option maps the virtual port to
@@ -3431,7 +3431,13 @@ The next section describes the per service options that can only be set
     paths may be quoted, and may use standard C escapes.)
     You may also have multiple lines with  the same VIRTPORT: when a user
     connects to that VIRTPORT, one of the TARGETs from those lines will be
-    chosen at random. Note that address-port pairs have to be comma-separated.
+    chosen at random. Note that address-port pairs have to be
+    comma-separated. +
+     +
+    You also may specify the export circuit id protocol which is similar to
+    the one specified in **HiddenServiceExportCircuitID** but the procool
+    will be applied only to this port instead of being applied globally
+    in the service.
 
 [[HiddenServiceVersion]] **HiddenServiceVersion** **3**::
     A list of rendezvous service descriptor versions to publish for the hidden

--- a/src/core/or/connection_edge.c
+++ b/src/core/or/connection_edge.c
@@ -3881,9 +3881,7 @@ handle_hs_exit_conn(circuit_t *circ, edge_connection_t *conn)
   /* If it's an onion service connection, we might want to include the proxy
    * protocol header: */
   if (conn->hs_ident) {
-    hs_circuit_id_protocol_t circuit_id_protocol =
-      hs_service_exports_circuit_id(&conn->hs_ident->identity_pk);
-    export_hs_client_circuit_id(conn, circuit_id_protocol);
+    export_hs_client_circuit_id(conn, conn->hs_ident->circuit_id_protocol);
   }
 
   /* Connect tor to the hidden service destination. */

--- a/src/core/or/connection_edge.c
+++ b/src/core/or/connection_edge.c
@@ -936,7 +936,7 @@ connected_cell_format_payload(uint8_t *payload_out,
 
 /* This is an onion service client connection: Export the client circuit ID
  * according to the HAProxy proxy protocol. */
-STATIC void
+static void
 export_hs_client_circuit_id(edge_connection_t *edge_conn,
                             hs_circuit_id_protocol_t protocol)
 {
@@ -3810,7 +3810,7 @@ begin_cell_parse(const cell_t *cell, begin_cell_t *bcell,
  * connection, attach it to the circ and connect it. Return 0 on success
  * or END_CIRC_AT_ORIGIN if we can't find the requested hidden service port
  * where the caller should close the circuit. */
-static int
+STATIC int
 handle_hs_exit_conn(circuit_t *circ, edge_connection_t *conn)
 {
   int ret;
@@ -4185,8 +4185,8 @@ network_reentry_is_allowed(void)
  * address, but <em>only</em> if it's a general exit stream. (Rendezvous
  * streams must not reveal what IP they connected to.)
  */
-void
-connection_exit_connect(edge_connection_t *edge_conn)
+MOCK_IMPL(void,
+connection_exit_connect,(edge_connection_t *edge_conn))
 {
   const tor_addr_t *addr;
   uint16_t port;

--- a/src/core/or/connection_edge.h
+++ b/src/core/or/connection_edge.h
@@ -129,7 +129,7 @@ void connection_ap_handshake_socks_resolved_addr(entry_connection_t *conn,
 
 int connection_exit_begin_conn(cell_t *cell, circuit_t *circ);
 int connection_exit_begin_resolve(cell_t *cell, or_circuit_t *circ);
-void connection_exit_connect(edge_connection_t *conn);
+MOCK_DECL(void,connection_exit_connect,(edge_connection_t *conn));
 int connection_edge_is_rendezvous_stream(const edge_connection_t *conn);
 int connection_ap_can_use_exit(const entry_connection_t *conn,
                                const node_t *exit);
@@ -290,8 +290,7 @@ STATIC void connection_ap_handshake_rewrite(entry_connection_t *conn,
                                             rewrite_result_t *out);
 
 STATIC int connection_ap_process_http_connect(entry_connection_t *conn);
-STATIC void export_hs_client_circuit_id(edge_connection_t *edge_conn,
-                            hs_circuit_id_protocol_t protocol);
+STATIC int handle_hs_exit_conn(circuit_t *circ, edge_connection_t *conn);
 
 struct half_edge_t;
 STATIC void connection_half_edge_add(const edge_connection_t *conn,

--- a/src/feature/hs/hs_common.h
+++ b/src/feature/hs/hs_common.h
@@ -145,6 +145,15 @@ typedef enum {
   RSAE_OKAY        = 0   /**< Service added as expected */
 } hs_service_add_ephemeral_status_t;
 
+/** Which protocol to use for exporting HS client circuit ID. */
+typedef enum {
+  /** Don't expose the circuit id. */
+  HS_CIRCUIT_ID_PROTOCOL_NONE,
+
+  /** Use the HAProxy proxy protocol. */
+  HS_CIRCUIT_ID_PROTOCOL_HAPROXY
+} hs_circuit_id_protocol_t;
+
 /** Represents the mapping from a virtual port of a rendezvous service to a
  * real port on some IP. */
 typedef struct hs_port_config_t {
@@ -156,6 +165,8 @@ typedef struct hs_port_config_t {
   uint16_t real_port;
   /** The outgoing IPv4 or IPv6 address to use, if !is_unix_addr */
   tor_addr_t real_addr;
+  /** Does this port export the circuit ID of its clients? */
+  hs_circuit_id_protocol_t circuit_id_protocol;
   /** The socket path to connect to, if is_unix_addr */
   char unix_addr[FLEXIBLE_ARRAY_MEMBER];
 } hs_port_config_t;
@@ -241,6 +252,8 @@ void hs_purge_last_hid_serv_requests(void);
 int hs_set_conn_addr_port(const smartlist_t *ports, edge_connection_t *conn);
 hs_port_config_t *hs_parse_port_config(const char *string, const char *sep,
                                        char **err_msg_out);
+hs_circuit_id_protocol_t hs_parse_circuit_id_protocol(const char *protocol_str,
+                                                      int *ok);
 void hs_port_config_free_(hs_port_config_t *p);
 #define hs_port_config_free(p) \
   FREE_AND_NULL(hs_port_config_t, hs_port_config_free_, (p))

--- a/src/feature/hs/hs_config.c
+++ b/src/feature/hs/hs_config.c
@@ -177,34 +177,6 @@ check_value_oob(int i, const char *name, int low, int high)
 #define CHECK_OOB(opts, name, low, high)      \
   check_value_oob((opts)->name, #name, (low), (high))
 
-/** Helper function: Given a configuration option and its value, parse the
- * value as a hs_circuit_id_protocol_t. On success, ok is set to 1 and ret is
- * the parse value. On error, ok is set to 0 and the "none"
- * hs_circuit_id_protocol_t is returned. This function logs on error. */
-static hs_circuit_id_protocol_t
-helper_parse_circuit_id_protocol(const char *key, const char *value, int *ok)
-{
-  tor_assert(value);
-  tor_assert(ok);
-
-  hs_circuit_id_protocol_t ret = HS_CIRCUIT_ID_PROTOCOL_NONE;
-  *ok = 0;
-
-  if (! strcasecmp(value, "haproxy")) {
-    *ok = 1;
-    ret = HS_CIRCUIT_ID_PROTOCOL_HAPROXY;
-  } else if (! strcasecmp(value, "none")) {
-    *ok = 1;
-    ret = HS_CIRCUIT_ID_PROTOCOL_NONE;
-  } else {
-    log_warn(LD_CONFIG, "%s must be 'haproxy' or 'none'.", key);
-    goto err;
-  }
-
- err:
-  return ret;
-}
-
 /** Return the service version by trying to learn it from the key on disk if
  * any. If nothing is found, the current service configured version is
  * returned. */
@@ -351,10 +323,10 @@ config_service_v3(const hs_opts_t *hs_opts,
   if (hs_opts->HiddenServiceExportCircuitID) {
     int ok;
     config->circuit_id_protocol =
-      helper_parse_circuit_id_protocol("HiddenServcieExportCircuitID",
-                                       hs_opts->HiddenServiceExportCircuitID,
-                                       &ok);
+      hs_parse_circuit_id_protocol(hs_opts->HiddenServiceExportCircuitID, &ok);
     if (!ok) {
+      log_warn(LD_CONFIG, "HiddenServiceExportCircuitID must be "
+                          "'haproxy' or 'none'.");
       goto err;
     }
   }

--- a/src/feature/hs/hs_ident.h
+++ b/src/feature/hs/hs_ident.h
@@ -109,6 +109,9 @@ typedef struct hs_ident_edge_conn_t {
    * service, regardless of the internal port forwarding that might have
    * happened on the service-side. */
   uint16_t orig_virtual_port;
+
+  /** The export circuit id protocol that is used in this connection. */
+  hs_circuit_id_protocol_t circuit_id_protocol;
   /* XXX: Client authorization. */
 } hs_ident_edge_conn_t;
 

--- a/src/feature/hs/hs_service.c
+++ b/src/feature/hs/hs_service.c
@@ -3998,6 +3998,12 @@ hs_service_set_conn_addr_port(const origin_circuit_t *circ,
     goto err_no_close;
   }
 
+  /* If the the export circuit id protocol is none, looks at
+   * the HiddenServiceExportCircuitID config instead. */
+  if (conn->hs_ident->circuit_id_protocol == HS_CIRCUIT_ID_PROTOCOL_NONE) {
+    conn->hs_ident->circuit_id_protocol = service->config.circuit_id_protocol;
+  }
+
   /* Success. */
   return 0;
  err_close:
@@ -4006,19 +4012,6 @@ hs_service_set_conn_addr_port(const origin_circuit_t *circ,
  err_no_close:
   /* Indicate the caller to NOT close the circuit. */
   return -1;
-}
-
-/** Does the service with identity pubkey <b>pk</b> export the circuit IDs of
- *  its clients?  */
-hs_circuit_id_protocol_t
-hs_service_exports_circuit_id(const ed25519_public_key_t *pk)
-{
-  hs_service_t *service = find_service(hs_service_map, pk);
-  if (!service) {
-    return HS_CIRCUIT_ID_PROTOCOL_NONE;
-  }
-
-  return service->config.circuit_id_protocol;
 }
 
 /** Add to file_list every filename used by a configured hidden service, and to

--- a/src/feature/hs/hs_service.h
+++ b/src/feature/hs/hs_service.h
@@ -190,15 +190,6 @@ typedef struct hs_service_authorized_client_t {
   curve25519_public_key_t client_pk;
 } hs_service_authorized_client_t;
 
-/** Which protocol to use for exporting HS client circuit ID. */
-typedef enum {
-  /** Don't expose the circuit id. */
-  HS_CIRCUIT_ID_PROTOCOL_NONE,
-
-  /** Use the HAProxy proxy protocol. */
-  HS_CIRCUIT_ID_PROTOCOL_HAPROXY
-} hs_circuit_id_protocol_t;
-
 /** Service configuration. The following are set from the torrc options either
  * set by the configuration file or by the control port. Nothing else should
  * change those values. */
@@ -379,9 +370,6 @@ void hs_service_upload_desc_to_dir(const char *encoded_desc,
                                    const ed25519_public_key_t *identity_pk,
                                    const ed25519_public_key_t *blinded_pk,
                                    const routerstatus_t *hsdir_rs);
-
-hs_circuit_id_protocol_t
-hs_service_exports_circuit_id(const ed25519_public_key_t *pk);
 
 void hs_service_dump_stats(int severity);
 void hs_service_circuit_cleanup_on_close(const circuit_t *circ);

--- a/src/test/test_hs_config.c
+++ b/src/test/test_hs_config.c
@@ -151,8 +151,8 @@ test_invalid_service(void *arg)
     setup_full_capture_of_logs(LOG_WARN);
     ret = helper_config_service(conf, 1);
     tt_int_op(ret, OP_EQ, -1);
-    expect_log_msg_containing("HiddenServicePort parse error: "
-                              "invalid port mapping");
+    expect_log_msg_containing("HiddenServicePort parse error: export circuit "
+                              "id protocol must be 'haproxy' or 'none'.");
     teardown_capture_of_logs();
   }
 

--- a/src/test/test_hs_config.c
+++ b/src/test/test_hs_config.c
@@ -156,6 +156,20 @@ test_invalid_service(void *arg)
     teardown_capture_of_logs();
   }
 
+  /* Bad export circuit id protocol. */
+  {
+    const char *conf =
+      "HiddenServiceDir /tmp/tor-test-hs-RANDOM/hs1\n"
+      "HiddenServiceVersion 3\n"
+      "HiddenServicePort 80 127.0.0.1 badprotocol\n";
+    setup_full_capture_of_logs(LOG_WARN);
+    ret = helper_config_service(conf, 1);
+    tt_int_op(ret, OP_EQ, -1);
+    expect_log_msg_containing("HiddenServicePort parse error: export circuit "
+                              "id protocol must be 'haproxy' or 'none'.");
+    teardown_capture_of_logs();
+  }
+
   /* Out of order directives. */
   {
     const char *conf =
@@ -186,6 +200,24 @@ test_valid_service(void *arg)
       "HiddenServiceDir /tmp/tor-test-hs-RANDOM/hs2\n"
       "HiddenServiceVersion 3\n"
       "HiddenServicePort 81\n";
+    ret = helper_config_service(conf, 1);
+    tt_int_op(ret, OP_EQ, 0);
+  }
+
+  {
+    const char *conf =
+      "HiddenServiceDir /tmp/tor-test-hs-RANDOM/hs2\n"
+      "HiddenServiceVersion 3\n"
+      "HiddenServicePort 81 127.0.0.1:81 haproxy\n";
+    ret = helper_config_service(conf, 1);
+    tt_int_op(ret, OP_EQ, 0);
+  }
+
+  {
+    const char *conf =
+      "HiddenServiceDir /tmp/tor-test-hs-RANDOM/hs2\n"
+      "HiddenServiceVersion 3\n"
+      "HiddenServicePort 81 127.0.0.1:81 none\n";
     ret = helper_config_service(conf, 1);
     tt_int_op(ret, OP_EQ, 0);
   }

--- a/src/test/test_hs_service.c
+++ b/src/test/test_hs_service.c
@@ -2109,13 +2109,7 @@ test_export_client_circuit_id(void *arg)
 
   /* Create service */
   hs_service_t *service = helper_create_service();
-  /* Check that export circuit ID detection works */
-  service->config.circuit_id_protocol = HS_CIRCUIT_ID_PROTOCOL_NONE;
-  tt_int_op(0, OP_EQ,
-            hs_service_exports_circuit_id(&service->keys.identity_pk));
   service->config.circuit_id_protocol = HS_CIRCUIT_ID_PROTOCOL_HAPROXY;
-  tt_int_op(1, OP_EQ,
-            hs_service_exports_circuit_id(&service->keys.identity_pk));
 
   /* Create client connection */
   conn = test_conn_get_connection(AP_CONN_STATE_CIRCUIT_WAIT, CONN_TYPE_AP, 0);


### PR DESCRIPTION
Previously we have HiddenServiceExportCircuitID which allows us to
export the circuit id using haproxy. However, such directive is applied
globally in the service. We need a way to export the circuit id only for
some virtual ports.
    
We can do that by adding an optional flag to the HiddenServicePort
directive to specify that we will export the circuit id for such port.
The flag in HiddenServicePort will override the one in
HiddenServiceExportCircuitID, if it's not none. But it will use the
protocol specified in HiddenServiceExportCircuitID, if it's otherwise.

So, the new syntax for HiddenServicePort directive will be
`HiddenServicePort VIRTPORT [TARGET [EXPORT-CIRCUIT-ID-PROTOCOL]]`
